### PR TITLE
Fixed package decl + JSON tag issues (via go vet).

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -103,7 +103,7 @@ type User struct {
 	Telephone     string         `json:"telephone"`
 	Country       string         `json:"country"`
 	Zipcode       string         `json:"zipcode"`
-	CreatedOn     string         `json:"created_on` // Should this be a time.Date?
+	CreatedOn     string         `json:"created_on"` // Should this be a time.Date?
 	ModifiedOn    string         `json:"modified_on"`
 	APIKey        string         `json:"api_key"`
 	TwoFA         bool           `json:"two_factor_authentication_enabled"`
@@ -204,8 +204,8 @@ type ZoneSetting struct {
 	ID            string      `json:"id"`
 	Editable      bool        `json:"editable"`
 	ModifiedOn    string      `json:"modified_on"`
-	Value         interface{} `json:"value""`
-	TimeRemaining int         `json:"time_remaining""`
+	Value         interface{} `json:"value"`
+	TimeRemaining int         `json:"time_remaining"`
 }
 
 type ZoneSettingResponse struct {

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
-	"github.com/jamesog/cloudflare"
+	"github.com/jamesog/cloudflare-go"
 )
 
 var api *cloudflare.API


### PR DESCRIPTION
Fixed the import path in `cmd/flarectl` to refer to the (correct) `github.com/jamesog/cloudflare-go` import path. This was preventing flarectl from being built automatically.
