### PR TITLE
Added POC arbitrary query strings

### DIFF
--- a/waf.go
+++ b/waf.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"errors"
+	"net/url"
 )
 
 func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
@@ -26,12 +28,20 @@ func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
 	return packages, err
 }
 
-func (api *API) ListWAFRules(zoneID string, packageID string) ([]WAFRule, error) {
+func (api *API) ListWAFRules(zoneID string, packageID string, v ...url.Values) ([]WAFRule, error) {
+	var query url.Values
 	var r WAFRulesResponse
 	var rules []WAFRule
 	var res []byte
 	var err error
-	res, err = api.makeRequest("GET", "/zones/"+zoneID+"/firewall/waf/packages/"+packageID+"/rules", nil)
+	if len(v) > 1 {
+		return []WAFRule{}, errors.New("Too many arguments")
+	} else if len(v) == 0 {
+		query = url.Values{}
+	} else {
+		query = v[0]
+	}
+	res, err = api.makeRequest("GET", "/zones/"+zoneID+"/firewall/waf/packages/"+packageID+"/rules?"+query.Encode(), nil)
 	if err != nil {
 		return []WAFRule{}, err
 	}


### PR DESCRIPTION
So there's a strong chance that this particular incarnation of this PR will be rejected, but I figured a POC would be better than trying to say what I mean in an issue

I've modified the ListWAFRules function to take an optional url.Values... My personal use case for this being that I want to see ALL my WAF rules, so ?per_page=1000 for example.

Obviously this is introducing a special case, so a couple of ideas would be:
- Do this on *, or at least all places it makes sense (messy but would make everything super flexible)
- Add a url.Values to the API struct that can be used as a default, and add it on to the URL within makeRequest (much tidier but modifying would no longer be concurrency safe)
- Both (which I quite like, as you can have your default set in the API struct and any special rules explicitly entered per request)

Equally, I'd be very happy for this to be accepted in to master as it's on my critical path, but beyond that the second option would help immensely for my use case.

Anyway, let me know what you think, I'm happy to do some more leg work on this.
