### PR TITLE
Add support for /ips

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -408,3 +408,17 @@ type PurgeCacheResponse struct {
 	Errors   []string `json:"errors"`
 	Messages []string `json:"messages"`
 }
+
+// IPs contains a list of IPv4 and IPv6 CIDRs
+type IPRanges struct {
+	IPv4CIDRs []string `json:"ipv4_cidrs"`
+	IPv6CIDRs []string `json:"ipv6_cidrs"`
+}
+
+// IPsResponse is the API response containing a list of IPs
+type IPsResponse struct {
+	Success  bool     `json:"success"`
+	Errors   []string `json:"errors"`
+	Messages []string `json:"messages"`
+	Result   IPRanges `json:"result"`
+}

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -50,6 +51,16 @@ func makeTable(zones []table, cols ...string) {
 
 }
 
+func checkEnv() error {
+	if api.APIKey == "" {
+		return errors.New("API key not defined")
+	}
+	if api.APIEmail == "" {
+		return errors.New("API email not defined")
+	}
+	return nil
+}
+
 // Utility function to check if CLI flags were given.
 func checkFlags(c *cli.Context, flags ...string) error {
 	for _, flag := range flags {
@@ -62,6 +73,10 @@ func checkFlags(c *cli.Context, flags ...string) error {
 }
 
 func userInfo(*cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	user, err := api.UserDetails()
 	if err != nil {
 		fmt.Println(err)
@@ -82,6 +97,10 @@ func userUpdate(*cli.Context) {
 }
 
 func zoneList(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	zones, err := api.ListZones()
 	if err != nil {
 		fmt.Println(err)
@@ -100,6 +119,10 @@ func zoneList(c *cli.Context) {
 }
 
 func zoneInfo(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	var zone string
 	if len(c.Args()) > 0 {
 		zone = c.Args()[0]
@@ -136,6 +159,10 @@ func zoneSettings(*cli.Context) {
 }
 
 func zoneRecords(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	var zone string
 	if len(c.Args()) > 0 {
 		zone = c.Args()[0]
@@ -195,6 +222,10 @@ func zoneRecords(c *cli.Context) {
 }
 
 func dnsCreate(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	if err := checkFlags(c, "zone", "name", "type", "content"); err != nil {
 		return
 	}
@@ -219,6 +250,10 @@ func dnsCreate(c *cli.Context) {
 }
 
 func dnsCreateOrUpdate(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	if err := checkFlags(c, "zone", "name", "type", "content"); err != nil {
 		return
 	}
@@ -270,6 +305,10 @@ func dnsCreateOrUpdate(c *cli.Context) {
 }
 
 func dnsUpdate(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		return
 	}
@@ -292,6 +331,10 @@ func dnsUpdate(c *cli.Context) {
 }
 
 func dnsDelete(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		return
 	}
@@ -318,15 +361,6 @@ func railgun(*cli.Context) {
 
 func main() {
 	api = cloudflare.New(os.Getenv("CF_API_KEY"), os.Getenv("CF_API_EMAIL"))
-
-	if api.APIKey == "" {
-		fmt.Println("API key not defined")
-		return
-	}
-	if api.APIEmail == "" {
-		fmt.Println("API email not defined")
-		return
-	}
 
 	app := cli.NewApp()
 	app.Name = "flarectl"

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/cloudflare/cloudflare-go"
 	"github.com/codegangsta/cli"
-	"github.com/jamesog/cloudflare-go"
 )
 
 var api *cloudflare.API

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -72,6 +72,19 @@ func checkFlags(c *cli.Context, flags ...string) error {
 	return nil
 }
 
+func ips(*cli.Context) {
+	ips, _ := cloudflare.IPs()
+	fmt.Println("IPv4 ranges:")
+	for _, r := range ips.IPv4CIDRs {
+		fmt.Println(" ", r)
+	}
+	fmt.Println()
+	fmt.Println("IPv6 ranges:")
+	for _, r := range ips.IPv6CIDRs {
+		fmt.Println(" ", r)
+	}
+}
+
 func userInfo(*cli.Context) {
 	if err := checkEnv(); err != nil {
 		fmt.Println(err)
@@ -367,6 +380,12 @@ func main() {
 	app.Usage = "CloudFlare CLI"
 	app.Version = "2015.12.0"
 	app.Commands = []cli.Command{
+		{
+			Name:    "ips",
+			Aliases: []string{"i"},
+			Action:  ips,
+			Usage:   "List of CloudFlare IP ranges",
+		},
 		{
 			Name:    "user",
 			Aliases: []string{"u"},

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -384,7 +384,7 @@ func main() {
 			Name:    "ips",
 			Aliases: []string{"i"},
 			Action:  ips,
-			Usage:   "List of CloudFlare IP ranges",
+			Usage:   "Print CloudFlare IP ranges",
 		},
 		{
 			Name:    "user",

--- a/ips.go
+++ b/ips.go
@@ -1,0 +1,31 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+/*
+IPs gets a list of CloudFlare's IP ranges
+
+This does not require logging in to the API.
+
+API reference:
+  https://api.cloudflare.com/#cloudflare-ips
+  GET /client/v4/ips
+*/
+func IPs() (IPRanges, error) {
+	resp, err := http.Get(apiURL + "/ips")
+	if err != nil {
+		return IPRanges{}, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	var r IPsResponse
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return IPRanges{}, err
+	}
+	return r.Result, nil
+}


### PR DESCRIPTION
A new API endpoint exposes CloudFlare's public IP ranges.

This endpoint does not require logging in to the API.