### PR TITLE
Refactoring of method signatures

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -35,6 +35,20 @@ func NewZone() *Zone {
 	return &Zone{}
 }
 
+// ZoneIDByName retrieves a zone's ID from the name.
+func (api *API) ZoneIDByName(zoneName string) (string, error) {
+	res, err := api.ListZones(zoneName)
+	if err != nil {
+		return "", err
+	}
+	for _, zone := range res {
+		if zone.Name == zoneName {
+			return zone.ID, nil
+		}
+	}
+	return "", errors.New("Zone could not be found")
+}
+
 // Params can be turned into a URL query string or a body
 // TODO: Give this func a better name
 func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, error) {

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -186,7 +186,7 @@ func zoneRecords(c *cli.Context) {
 		return
 	}
 
-	zid, err := api.ZoneIDByName(zone)
+	zoneID, err := api.ZoneIDByName(zone)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -196,7 +196,7 @@ func zoneRecords(c *cli.Context) {
 	rr := cloudflare.DNSRecord{}
 	var records []cloudflare.DNSRecord
 	if c.String("id") != "" {
-		rec, err := api.DNSRecord(zid, c.String("id"))
+		rec, err := api.DNSRecord(zoneID, c.String("id"))
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -210,7 +210,7 @@ func zoneRecords(c *cli.Context) {
 			rr.Name = c.String("content")
 		}
 		var err error
-		records, err = api.DNSRecords(zid, rr)
+		records, err = api.DNSRecords(zoneID, rr)
 		if err != nil {
 			fmt.Println(err)
 			return
@@ -256,7 +256,7 @@ func dnsCreate(c *cli.Context) {
 	ttl := c.Int("ttl")
 	proxy := c.Bool("proxy")
 
-	zid, err := api.ZoneIDByName(zone)
+	zoneID, err := api.ZoneIDByName(zone)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -269,7 +269,7 @@ func dnsCreate(c *cli.Context) {
 		TTL:     ttl,
 		Proxied: proxy,
 	}
-	err = api.CreateDNSRecord(zid, record)
+	err = api.CreateDNSRecord(zoneID, record)
 	if err != nil {
 		fmt.Println("Error creating DNS record:", err)
 	}
@@ -290,7 +290,7 @@ func dnsCreateOrUpdate(c *cli.Context) {
 	ttl := c.Int("ttl")
 	proxy := c.Bool("proxy")
 
-	zid, err := api.ZoneIDByName(zone)
+	zoneID, err := api.ZoneIDByName(zone)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -300,7 +300,7 @@ func dnsCreateOrUpdate(c *cli.Context) {
 	rr := cloudflare.DNSRecord{
 		Name: name + "." + zone,
 	}
-	records, err := api.DNSRecords(zid, rr)
+	records, err := api.DNSRecords(zoneID, rr)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -317,7 +317,7 @@ func dnsCreateOrUpdate(c *cli.Context) {
 				rr.Content = content
 				rr.TTL = ttl
 				rr.Proxied = proxy
-				err := api.UpdateDNSRecord(zid, r.ID, rr)
+				err := api.UpdateDNSRecord(zoneID, r.ID, rr)
 				if err != nil {
 					fmt.Println("Error updating DNS record:", err)
 				}
@@ -329,7 +329,7 @@ func dnsCreateOrUpdate(c *cli.Context) {
 		rr.Content = content
 		rr.TTL = ttl
 		rr.Proxied = proxy
-		err := api.CreateDNSRecord(zid, rr)
+		err := api.CreateDNSRecord(zoneID, rr)
 		if err != nil {
 			fmt.Println("Error creating DNS record:", err)
 		}
@@ -345,24 +345,24 @@ func dnsUpdate(c *cli.Context) {
 		return
 	}
 	zone := c.String("zone")
-	rid := c.String("id")
+	recordID := c.String("id")
 	content := c.String("content")
 	ttl := c.Int("ttl")
 	proxy := c.Bool("proxy")
 
-	zid, err := api.ZoneIDByName(zone)
+	zoneID, err := api.ZoneIDByName(zone)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
 	record := cloudflare.DNSRecord{
-		ID:      rid,
+		ID:      recordID,
 		Content: content,
 		TTL:     ttl,
 		Proxied: proxy,
 	}
-	err = api.UpdateDNSRecord(zid, rid, record)
+	err = api.UpdateDNSRecord(zoneID, recordID, record)
 	if err != nil {
 		fmt.Println("Error updating DNS record:", err)
 	}
@@ -377,15 +377,15 @@ func dnsDelete(c *cli.Context) {
 		return
 	}
 	zone := c.String("zone")
-	rid := c.String("id")
+	recordID := c.String("id")
 
-	zid, err := api.ZoneIDByName(zone)
+	zoneID, err := api.ZoneIDByName(zone)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	err = api.DeleteDNSRecord(zid, rid)
+	err = api.DeleteDNSRecord(zoneID, recordID)
 	if err != nil {
 		fmt.Println("Error deleting DNS record:", err)
 	}
@@ -410,13 +410,13 @@ func pageRules(c *cli.Context) {
 	}
 	zone := c.String("zone")
 
-	zid, err := api.ZoneIDByName(zone)
+	zoneID, err := api.ZoneIDByName(zone)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 
-	rules, err := api.ListPageRules(zid)
+	rules, err := api.ListPageRules(zoneID)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/dns.go
+++ b/dns.go
@@ -13,13 +13,7 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
   POST /zones/:zone_identifier/dns_records
 */
-func (api *API) CreateDNSRecord(zone string, rr DNSRecord) error {
-	z, err := api.ListZones(zone)
-	if err != nil {
-		return err
-	}
-	// TODO(jamesog): This is brittle, fix it
-	zid := z[0].ID
+func (api *API) CreateDNSRecord(zid string, rr DNSRecord) error {
 	uri := "/zones/" + zid + "/dns_records"
 	res, err := api.makeRequest("POST", uri, rr)
 	if err != nil {
@@ -42,14 +36,7 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
   GET /zones/:zone_identifier/dns_records
 */
-func (api *API) DNSRecords(zone string, rr DNSRecord) ([]DNSRecord, error) {
-	z, err := api.ListZones(zone)
-	if err != nil {
-		return []DNSRecord{}, err
-	}
-	// TODO(jamesog): This is brittle, fix it
-	zid := z[0].ID
-
+func (api *API) DNSRecords(zid string, rr DNSRecord) ([]DNSRecord, error) {
 	// Construct a query string
 	v := url.Values{}
 	if rr.Name != "" {
@@ -85,14 +72,8 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-dns-record-details
   GET /zones/:zone_identifier/dns_records/:identifier
 */
-func (api *API) DNSRecord(zone, id string) (DNSRecord, error) {
-	z, err := api.ListZones(zone)
-	if err != nil {
-		return DNSRecord{}, err
-	}
-	// TODO(jamesog): This is brittle, fix it
-	zid := z[0].ID
-	uri := "/zones/" + zid + "/dns_records/" + id
+func (api *API) DNSRecord(zid, rid string) (DNSRecord, error) {
+	uri := "/zones/" + zid + "/dns_records/" + rid
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return DNSRecord{}, err
@@ -112,20 +93,14 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
   PUT /zones/:zone_identifier/dns_records/:identifier
 */
-func (api *API) UpdateDNSRecord(zone, id string, rr DNSRecord) error {
-	z, err := api.ListZones(zone)
-	if err != nil {
-		return err
-	}
-	// TODO(jamesog): This is brittle, fix it
-	zid := z[0].ID
-	rec, err := api.DNSRecord(zone, id)
+func (api *API) UpdateDNSRecord(zid, rid string, rr DNSRecord) error {
+	rec, err := api.DNSRecord(zid, rid)
 	if err != nil {
 		return err
 	}
 	rr.Name = rec.Name
 	rr.Type = rec.Type
-	uri := "/zones/" + zid + "/dns_records/" + id
+	uri := "/zones/" + zid + "/dns_records/" + rid
 	res, err := api.makeRequest("PUT", uri, rr)
 	if err != nil {
 		fmt.Println("Error with makeRequest")
@@ -147,14 +122,8 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-delete-dns-record
   DELETE /zones/:zone_identifier/dns_records/:identifier
 */
-func (api *API) DeleteDNSRecord(zone, id string) error {
-	z, err := api.ListZones(zone)
-	if err != nil {
-		return err
-	}
-	// TODO(jamesog): This is brittle, fix it
-	zid := z[0].ID
-	uri := "/zones/" + zid + "/dns_records/" + id
+func (api *API) DeleteDNSRecord(zid, rid string) error {
+	uri := "/zones/" + zid + "/dns_records/" + rid
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
 		fmt.Println("Error with makeRequest")

--- a/dns.go
+++ b/dns.go
@@ -13,8 +13,8 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
   POST /zones/:zone_identifier/dns_records
 */
-func (api *API) CreateDNSRecord(zid string, rr DNSRecord) error {
-	uri := "/zones/" + zid + "/dns_records"
+func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) error {
+	uri := "/zones/" + zoneID + "/dns_records"
 	res, err := api.makeRequest("POST", uri, rr)
 	if err != nil {
 		fmt.Println("Error with makeRequest")
@@ -36,7 +36,7 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
   GET /zones/:zone_identifier/dns_records
 */
-func (api *API) DNSRecords(zid string, rr DNSRecord) ([]DNSRecord, error) {
+func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	// Construct a query string
 	v := url.Values{}
 	if rr.Name != "" {
@@ -52,7 +52,7 @@ func (api *API) DNSRecords(zid string, rr DNSRecord) ([]DNSRecord, error) {
 	if len(v) > 0 {
 		query = "?" + v.Encode()
 	}
-	uri := "/zones/" + zid + "/dns_records" + query
+	uri := "/zones/" + zoneID + "/dns_records" + query
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return []DNSRecord{}, err
@@ -72,8 +72,8 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-dns-record-details
   GET /zones/:zone_identifier/dns_records/:identifier
 */
-func (api *API) DNSRecord(zid, rid string) (DNSRecord, error) {
-	uri := "/zones/" + zid + "/dns_records/" + rid
+func (api *API) DNSRecord(zoneID, recordID string) (DNSRecord, error) {
+	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return DNSRecord{}, err
@@ -93,14 +93,14 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
   PUT /zones/:zone_identifier/dns_records/:identifier
 */
-func (api *API) UpdateDNSRecord(zid, rid string, rr DNSRecord) error {
-	rec, err := api.DNSRecord(zid, rid)
+func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
+	rec, err := api.DNSRecord(zoneID, recordID)
 	if err != nil {
 		return err
 	}
 	rr.Name = rec.Name
 	rr.Type = rec.Type
-	uri := "/zones/" + zid + "/dns_records/" + rid
+	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("PUT", uri, rr)
 	if err != nil {
 		fmt.Println("Error with makeRequest")
@@ -122,8 +122,8 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-delete-dns-record
   DELETE /zones/:zone_identifier/dns_records/:identifier
 */
-func (api *API) DeleteDNSRecord(zid, rid string) error {
-	uri := "/zones/" + zid + "/dns_records/" + rid
+func (api *API) DeleteDNSRecord(zoneID, recordID string) error {
+	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
 		fmt.Println("Error with makeRequest")

--- a/pagerules.go
+++ b/pagerules.go
@@ -105,8 +105,8 @@ API reference:
   https://api.cloudflare.com/#page-rules-for-a-zone-create-a-page-rule
   POST /zones/:zone_identifier/pagerules
 */
-func (api *API) CreatePageRule(zid string, rule PageRule) error {
-	uri := "/zones/" + zid + "/pagerules"
+func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
+	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("POST", uri, rule)
 	if err != nil {
 		return err
@@ -126,8 +126,8 @@ API reference:
   https://api.cloudflare.com/#page-rules-for-a-zone-list-page-rules
   GET /zones/:zone_identifier/pagerules
 */
-func (api *API) ListPageRules(zid string) ([]PageRule, error) {
-	uri := "/zones/" + zid + "/pagerules"
+func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
+	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return []PageRule{}, err
@@ -147,8 +147,8 @@ API reference:
   https://api.cloudflare.com/#page-rules-for-a-zone-page-rule-details
   GET /zones/:zone_identifier/pagerules/:identifier
 */
-func (api *API) PageRule(zid, id string) (PageRule, error) {
-	uri := "/zones/" + zid + "/pagerules/" + id
+func (api *API) PageRule(zoneID, ruleID string) (PageRule, error) {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return PageRule{}, err
@@ -169,8 +169,8 @@ API reference:
   https://api.cloudflare.com/#page-rules-for-a-zone-change-a-page-rule
   PATCH /zones/:zone_identifier/pagerules/:identifier
 */
-func (api *API) ChangePageRule(zid, id string, rule PageRule) error {
-	uri := "/zones/" + zid + "/pagerules/" + id
+func (api *API) ChangePageRule(zoneID, ruleID string, rule PageRule) error {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PATCH", uri, rule)
 	if err != nil {
 		return err
@@ -191,8 +191,8 @@ API reference:
   https://api.cloudflare.com/#page-rules-for-a-zone-update-a-page-rule
   PUT /zones/:zone_identifier/pagerules/:identifier
 */
-func (api *API) UpdatePageRule(zid, id string, rule PageRule) error {
-	uri := "/zones/" + zid + "/pagerules/" + id
+func (api *API) UpdatePageRule(zoneID, ruleID string, rule PageRule) error {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PUT", uri, nil)
 	if err != nil {
 		return err
@@ -212,8 +212,8 @@ API reference:
   https://api.cloudflare.com/#page-rules-for-a-zone-delete-a-page-rule
   DELETE /zones/:zone_identifier/pagerules/:identifier
 */
-func (api *API) DeletePageRule(zid, id string) error {
-	uri := "/zones/" + zid + "/pagerules/" + id
+func (api *API) DeletePageRule(zoneID, ruleID string) error {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
 		return err

--- a/waf.go
+++ b/waf.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 )
 
-func (api *API) ListWAFPackages(zid string) ([]WAFPackage, error) {
+func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
 	var p WAFPackagesResponse
 	var packages []WAFPackage
 	var res []byte
 	var err error
-	uri := "/zones/" + zid + "/firewall/waf/packages"
+	uri := "/zones/" + zoneID + "/firewall/waf/packages"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return []WAFPackage{}, err
@@ -27,12 +27,12 @@ func (api *API) ListWAFPackages(zid string) ([]WAFPackage, error) {
 	return packages, err
 }
 
-func (api *API) ListWAFRules(zid, pid string) ([]WAFRule, error) {
+func (api *API) ListWAFRules(zoneID, packageID string) ([]WAFRule, error) {
 	var r WAFRulesResponse
 	var rules []WAFRule
 	var res []byte
 	var err error
-	uri := "/zones/" + zid + "/firewall/waf/packages/" + pid + "/rules"
+	uri := "/zones/" + zoneID + "/firewall/waf/packages/" + packageID + "/rules"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return []WAFRule{}, err

--- a/waf.go
+++ b/waf.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 )
 
-func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
+func (api *API) ListWAFPackages(zid string) ([]WAFPackage, error) {
 	var p WAFPackagesResponse
 	var packages []WAFPackage
 	var res []byte
 	var err error
-	res, err = api.makeRequest("GET", "/zones/"+zoneID+"/firewall/waf/packages", nil)
+	uri := "/zones/" + zid + "/firewall/waf/packages"
+	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return []WAFPackage{}, err
 	}
@@ -26,12 +27,13 @@ func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
 	return packages, err
 }
 
-func (api *API) ListWAFRules(zoneID string, packageID string) ([]WAFRule, error) {
+func (api *API) ListWAFRules(zid, pid string) ([]WAFRule, error) {
 	var r WAFRulesResponse
 	var rules []WAFRule
 	var res []byte
 	var err error
-	res, err = api.makeRequest("GET", "/zones/"+zoneID+"/firewall/waf/packages/"+packageID+"/rules", nil)
+	uri := "/zones/" + zid + "/firewall/waf/packages/" + pid + "/rules"
+	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return []WAFRule{}, err
 	}

--- a/zone.go
+++ b/zone.go
@@ -96,8 +96,9 @@ func EditZone() {
 
 // https://api.cloudflare.com/#zone-purge-all-files
 // DELETE /zones/:id/purge_cache
-func (api *API) PurgeEverything(z Zone) (PurgeCacheResponse, error) {
-	res, err := api.makeRequest("DELETE", "/zones/"+z.ID+"/purge_cache", PurgeCacheRequest{true, nil, nil})
+func (api *API) PurgeEverything(zid string) (PurgeCacheResponse, error) {
+	uri := "/zones/" + zid + "/purge_cache"
+	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil})
 	if err != nil {
 		return PurgeCacheResponse{}, err
 	}
@@ -111,8 +112,9 @@ func (api *API) PurgeEverything(z Zone) (PurgeCacheResponse, error) {
 
 // https://api.cloudflare.com/#zone-purge-individual-files-by-url-and-cache-tags
 // DELETE /zones/:id/purge_cache
-func (api *API) PurgeCache(z Zone, pcr PurgeCacheRequest) (PurgeCacheResponse, error) {
-	res, err := api.makeRequest("DELETE", "/zones/"+z.ID+"/purge_cache", pcr)
+func (api *API) PurgeCache(zid string, pcr PurgeCacheRequest) (PurgeCacheResponse, error) {
+	uri := "/zones/" + zid + "/purge_cache"
+	res, err := api.makeRequest("DELETE", uri, pcr)
 	if err != nil {
 		return PurgeCacheResponse{}, err
 	}

--- a/zone.go
+++ b/zone.go
@@ -96,8 +96,8 @@ func EditZone() {
 
 // https://api.cloudflare.com/#zone-purge-all-files
 // DELETE /zones/:id/purge_cache
-func (api *API) PurgeEverything(zid string) (PurgeCacheResponse, error) {
-	uri := "/zones/" + zid + "/purge_cache"
+func (api *API) PurgeEverything(zoneID string) (PurgeCacheResponse, error) {
+	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil})
 	if err != nil {
 		return PurgeCacheResponse{}, err
@@ -112,8 +112,8 @@ func (api *API) PurgeEverything(zid string) (PurgeCacheResponse, error) {
 
 // https://api.cloudflare.com/#zone-purge-individual-files-by-url-and-cache-tags
 // DELETE /zones/:id/purge_cache
-func (api *API) PurgeCache(zid string, pcr PurgeCacheRequest) (PurgeCacheResponse, error) {
-	uri := "/zones/" + zid + "/purge_cache"
+func (api *API) PurgeCache(zoneID string, pcr PurgeCacheRequest) (PurgeCacheResponse, error) {
+	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, pcr)
 	if err != nil {
 		return PurgeCacheResponse{}, err


### PR DESCRIPTION
As discussed in #18, we should have a more consistent signature for the methods provided in the package, this is an attempt to implement that. It changes all methods interacting with the CF API to use a zone ID, if needed by the API.

It also adds the `ZoneIDByName()` convenience method to get a zone ID from a zone name, and makes use of that in `flarectl`.

/cc @jamesog @elithrar 