### PR TITLE
Use the correct field name for status of a zone in the Zone struct

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -145,7 +145,7 @@ type Zone struct {
 	Owner             Owner    `json:"owner"`
 	Permissions       []string `json:"permissions"`
 	Plan              ZonePlan `json:"plan"`
-	Status            string   `json:"success"`
+	Status            string   `json:"status"`
 	Paused            bool     `json:"paused"`
 	Type              string   `json:"type"`
 	Host              struct {


### PR DESCRIPTION
A silly little bug I found while testing the changes in #22.