### PR TITLE
Better and more consistent error handling by wrapping the errors

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -21,6 +21,10 @@ import (
 
 const apiURL = "https://api.cloudflare.com/client/v4"
 
+// Error messages
+const errMakeRequestError = "Error from makeRequest"
+const errUnmarshalError = "Error unmarshalling JSON"
+
 type API struct {
 	APIKey   string
 	APIEmail string

--- a/dns.go
+++ b/dns.go
@@ -2,8 +2,9 @@ package cloudflare
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
+
+	pkgErrors "github.com/pkg/errors"
 )
 
 /*
@@ -17,14 +18,12 @@ func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) error {
 	uri := "/zones/" + zoneID + "/dns_records"
 	res, err := api.makeRequest("POST", uri, rr)
 	if err != nil {
-		fmt.Println("Error with makeRequest")
-		return err
+		return pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		fmt.Println("Error with unmarshal")
-		return err
+		return pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return nil
 }
@@ -55,12 +54,12 @@ func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records" + query
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []DNSRecord{}, err
+		return []DNSRecord{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r DNSListResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []DNSRecord{}, err
+		return []DNSRecord{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r.Result, nil
 }
@@ -76,12 +75,12 @@ func (api *API) DNSRecord(zoneID, recordID string) (DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return DNSRecord{}, err
+		return DNSRecord{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return DNSRecord{}, err
+		return DNSRecord{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r.Result, nil
 }
@@ -103,16 +102,14 @@ func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("PUT", uri, rr)
 	if err != nil {
-		fmt.Println("Error with makeRequest")
-		return err
+		return pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		fmt.Println("Error with unmarshal")
-		return err
+		return pkgErrors.Wrap(err, "Error from unmarshal")
 	}
-	return err
+	return nil
 }
 
 /*
@@ -126,14 +123,12 @@ func (api *API) DeleteDNSRecord(zoneID, recordID string) error {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		fmt.Println("Error with makeRequest")
-		return err
+		return pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		fmt.Println("Error with unmarshal")
-		return err
+		return pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return nil
 }

--- a/dns.go
+++ b/dns.go
@@ -18,12 +18,12 @@ func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) error {
 	uri := "/zones/" + zoneID + "/dns_records"
 	res, err := api.makeRequest("POST", uri, rr)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from makeRequest")
+		return pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from unmarshal")
+		return pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -54,12 +54,12 @@ func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records" + query
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []DNSRecord{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return []DNSRecord{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSListResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []DNSRecord{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return []DNSRecord{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -75,12 +75,12 @@ func (api *API) DNSRecord(zoneID, recordID string) (DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return DNSRecord{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return DNSRecord{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return DNSRecord{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return DNSRecord{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -102,12 +102,12 @@ func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("PUT", uri, rr)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from makeRequest")
+		return pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from unmarshal")
+		return pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -123,12 +123,12 @@ func (api *API) DeleteDNSRecord(zoneID, recordID string) error {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from makeRequest")
+		return pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from unmarshal")
+		return pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }

--- a/ips.go
+++ b/ips.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+
+	pkgErrors "github.com/pkg/errors"
 )
 
 /*
@@ -18,14 +20,17 @@ API reference:
 func IPs() (IPRanges, error) {
 	resp, err := http.Get(apiURL + "/ips")
 	if err != nil {
-		return IPRanges{}, err
+		return IPRanges{}, pkgErrors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return IPRanges{}, pkgErrors.Wrap(err, "Response body could not be read")
+	}
 	var r IPsResponse
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		return IPRanges{}, err
+		return IPRanges{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r.Result, nil
 }

--- a/ips.go
+++ b/ips.go
@@ -30,7 +30,7 @@ func IPs() (IPRanges, error) {
 	var r IPsResponse
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		return IPRanges{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return IPRanges{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/pagerules.go
+++ b/pagerules.go
@@ -1,6 +1,10 @@
 package cloudflare
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	pkgErrors "github.com/pkg/errors"
+)
 
 /*
 PageRuleTarget is the target to evaluate on a request.
@@ -109,12 +113,12 @@ func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("POST", uri, rule)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return nil
 }
@@ -130,12 +134,12 @@ func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []PageRule{}, err
+		return []PageRule{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PageRulesResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []PageRule{}, err
+		return []PageRule{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r.Result, nil
 }
@@ -151,12 +155,12 @@ func (api *API) PageRule(zoneID, ruleID string) (PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return PageRule{}, err
+		return PageRule{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PageRule{}, err
+		return PageRule{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r.Result, nil
 }
@@ -173,12 +177,12 @@ func (api *API) ChangePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PATCH", uri, rule)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return nil
 }
@@ -195,12 +199,12 @@ func (api *API) UpdatePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PUT", uri, nil)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return nil
 }
@@ -216,12 +220,12 @@ func (api *API) DeletePageRule(zoneID, ruleID string) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return err
+		return pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return nil
 }

--- a/pagerules.go
+++ b/pagerules.go
@@ -113,12 +113,12 @@ func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("POST", uri, rule)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from makeRequest")
+		return pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from unmarshal")
+		return pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -134,12 +134,12 @@ func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []PageRule{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return []PageRule{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRulesResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []PageRule{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return []PageRule{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -155,12 +155,12 @@ func (api *API) PageRule(zoneID, ruleID string) (PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return PageRule{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return PageRule{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PageRule{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return PageRule{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -177,12 +177,12 @@ func (api *API) ChangePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PATCH", uri, rule)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from makeRequest")
+		return pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from unmarshal")
+		return pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -199,12 +199,12 @@ func (api *API) UpdatePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PUT", uri, nil)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from makeRequest")
+		return pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from unmarshal")
+		return pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -220,12 +220,12 @@ func (api *API) DeletePageRule(zoneID, ruleID string) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from makeRequest")
+		return pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, "Error from unmarshal")
+		return pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }

--- a/user.go
+++ b/user.go
@@ -15,11 +15,11 @@ func (api API) UserDetails() (User, error) {
 	var r UserResponse
 	res, err := api.makeRequest("GET", "/user", nil)
 	if err != nil {
-		return User{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return User{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return User{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return User{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/user.go
+++ b/user.go
@@ -1,6 +1,10 @@
 package cloudflare
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	pkgErrors "github.com/pkg/errors"
+)
 
 /*
 Information about the logged-in user.
@@ -11,11 +15,11 @@ func (api API) UserDetails() (User, error) {
 	var r UserResponse
 	res, err := api.makeRequest("GET", "/user", nil)
 	if err != nil {
-		return User{}, err
+		return User{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return User{}, err
+		return User{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r.Result, nil
 }

--- a/waf.go
+++ b/waf.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"encoding/json"
+
+	pkgErrors "github.com/pkg/errors"
 )
 
 func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
@@ -12,19 +14,20 @@ func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
 	uri := "/zones/" + zoneID + "/firewall/waf/packages"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []WAFPackage{}, err
+		return []WAFPackage{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	err = json.Unmarshal(res, &p)
 	if err != nil {
-		return []WAFPackage{}, err
+		return []WAFPackage{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	if !p.Success {
+		// TODO: Provide an actual error message instead of always returning nil
 		return []WAFPackage{}, err
 	}
 	for pi, _ := range p.Result {
 		packages = append(packages, p.Result[pi])
 	}
-	return packages, err
+	return packages, nil
 }
 
 func (api *API) ListWAFRules(zoneID, packageID string) ([]WAFRule, error) {
@@ -35,17 +38,18 @@ func (api *API) ListWAFRules(zoneID, packageID string) ([]WAFRule, error) {
 	uri := "/zones/" + zoneID + "/firewall/waf/packages/" + packageID + "/rules"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []WAFRule{}, err
+		return []WAFRule{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []WAFRule{}, err
+		return []WAFRule{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	if !r.Success {
+		// TODO: Provide an actual error message instead of always returning nil
 		return []WAFRule{}, err
 	}
 	for ri, _ := range r.Result {
 		rules = append(rules, r.Result[ri])
 	}
-	return rules, err
+	return rules, nil
 }

--- a/waf.go
+++ b/waf.go
@@ -14,11 +14,11 @@ func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
 	uri := "/zones/" + zoneID + "/firewall/waf/packages"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []WAFPackage{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return []WAFPackage{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	err = json.Unmarshal(res, &p)
 	if err != nil {
-		return []WAFPackage{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return []WAFPackage{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	if !p.Success {
 		// TODO: Provide an actual error message instead of always returning nil
@@ -38,11 +38,11 @@ func (api *API) ListWAFRules(zoneID, packageID string) ([]WAFRule, error) {
 	uri := "/zones/" + zoneID + "/firewall/waf/packages/" + packageID + "/rules"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []WAFRule{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return []WAFRule{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []WAFRule{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return []WAFRule{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	if !r.Success {
 		// TODO: Provide an actual error message instead of always returning nil

--- a/zone.go
+++ b/zone.go
@@ -32,11 +32,11 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 			v.Set("name", zone)
 			res, err = api.makeRequest("GET", "/zones?"+v.Encode(), nil)
 			if err != nil {
-				return []Zone{}, pkgErrors.Wrap(err, "Error from makeRequest")
+				return []Zone{}, pkgErrors.Wrap(err, errMakeRequestError)
 			}
 			err = json.Unmarshal(res, &r)
 			if err != nil {
-				return []Zone{}, pkgErrors.Wrap(err, "Error from unmarshal")
+				return []Zone{}, pkgErrors.Wrap(err, errUnmarshalError)
 			}
 			if !r.Success {
 				// TODO: Provide an actual error message instead of always returning nil
@@ -49,11 +49,11 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 	} else {
 		res, err = api.makeRequest("GET", "/zones", nil)
 		if err != nil {
-			return []Zone{}, pkgErrors.Wrap(err, "Error from makeRequest")
+			return []Zone{}, pkgErrors.Wrap(err, errMakeRequestError)
 		}
 		err = json.Unmarshal(res, &r)
 		if err != nil {
-			return []Zone{}, pkgErrors.Wrap(err, "Error from unmarshal")
+			return []Zone{}, pkgErrors.Wrap(err, errUnmarshalError)
 		}
 		zones = r.Result
 	}
@@ -103,12 +103,12 @@ func (api *API) PurgeEverything(zoneID string) (PurgeCacheResponse, error) {
 	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil})
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PurgeCacheResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r, nil
 }
@@ -119,12 +119,12 @@ func (api *API) PurgeCache(zoneID string, pcr PurgeCacheRequest) (PurgeCacheResp
 	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, pcr)
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from makeRequest")
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errMakeRequestError)
 	}
 	var r PurgeCacheResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from unmarshal")
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errUnmarshalError)
 	}
 	return r, nil
 }

--- a/zone.go
+++ b/zone.go
@@ -3,6 +3,8 @@ package cloudflare
 import (
 	"encoding/json"
 	"net/url"
+
+	pkgErrors "github.com/pkg/errors"
 )
 
 /*
@@ -30,14 +32,15 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 			v.Set("name", zone)
 			res, err = api.makeRequest("GET", "/zones?"+v.Encode(), nil)
 			if err != nil {
-				return []Zone{}, err
+				return []Zone{}, pkgErrors.Wrap(err, "Error from makeRequest")
 			}
 			err = json.Unmarshal(res, &r)
 			if err != nil {
-				return []Zone{}, err
+				return []Zone{}, pkgErrors.Wrap(err, "Error from unmarshal")
 			}
 			if !r.Success {
-				return []Zone{}, err //errors.New(r.Messages)
+				// TODO: Provide an actual error message instead of always returning nil
+				return []Zone{}, err
 			}
 			for zi, _ := range r.Result {
 				zones = append(zones, r.Result[zi])
@@ -46,11 +49,11 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 	} else {
 		res, err = api.makeRequest("GET", "/zones", nil)
 		if err != nil {
-			return []Zone{}, err
+			return []Zone{}, pkgErrors.Wrap(err, "Error from makeRequest")
 		}
 		err = json.Unmarshal(res, &r)
 		if err != nil {
-			return []Zone{}, err
+			return []Zone{}, pkgErrors.Wrap(err, "Error from unmarshal")
 		}
 		zones = r.Result
 	}
@@ -100,12 +103,12 @@ func (api *API) PurgeEverything(zoneID string) (PurgeCacheResponse, error) {
 	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil})
 	if err != nil {
-		return PurgeCacheResponse{}, err
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PurgeCacheResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PurgeCacheResponse{}, err
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r, nil
 }
@@ -116,12 +119,12 @@ func (api *API) PurgeCache(zoneID string, pcr PurgeCacheRequest) (PurgeCacheResp
 	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, pcr)
 	if err != nil {
-		return PurgeCacheResponse{}, err
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from makeRequest")
 	}
 	var r PurgeCacheResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PurgeCacheResponse{}, err
+		return PurgeCacheResponse{}, pkgErrors.Wrap(err, "Error from unmarshal")
 	}
 	return r, nil
 }


### PR DESCRIPTION
This is based on Dave Cheney's [talk from Gocon 2016](http://dave.cheney.net/paste/gocon-spring-2016.pdf) and make use of the github.com/pkg/errors package to do error wrapping.

We no longer print error messages and then return them as that would lead to the same error being handling multiple times.

I have also added a missing error check inside makeRequest() after the HTTP request has been tried, plus added a couple of TODO lines in error cases where we return `err` but we already know it's `nil`.