### PR TITLE
[refactor] Replace stdlib errors pkg w/ pkg/errors

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -11,12 +11,11 @@ package cloudflare
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 const apiURL = "https://api.cloudflare.com/client/v4"
@@ -44,7 +43,7 @@ func NewZone() *Zone {
 func (api *API) ZoneIDByName(zoneName string) (string, error) {
 	res, err := api.ListZones(zoneName)
 	if err != nil {
-		return "", pkgErrors.Wrap(err, "ListZones command failed")
+		return "", errors.Wrap(err, "ListZones command failed")
 	}
 	for _, zone := range res {
 		if zone.Name == zoneName {
@@ -62,7 +61,7 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 	if params != nil {
 		json, err := json.Marshal(params)
 		if err != nil {
-			return nil, pkgErrors.Wrap(err, "Error marshalling params to JSON")
+			return nil, errors.Wrap(err, "Error marshalling params to JSON")
 		}
 		reqBody = bytes.NewReader(json)
 	} else {
@@ -70,7 +69,7 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 	}
 	req, err := http.NewRequest(method, apiURL+uri, reqBody)
 	if err != nil {
-		return nil, pkgErrors.Wrap(err, "HTTP request creation failed")
+		return nil, errors.Wrap(err, "HTTP request creation failed")
 	}
 	req.Header.Add("X-Auth-Key", api.APIKey)
 	req.Header.Add("X-Auth-Email", api.APIEmail)
@@ -79,13 +78,13 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, pkgErrors.Wrap(err, "HTTP request failed")
+		return nil, errors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
 	resBody, err := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		if err != nil {
-			return nil, pkgErrors.Wrap(err, "Error returned from API")
+			return nil, errors.Wrap(err, "Error returned from API")
 		} else if resBody != nil {
 			return nil, errors.New(string(resBody))
 		} else {

--- a/dns.go
+++ b/dns.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -18,12 +18,12 @@ func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) error {
 	uri := "/zones/" + zoneID + "/dns_records"
 	res, err := api.makeRequest("POST", uri, rr)
 	if err != nil {
-		return pkgErrors.Wrap(err, errMakeRequestError)
+		return errors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, errUnmarshalError)
+		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -54,12 +54,12 @@ func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records" + query
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []DNSRecord{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return []DNSRecord{}, errors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSListResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []DNSRecord{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return []DNSRecord{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -75,12 +75,12 @@ func (api *API) DNSRecord(zoneID, recordID string) (DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return DNSRecord{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return DNSRecord{}, errors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return DNSRecord{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return DNSRecord{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -102,12 +102,12 @@ func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("PUT", uri, rr)
 	if err != nil {
-		return pkgErrors.Wrap(err, errMakeRequestError)
+		return errors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, errUnmarshalError)
+		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -123,12 +123,12 @@ func (api *API) DeleteDNSRecord(zoneID, recordID string) error {
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		return pkgErrors.Wrap(err, errMakeRequestError)
+		return errors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, errUnmarshalError)
+		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }

--- a/ips.go
+++ b/ips.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -20,17 +20,17 @@ API reference:
 func IPs() (IPRanges, error) {
 	resp, err := http.Get(apiURL + "/ips")
 	if err != nil {
-		return IPRanges{}, pkgErrors.Wrap(err, "HTTP request failed")
+		return IPRanges{}, errors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return IPRanges{}, pkgErrors.Wrap(err, "Response body could not be read")
+		return IPRanges{}, errors.Wrap(err, "Response body could not be read")
 	}
 	var r IPsResponse
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		return IPRanges{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return IPRanges{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/pagerules.go
+++ b/pagerules.go
@@ -3,7 +3,7 @@ package cloudflare
 import (
 	"encoding/json"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -113,12 +113,12 @@ func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("POST", uri, rule)
 	if err != nil {
-		return pkgErrors.Wrap(err, errMakeRequestError)
+		return errors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, errUnmarshalError)
+		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -134,12 +134,12 @@ func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []PageRule{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return []PageRule{}, errors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRulesResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []PageRule{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return []PageRule{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -155,12 +155,12 @@ func (api *API) PageRule(zoneID, ruleID string) (PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return PageRule{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return PageRule{}, errors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PageRule{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return PageRule{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
@@ -177,12 +177,12 @@ func (api *API) ChangePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PATCH", uri, rule)
 	if err != nil {
-		return pkgErrors.Wrap(err, errMakeRequestError)
+		return errors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, errUnmarshalError)
+		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -199,12 +199,12 @@ func (api *API) UpdatePageRule(zoneID, ruleID string, rule PageRule) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("PUT", uri, nil)
 	if err != nil {
-		return pkgErrors.Wrap(err, errMakeRequestError)
+		return errors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, errUnmarshalError)
+		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }
@@ -220,12 +220,12 @@ func (api *API) DeletePageRule(zoneID, ruleID string) error {
 	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		return pkgErrors.Wrap(err, errMakeRequestError)
+		return errors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return pkgErrors.Wrap(err, errUnmarshalError)
+		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
 }

--- a/user.go
+++ b/user.go
@@ -3,7 +3,7 @@ package cloudflare
 import (
 	"encoding/json"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -15,11 +15,11 @@ func (api API) UserDetails() (User, error) {
 	var r UserResponse
 	res, err := api.makeRequest("GET", "/user", nil)
 	if err != nil {
-		return User{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return User{}, errors.Wrap(err, errMakeRequestError)
 	}
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return User{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return User{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/waf.go
+++ b/waf.go
@@ -3,7 +3,7 @@ package cloudflare
 import (
 	"encoding/json"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
@@ -14,11 +14,11 @@ func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
 	uri := "/zones/" + zoneID + "/firewall/waf/packages"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []WAFPackage{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return []WAFPackage{}, errors.Wrap(err, errMakeRequestError)
 	}
 	err = json.Unmarshal(res, &p)
 	if err != nil {
-		return []WAFPackage{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return []WAFPackage{}, errors.Wrap(err, errUnmarshalError)
 	}
 	if !p.Success {
 		// TODO: Provide an actual error message instead of always returning nil
@@ -38,11 +38,11 @@ func (api *API) ListWAFRules(zoneID, packageID string) ([]WAFRule, error) {
 	uri := "/zones/" + zoneID + "/firewall/waf/packages/" + packageID + "/rules"
 	res, err = api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []WAFRule{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return []WAFRule{}, errors.Wrap(err, errMakeRequestError)
 	}
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return []WAFRule{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return []WAFRule{}, errors.Wrap(err, errUnmarshalError)
 	}
 	if !r.Success {
 		// TODO: Provide an actual error message instead of always returning nil

--- a/zone.go
+++ b/zone.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 
-	pkgErrors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -32,11 +32,11 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 			v.Set("name", zone)
 			res, err = api.makeRequest("GET", "/zones?"+v.Encode(), nil)
 			if err != nil {
-				return []Zone{}, pkgErrors.Wrap(err, errMakeRequestError)
+				return []Zone{}, errors.Wrap(err, errMakeRequestError)
 			}
 			err = json.Unmarshal(res, &r)
 			if err != nil {
-				return []Zone{}, pkgErrors.Wrap(err, errUnmarshalError)
+				return []Zone{}, errors.Wrap(err, errUnmarshalError)
 			}
 			if !r.Success {
 				// TODO: Provide an actual error message instead of always returning nil
@@ -49,11 +49,11 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 	} else {
 		res, err = api.makeRequest("GET", "/zones", nil)
 		if err != nil {
-			return []Zone{}, pkgErrors.Wrap(err, errMakeRequestError)
+			return []Zone{}, errors.Wrap(err, errMakeRequestError)
 		}
 		err = json.Unmarshal(res, &r)
 		if err != nil {
-			return []Zone{}, pkgErrors.Wrap(err, errUnmarshalError)
+			return []Zone{}, errors.Wrap(err, errUnmarshalError)
 		}
 		zones = r.Result
 	}
@@ -103,12 +103,12 @@ func (api *API) PurgeEverything(zoneID string) (PurgeCacheResponse, error) {
 	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil})
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return PurgeCacheResponse{}, errors.Wrap(err, errMakeRequestError)
 	}
 	var r PurgeCacheResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return PurgeCacheResponse{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r, nil
 }
@@ -119,12 +119,12 @@ func (api *API) PurgeCache(zoneID string, pcr PurgeCacheRequest) (PurgeCacheResp
 	uri := "/zones/" + zoneID + "/purge_cache"
 	res, err := api.makeRequest("DELETE", uri, pcr)
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errMakeRequestError)
+		return PurgeCacheResponse{}, errors.Wrap(err, errMakeRequestError)
 	}
 	var r PurgeCacheResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return PurgeCacheResponse{}, pkgErrors.Wrap(err, errUnmarshalError)
+		return PurgeCacheResponse{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r, nil
 }


### PR DESCRIPTION
@Tenzer I realised that `github.com/pkg/errors` provides an `errors.New` function synonymous with the std. lib's `errors.New` after merging.
