### PR TITLE
return the created DNS record with creation

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -14,18 +14,18 @@ API reference:
   https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
   POST /zones/:zone_identifier/dns_records
 */
-func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) error {
+func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) (DNSRecord, error) {
 	uri := "/zones/" + zoneID + "/dns_records"
 	res, err := api.makeRequest("POST", uri, rr)
 	if err != nil {
-		return errors.Wrap(err, errMakeRequestError)
+		return DNSRecord{}, errors.Wrap(err, errMakeRequestError)
 	}
 	var r DNSRecordResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return errors.Wrap(err, errUnmarshalError)
+		return DNSRecord{}, errors.Wrap(err, errUnmarshalError)
 	}
-	return nil
+	return r.Result, nil
 }
 
 /*


### PR DESCRIPTION
This is a breaking API change.

The CreateDNSRecord API wasn't returning the DNSRecord which meant that there was no way to safely retrieve the ID of the created record. This is necessary to make further requests.

We're currently using my fork for Terraform with this change since we require this functionality. If you want me to change it in any way to get it in we'd be happy to.