### PR TITLE
Rename `railgun` -> `disable_railgun`

### DIFF
--- a/pagerules.go
+++ b/pagerules.go
@@ -32,13 +32,13 @@ Valid IDs are:
   cache_level
   disable_apps
   disable_performance
+  disable_railgun
   disable_security
   edge_cache_ttl
   email_obfuscation
   forwarding_url
   ip_geolocation
   mirage
-  railgun
   rocket_loader
   security_level
   server_side_exclude
@@ -60,13 +60,13 @@ var PageRuleActions = map[string]string{
 	"cache_level":         "Cache Level",              // Value of type string
 	"disable_apps":        "Disable Apps",             // Value of type interface{}
 	"disable_performance": "Disable Performance",      // Value of type interface{}
+	"disable_railgun":     "Disable Railgun",          // Value of type string
 	"disable_security":    "Disable Security",         // Value of type interface{}
 	"edge_cache_ttl":      "Edge Cache TTL",           // Value of type int
 	"email_obfuscation":   "Email Obfuscation",        // Value of type string
 	"forwarding_url":      "Forwarding URL",           // Value of type map[string]interface
 	"ip_geolocation":      "IP Geolocation Header",    // Value of type string
 	"mirage":              "Mirage",                   // Value of type string
-	"railgun":             "Railgun",                  // Value of type string
 	"rocket_loader":       "Rocker Loader",            // Value of type string
 	"security_level":      "Security Level",           // Value of type string
 	"server_side_exclude": "Server Side Excludes",     // Value of type string


### PR DESCRIPTION
The `railgun` page rule setting has been renamed to `disable_railgun` in the API.