### PR TITLE
Run golint in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,14 @@ matrix:
   allow_failures:
     - go: tip
 
+install:
+  - if [[ $TRAVIS_GO_VERSION == 1.6* ]]; then go get github.com/golang/lint/golint; fi
+
 script:
   - go get -t -v $(go list ./... | grep -v '/vendor/')
-  - diff -u <(echo -n) <(gofmt -d .)
-  - go vet $(go list ./... | grep -v '/vendor/')
+  - if [[ $TRAVIS_GO_VERSION == 1.6* ]]; then diff -u <(echo -n) <(gofmt -d .); fi
+  - if [[ $TRAVIS_GO_VERSION == 1.6* ]]; then go vet $(go list ./... | grep -v '/vendor/'); fi
+  - if [[ $TRAVIS_GO_VERSION == 1.6* ]]; then for package in $(go list ./... | grep -v '/vendor/'); do golint -set_exit_status $package; done; fi
   - go test -v -race $(go list ./... | grep -v '/vendor/')
 
 notifications:

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -432,7 +432,7 @@ type PurgeCacheResponse struct {
 	Response
 }
 
-// IPs contains a list of IPv4 and IPv6 CIDRs
+// IPRanges contains lists of IPv4 and IPv6 CIDRs
 type IPRanges struct {
 	IPv4CIDRs []string `json:"ipv4_cidrs"`
 	IPv6CIDRs []string `json:"ipv6_cidrs"`


### PR DESCRIPTION
When I try to run `golint` with the syntax used in the other tests it seems to fail:
```
$ golint -set_exit_status $(go list ./... | grep -v '/vendor/')
open github.com/cloudflare/cloudflare-go: no such file or directory
open github.com/cloudflare/cloudflare-go/cmd/flarectl: no such file or directory
```
Using a bit of shell scripting seems to make it happier.