### PR TITLE
[bugfix] Re-add BaseURL to New()

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -32,6 +32,7 @@ func New(key, email string, opts ...Option) (*API, error) {
 	api := &API{
 		APIKey:   key,
 		APIEmail: email,
+		BaseURL:  apiURL,
 		headers:  make(http.Header),
 	}
 


### PR DESCRIPTION
Looks like this got accidentally removed as part of a rebase.