### PR TITLE
Switch to a flat-square style for badges in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # cloudflare-go
-[![GoDoc](https://godoc.org/github.com/cloudflare/cloudflare-go?status.svg)](https://godoc.org/github.com/cloudflare/cloudflare-go) [![Build Status](https://travis-ci.org/cloudflare/cloudflare-go.svg?branch=master)](https://travis-ci.org/cloudflare/cloudflare-go) [![Go Report Card](https://goreportcard.com/badge/github.com/cloudflare/cloudflare-go)](https://goreportcard.com/report/github.com/cloudflare/cloudflare-go)
+
+[![GoDoc](https://img.shields.io/badge/godoc-reference-5673AF.svg?style=flat-square)](https://godoc.org/github.com/cloudflare/cloudflare-go)
+[![Build Status](https://img.shields.io/travis/cloudflare/cloudflare-go/master.svg?style=flat-square)](https://travis-ci.org/cloudflare/cloudflare-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/cloudflare/cloudflare-go?style=flat-square)](https://goreportcard.com/report/github.com/cloudflare/cloudflare-go)
 
 > **Note**: This library is under active development as we expand it to cover our (expanding!) API.
 Consider the public API of this package a little unstable as we work towards a v1.0.


### PR DESCRIPTION
@terinjokes As discussed in #71, although I just placed them on their own separate lines, and let Markdown join the lines together. I think this is a slightly neater solution than having the references one place and the URLs another.