### PR TITLE
flarectl: Move api invocation to checkEnv()

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -53,12 +53,21 @@ func makeTable(zones []table, cols ...string) {
 }
 
 func checkEnv() error {
+	if api == nil {
+		var err error
+		api, err = cloudflare.New(os.Getenv("CF_API_KEY"), os.Getenv("CF_API_EMAIL"))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	if api.APIKey == "" {
 		return errors.New("API key not defined")
 	}
 	if api.APIEmail == "" {
 		return errors.New("API email not defined")
 	}
+
 	return nil
 }
 
@@ -455,12 +464,6 @@ func railgun(*cli.Context) {
 }
 
 func main() {
-	var err error
-	api, err = cloudflare.New(os.Getenv("CF_API_KEY"), os.Getenv("CF_API_EMAIL"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	app := cli.NewApp()
 	app.Name = "flarectl"
 	app.Usage = "CloudFlare CLI"


### PR DESCRIPTION
Since 586e5a5 `cloudflare.New()` will error if the API email and key are
not defined. Since flarectl was instantiating the API object at the
start, this meant that flarectl would not operate at all without having
the environment variables defined.

This moves the API object instantiation to `checkEnv()` so that, e.g.
`ips` and `--help` will still work. All other functions already call
`checkEnv()`.

Refs #73