### PR TITLE
[ref] Refactor method params to use "api".

### DIFF
--- a/keyless.go
+++ b/keyless.go
@@ -4,33 +4,33 @@ package cloudflare
 // API reference:
 // 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-create-a-keyless-ssl-configuration
 // 	POST /zones/:zone_identifier/keyless_certificates
-func (c *API) CreateKeyless() {
+func (api *API) CreateKeyless() {
 }
 
 // ListKeyless lists Keyless SSL configurations for a zone.
 // API reference:
 // 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-list-keyless-ssls
 // 	GET /zones/:zone_identifier/keyless_certificates
-func (c *API) ListKeyless() {
+func (api *API) ListKeyless() {
 }
 
 // Keyless provides the configuration for a given Keyless SSL identifier.
 // API reference:
 // 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-keyless-ssl-details
 // 	GET /zones/:zone_identifier/keyless_certificates/:identifier
-func (c *API) Keyless() {
+func (api *API) Keyless() {
 }
 
 // UpdateKeyless updates an existing Keyless SSL configuration.
 // API reference:
 // 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-update-keyless-configuration
 // 	PATCH /zones/:zone_identifier/keyless_certificates/:identifier
-func (c *API) UpdateKeyless() {
+func (api *API) UpdateKeyless() {
 }
 
 // DeleteKeyless deletes an existing Keyless SSL configuration.
 // API reference:
 // 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-delete-keyless-configuration
 // 	DELETE /zones/:zone_identifier/keyless_certificates/:identifier
-func (c *API) DeleteKeyless() {
+func (api *API) DeleteKeyless() {
 }

--- a/railgun.go
+++ b/railgun.go
@@ -4,7 +4,7 @@ package cloudflare
 // API reference:
 // 	https://api.cloudflare.com/#railgun-create-railgun
 // 	POST /railguns
-func (c *API) CreateRailgun() {
+func (api *API) CreateRailgun() {
 }
 
 // API reference:
@@ -29,19 +29,19 @@ func (c *API) CreateRailgun() {
 // API reference:
 // 	https://api.cloudflare.com/#railguns-for-a-zone-get-available-railguns
 // 	GET /zones/:zone_identifier/railguns
-func (c *API) Railguns() {
+func (api *API) Railguns() {
 }
 
 // Railgun returns the configuration for a given Railgun.
 // API reference:
 // 	https://api.cloudflare.com/#railguns-for-a-zone-get-railgun-details
 // 	GET /zones/:zone_identifier/railguns/:identifier
-func (c *API) Railgun() {
+func (api *API) Railgun() {
 }
 
 // ZoneRailgun connects (true) or disconnects (false) a Railgun for a given zone.
 // API reference:
 // 	https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
 // 	PATCH /zones/:zone_identifier/railguns/:identifier
-func (c *API) ZoneRailgun(connected bool) {
+func (api *API) ZoneRailgun(connected bool) {
 }

--- a/ssl.go
+++ b/ssl.go
@@ -4,28 +4,28 @@ package cloudflare
 // API reference:
 // 	https://api.cloudflare.com/#custom-ssl-for-a-zone-create-ssl-configuration
 // 	POST /zones/:zone_identifier/custom_certificates
-func (c *API) CreateSSL() {
+func (api *API) CreateSSL() {
 }
 
 // ListSSL lists the custom certificates for the given zone.
 // API reference:
 // 	https://api.cloudflare.com/#custom-ssl-for-a-zone-list-ssl-configurations
 // 	GET /zones/:zone_identifier/custom_certificates
-func (c *API) ListSSL() {
+func (api *API) ListSSL() {
 }
 
 // SSLDetails returns the configuration details for a custom SSL certificate.
 // API reference:
 // 	https://api.cloudflare.com/#custom-ssl-for-a-zone-ssl-configuration-details
 // 	GET /zones/:zone_identifier/custom_certificates/:identifier
-func (c *API) SSLDetails() {
+func (api *API) SSLDetails() {
 }
 
 // UpdateSSL updates (replaces) a custom SSL certificate.
 // API reference:
 // 	https://api.cloudflare.com/#custom-ssl-for-a-zone-update-ssl-configuration
 // 	PATCH /zones/:zone_identifier/custom_certificates/:identifier
-func (c *API) UpdateSSL() {
+func (api *API) UpdateSSL() {
 }
 
 // ReprioSSL allows you to change the priority (which is served for a given
@@ -33,12 +33,12 @@ func (c *API) UpdateSSL() {
 // API reference:
 // 	https://api.cloudflare.com/#custom-ssl-for-a-zone-re-prioritize-ssl-certificates
 // 	PUT /zones/:zone_identifier/custom_certificates/prioritize
-func (c *API) ReprioSSL() {
+func (api *API) ReprioSSL() {
 }
 
 // DeleteSSL deletes a custom SSL certificate from the given zone.
 // API reference:
 // 	https://api.cloudflare.com/#custom-ssl-for-a-zone-delete-an-ssl-certificate
 // 	DELETE /zones/:zone_identifier/custom_certificates/:identifier
-func (c *API) DeleteSSL() {
+func (api *API) DeleteSSL() {
 }


### PR DESCRIPTION
Replaced `c *API` with `api *API` to match convention.