### PR TITLE
Handle API backend failures with a better error message (#83)

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -98,6 +98,9 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 		return nil, errors.Errorf("HTTP status %d: invalid credentials", resp.StatusCode)
 	case http.StatusForbidden:
 		return nil, errors.Errorf("HTTP status %d: insufficient permissions", resp.StatusCode)
+	case http.StatusServiceUnavailable, http.StatusBadGateway, http.StatusGatewayTimeout,
+		522, 523, 524:
+		return nil, errors.Errorf("HTTP status %d: service failure", resp.StatusCode)
 	default:
 		var s string
 		if body != nil {


### PR DESCRIPTION
Everyone has bad days, CloudFlare is not immune to that, however
currently when CloudFlare's own API has a bad day, currently a
very verbose error message is returned that can cause very
large log lines ( #83 ) .

To address this we catch HTTP 522,523,524, and 504 with a
"Service Failure" message and do not include the responce
body back with it, since there is no need to return it
as it will most likely not be useful to anyone.