### PR TITLE
[WIP] Add and fix some API methods to manage SSL, zones, and page rules

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"time"
 
@@ -72,6 +73,7 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 	var reqBody io.Reader
 	if params != nil {
 		json, err := json.Marshal(params)
+		log.Printf("[DEBUG] Request is %s", string(json))
 		if err != nil {
 			return nil, errors.Wrap(err, "error marshalling params to JSON")
 		}
@@ -108,6 +110,7 @@ func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, err
 		}
 		return nil, errors.Errorf("HTTP status %d: content %q", resp.StatusCode, s)
 	}
+	log.Printf("[DEBUG] Response is: %s", string(body))
 
 	return body, nil
 }

--- a/ssl.go
+++ b/ssl.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/pkg/errors"
 )
@@ -16,9 +15,9 @@ type ZoneCustomSSL struct {
 	Status        string     `json:"status"`
 	BundleMethod  string     `json:"bundle_method"`
 	ZoneID        string     `json:"zone_id"`
-	UploadedOn    time.Time  `json:"uploaded_on"`
-	ModifiedOn    time.Time  `json:"modified_on"`
-	ExpiresOn     time.Time  `json:"expires_on"`
+	UploadedOn    string     `json:"uploaded_on"`
+	ModifiedOn    string     `json:"modified_on"`
+	ExpiresOn     string     `json:"expires_on"`
 	Priority      int        `json:"priority"`
 	KeylessServer KeylessSSL `json:"keyless_server"`
 }

--- a/zone.go
+++ b/zone.go
@@ -109,6 +109,11 @@ type ZoneSettingResponse struct {
 	Result []ZoneSetting `json:"result"`
 }
 
+// zoneSettingRequest represents a request to edit Zone settings
+type zoneSettingRequest struct {
+	Items []ZoneSetting `json:"items"`
+}
+
 // ZoneAnalyticsData contains totals and timeseries analytics data for a zone.
 type ZoneAnalyticsData struct {
 	Totals     ZoneAnalytics   `json:"totals"`
@@ -497,6 +502,34 @@ func (api *API) ZoneAnalyticsByColocation(zoneID string, options ZoneAnalyticsOp
 
 // Zone Settings
 // https://api.cloudflare.com/#zone-settings-for-a-zone-get-all-zone-settings
+func (api *API) GetZoneSettings(zoneID string) ([]ZoneSetting, error) {
+	uri := "/zones/" + zoneID + "/settings"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZoneSettingResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
 // e.g.
 // https://api.cloudflare.com/#zone-settings-for-a-zone-get-always-online-setting
 // https://api.cloudflare.com/#zone-settings-for-a-zone-change-always-online-setting
+func (api *API) EditZoneSettings(zoneID string, settings []ZoneSetting) ([]ZoneSetting, error) {
+	uri := "/zones/" + zoneID + "/settings"
+	s := zoneSettingRequest{Items: settings}
+	res, err := api.makeRequest("PATCH", uri, s)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZoneSettingResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}


### PR DESCRIPTION
This includes some changes that I had to make while working on implementing additional CF resources for Terraform and still needs tests.
