### PR TITLE
Tidy Structs

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -165,10 +165,3 @@ type ResultInfo struct {
 	Count   int `json:"count"`
 	Total   int `json:"total_count"`
 }
-
-// Owner describes the resource owner.
-type Owner struct {
-	ID        string `json:"id"`
-	Email     string `json:"email"`
-	OwnerType string `json:"owner_type"`
-}

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -198,37 +198,6 @@ type Owner struct {
 	OwnerType string `json:"owner_type"`
 }
 
-// DNSRecord represents a DNS record in a zone.
-type DNSRecord struct {
-	ID         string      `json:"id,omitempty"`
-	Type       string      `json:"type,omitempty"`
-	Name       string      `json:"name,omitempty"`
-	Content    string      `json:"content,omitempty"`
-	Proxiable  bool        `json:"proxiable,omitempty"`
-	Proxied    bool        `json:"proxied,omitempty"`
-	TTL        int         `json:"ttl,omitempty"`
-	Locked     bool        `json:"locked,omitempty"`
-	ZoneID     string      `json:"zone_id,omitempty"`
-	ZoneName   string      `json:"zone_name,omitempty"`
-	CreatedOn  time.Time   `json:"created_on,omitempty"`
-	ModifiedOn time.Time   `json:"modified_on,omitempty"`
-	Data       interface{} `json:"data,omitempty"` // data returned by: SRV, LOC
-	Meta       interface{} `json:"meta,omitempty"`
-	Priority   int         `json:"priority,omitempty"`
-}
-
-// DNSRecordResponse represents the response from the DNS endpoint.
-type DNSRecordResponse struct {
-	Response
-	Result DNSRecord `json:"result"`
-}
-
-// DNSListResponse represents the response from the list DNS records endpoint.
-type DNSListResponse struct {
-	Response
-	Result []DNSRecord `json:"result"`
-}
-
 // KeylessSSL represents Keyless SSL configuration.
 type KeylessSSL struct {
 	ID          string    `json:"id"`

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -316,15 +316,3 @@ type PurgeCacheRequest struct {
 type PurgeCacheResponse struct {
 	Response
 }
-
-// IPRanges contains lists of IPv4 and IPv6 CIDRs
-type IPRanges struct {
-	IPv4CIDRs []string `json:"ipv4_cidrs"`
-	IPv6CIDRs []string `json:"ipv6_cidrs"`
-}
-
-// IPsResponse is the API response containing a list of IPs
-type IPsResponse struct {
-	Response
-	Result IPRanges `json:"result"`
-}

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -167,30 +167,6 @@ type ResultInfo struct {
 	Total   int `json:"total_count"`
 }
 
-// User describes a user account.
-type User struct {
-	ID            string         `json:"id"`
-	Email         string         `json:"email"`
-	FirstName     string         `json:"first_name"`
-	LastName      string         `json:"last_name"`
-	Username      string         `json:"username"`
-	Telephone     string         `json:"telephone"`
-	Country       string         `json:"country"`
-	Zipcode       string         `json:"zipcode"`
-	CreatedOn     time.Time      `json:"created_on"`
-	ModifiedOn    time.Time      `json:"modified_on"`
-	APIKey        string         `json:"api_key"`
-	TwoFA         bool           `json:"two_factor_authentication_enabled"`
-	Betas         []string       `json:"betas"`
-	Organizations []Organization `json:"organizations"`
-}
-
-// UserResponse wraps a response containing User accounts.
-type UserResponse struct {
-	Response
-	Result User `json:"result"`
-}
-
 // Owner describes the resource owner.
 type Owner struct {
 	ID        string `json:"id"`

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -174,25 +174,6 @@ type Owner struct {
 	OwnerType string `json:"owner_type"`
 }
 
-// KeylessSSL represents Keyless SSL configuration.
-type KeylessSSL struct {
-	ID          string    `json:"id"`
-	Name        string    `json:"name"`
-	Host        string    `json:"host"`
-	Port        int       `json:"port"`
-	Status      string    `json:"success"`
-	Enabled     bool      `json:"enabled"`
-	Permissions []string  `json:"permissions"`
-	CreatedOn   time.Time `json:"created_on"`
-	ModifiedOn  time.Time `json:"modifed_on"`
-}
-
-// KeylessSSLResponse represents the response from the Keyless SSL endpoint.
-type KeylessSSLResponse struct {
-	Response
-	Result []KeylessSSL `json:"result"`
-}
-
 // CustomPage represents a custom page configuration.
 type CustomPage struct {
 	CreatedOn      string    `json:"created_on"`

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -265,46 +265,6 @@ type CustomPageResponse struct {
 	Result []CustomPage `json:"result"`
 }
 
-// WAFPackage represents a WAF package configuration.
-type WAFPackage struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	Description   string `json:"description"`
-	ZoneID        string `json:"zone_id"`
-	DetectionMode string `json:"detection_mode"`
-	Sensitivity   string `json:"sensitivity"`
-	ActionMode    string `json:"action_mode"`
-}
-
-// WAFPackagesResponse represents the response from the WAF packages endpoint.
-type WAFPackagesResponse struct {
-	Response
-	Result     []WAFPackage `json:"result"`
-	ResultInfo ResultInfo   `json:"result_info"`
-}
-
-// WAFRule represents a WAF rule.
-type WAFRule struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
-	Priority    string `json:"priority"`
-	PackageID   string `json:"package_id"`
-	Group       struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	} `json:"group"`
-	Mode         string   `json:"mode"`
-	DefaultMode  string   `json:"default_mode"`
-	AllowedModes []string `json:"allowed_modes"`
-}
-
-// WAFRulesResponse represents the response from the WAF rule endpoint.
-type WAFRulesResponse struct {
-	Response
-	Result     []WAFRule  `json:"result"`
-	ResultInfo ResultInfo `json:"result_info"`
-}
-
 // PurgeCacheRequest represents the request format made to the purge endpoint.
 type PurgeCacheRequest struct {
 	Everything bool     `json:"purge_everything,omitempty"`

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/pkg/errors"
 )
@@ -172,23 +171,6 @@ type Owner struct {
 	ID        string `json:"id"`
 	Email     string `json:"email"`
 	OwnerType string `json:"owner_type"`
-}
-
-// CustomPage represents a custom page configuration.
-type CustomPage struct {
-	CreatedOn      string    `json:"created_on"`
-	ModifiedOn     time.Time `json:"modified_on"`
-	URL            string    `json:"url"`
-	State          string    `json:"state"`
-	RequiredTokens []string  `json:"required_tokens"`
-	PreviewTarget  string    `json:"preview_target"`
-	Description    string    `json:"description"`
-}
-
-// CustomPageResponse represents the response from the custom pages endpoint.
-type CustomPageResponse struct {
-	Response
-	Result []CustomPage `json:"result"`
 }
 
 // PurgeCacheRequest represents the request format made to the purge endpoint.

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -172,15 +172,3 @@ type Owner struct {
 	Email     string `json:"email"`
 	OwnerType string `json:"owner_type"`
 }
-
-// PurgeCacheRequest represents the request format made to the purge endpoint.
-type PurgeCacheRequest struct {
-	Everything bool     `json:"purge_everything,omitempty"`
-	Files      []string `json:"files,omitempty"`
-	Tags       []string `json:"tags,omitempty"`
-}
-
-// PurgeCacheResponse represents the response from the purge endpoint.
-type PurgeCacheResponse struct {
-	Response
-}

--- a/cpage.go
+++ b/cpage.go
@@ -1,5 +1,24 @@
 package cloudflare
 
+import "time"
+
+// CustomPage represents a custom page configuration.
+type CustomPage struct {
+	CreatedOn      string    `json:"created_on"`
+	ModifiedOn     time.Time `json:"modified_on"`
+	URL            string    `json:"url"`
+	State          string    `json:"state"`
+	RequiredTokens []string  `json:"required_tokens"`
+	PreviewTarget  string    `json:"preview_target"`
+	Description    string    `json:"description"`
+}
+
+// CustomPageResponse represents the response from the custom pages endpoint.
+type CustomPageResponse struct {
+	Response
+	Result []CustomPage `json:"result"`
+}
+
 // https://api.cloudflare.com/#custom-pages-for-a-zone-available-custom-pages
 // GET /zones/:zone_identifier/custom_pages
 

--- a/dns.go
+++ b/dns.go
@@ -3,9 +3,41 @@ package cloudflare
 import (
 	"encoding/json"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 )
+
+// DNSRecord represents a DNS record in a zone.
+type DNSRecord struct {
+	ID         string      `json:"id,omitempty"`
+	Type       string      `json:"type,omitempty"`
+	Name       string      `json:"name,omitempty"`
+	Content    string      `json:"content,omitempty"`
+	Proxiable  bool        `json:"proxiable,omitempty"`
+	Proxied    bool        `json:"proxied,omitempty"`
+	TTL        int         `json:"ttl,omitempty"`
+	Locked     bool        `json:"locked,omitempty"`
+	ZoneID     string      `json:"zone_id,omitempty"`
+	ZoneName   string      `json:"zone_name,omitempty"`
+	CreatedOn  time.Time   `json:"created_on,omitempty"`
+	ModifiedOn time.Time   `json:"modified_on,omitempty"`
+	Data       interface{} `json:"data,omitempty"` // data returned by: SRV, LOC
+	Meta       interface{} `json:"meta,omitempty"`
+	Priority   int         `json:"priority,omitempty"`
+}
+
+// DNSRecordResponse represents the response from the DNS endpoint.
+type DNSRecordResponse struct {
+	Response
+	Result DNSRecord `json:"result"`
+}
+
+// DNSListResponse represents the response from the list DNS records endpoint.
+type DNSListResponse struct {
+	Response
+	Result []DNSRecord `json:"result"`
+}
 
 // CreateDNSRecord creates a DNS record for the zone identifier.
 // API reference:

--- a/ips.go
+++ b/ips.go
@@ -8,6 +8,18 @@ import (
 	"github.com/pkg/errors"
 )
 
+// IPRanges contains lists of IPv4 and IPv6 CIDRs
+type IPRanges struct {
+	IPv4CIDRs []string `json:"ipv4_cidrs"`
+	IPv6CIDRs []string `json:"ipv6_cidrs"`
+}
+
+// IPsResponse is the API response containing a list of IPs
+type IPsResponse struct {
+	Response
+	Result IPRanges `json:"result"`
+}
+
 /*
 IPs gets a list of CloudFlare's IP ranges
 

--- a/keyless.go
+++ b/keyless.go
@@ -1,5 +1,26 @@
 package cloudflare
 
+import "time"
+
+// KeylessSSL represents Keyless SSL configuration.
+type KeylessSSL struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Host        string    `json:"host"`
+	Port        int       `json:"port"`
+	Status      string    `json:"success"`
+	Enabled     bool      `json:"enabled"`
+	Permissions []string  `json:"permissions"`
+	CreatedOn   time.Time `json:"created_on"`
+	ModifiedOn  time.Time `json:"modifed_on"`
+}
+
+// KeylessSSLResponse represents the response from the Keyless SSL endpoint.
+type KeylessSSLResponse struct {
+	Response
+	Result []KeylessSSL `json:"result"`
+}
+
 // CreateKeyless creates a new Keyless SSL configuration for the zone.
 // API reference:
 // 	https://api.cloudflare.com/#keyless-ssl-for-a-zone-create-a-keyless-ssl-configuration

--- a/user.go
+++ b/user.go
@@ -2,9 +2,34 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/pkg/errors"
 )
+
+// User describes a user account.
+type User struct {
+	ID            string         `json:"id"`
+	Email         string         `json:"email"`
+	FirstName     string         `json:"first_name"`
+	LastName      string         `json:"last_name"`
+	Username      string         `json:"username"`
+	Telephone     string         `json:"telephone"`
+	Country       string         `json:"country"`
+	Zipcode       string         `json:"zipcode"`
+	CreatedOn     time.Time      `json:"created_on"`
+	ModifiedOn    time.Time      `json:"modified_on"`
+	APIKey        string         `json:"api_key"`
+	TwoFA         bool           `json:"two_factor_authentication_enabled"`
+	Betas         []string       `json:"betas"`
+	Organizations []Organization `json:"organizations"`
+}
+
+// UserResponse wraps a response containing User accounts.
+type UserResponse struct {
+	Response
+	Result User `json:"result"`
+}
 
 // UserDetails provides information about the logged-in user.
 // API reference:

--- a/waf.go
+++ b/waf.go
@@ -6,6 +6,46 @@ import (
 	"github.com/pkg/errors"
 )
 
+// WAFPackage represents a WAF package configuration.
+type WAFPackage struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	ZoneID        string `json:"zone_id"`
+	DetectionMode string `json:"detection_mode"`
+	Sensitivity   string `json:"sensitivity"`
+	ActionMode    string `json:"action_mode"`
+}
+
+// WAFPackagesResponse represents the response from the WAF packages endpoint.
+type WAFPackagesResponse struct {
+	Response
+	Result     []WAFPackage `json:"result"`
+	ResultInfo ResultInfo   `json:"result_info"`
+}
+
+// WAFRule represents a WAF rule.
+type WAFRule struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Priority    string `json:"priority"`
+	PackageID   string `json:"package_id"`
+	Group       struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"group"`
+	Mode         string   `json:"mode"`
+	DefaultMode  string   `json:"default_mode"`
+	AllowedModes []string `json:"allowed_modes"`
+}
+
+// WAFRulesResponse represents the response from the WAF rule endpoint.
+type WAFRulesResponse struct {
+	Response
+	Result     []WAFRule  `json:"result"`
+	ResultInfo ResultInfo `json:"result_info"`
+}
+
 // ListWAFPackages returns a slice of the WAF packages for the given zone.
 func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
 	var p WAFPackagesResponse

--- a/zone.go
+++ b/zone.go
@@ -9,6 +9,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Owner describes the resource owner.
+type Owner struct {
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	OwnerType string `json:"owner_type"`
+}
+
 // Zone describes a CloudFlare zone.
 type Zone struct {
 	ID                string    `json:"id"`

--- a/zone.go
+++ b/zone.go
@@ -182,6 +182,18 @@ type ZoneAnalyticsOptions struct {
 	Continuous *bool
 }
 
+// PurgeCacheRequest represents the request format made to the purge endpoint.
+type PurgeCacheRequest struct {
+	Everything bool     `json:"purge_everything,omitempty"`
+	Files      []string `json:"files,omitempty"`
+	Tags       []string `json:"tags,omitempty"`
+}
+
+// PurgeCacheResponse represents the response from the purge endpoint.
+type PurgeCacheResponse struct {
+	Response
+}
+
 // newZone describes a new zone.
 type newZone struct {
 	Name      string `json:"name"`


### PR DESCRIPTION
This tidies all of the struct definitions into their respective files per #49.

I was debating whether to squash the commits but I think having the individual commits makes more sense. Happy to squash if others aren't that bothered.