### PR TITLE
DNSRecords: Return all records

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -160,8 +160,9 @@ type Response struct {
 
 // ResultInfo contains metadata about the Response.
 type ResultInfo struct {
-	Page    int `json:"page"`
-	PerPage int `json:"per_page"`
-	Count   int `json:"count"`
-	Total   int `json:"total_count"`
+	Page       int `json:"page"`
+	PerPage    int `json:"per_page"`
+	TotalPages int `json:"total_pages"`
+	Count      int `json:"count"`
+	Total      int `json:"total_count"`
 }


### PR DESCRIPTION
Until pagination is implemented, the current implementation of
DNSRecords is lacklustre as it only returns a limited number of records
(20 by default).

This change updates DNSRecords to always return all records to the
caller, allowing it to use the data as it seems fit. It fetches the
maximum number of records per-page as allowed by the API to minimise the
API calls needed.