### PR TITLE
[wip] Virtual DNS - stubbed out types/funcs.

### DIFF
--- a/virtualdns/virtualdns.go
+++ b/virtualdns/virtualdns.go
@@ -1,0 +1,62 @@
+// Package virtualdns supports managing Cloudflare's Virtual DNS service
+// (https://www.cloudflare.com/dns/virtual-dns/).
+package virtualdns
+
+import cloudflare "github.com/cloudflare/cloudflare-go"
+
+type Client struct {
+	client *cloudflare.API
+	orgID  string
+}
+
+func NewClient(client *cloudflare.API) (*Client, error) {
+
+	return nil, nil
+}
+
+// GetClusters gets a list of the currently configured Virtual DNS clusters.
+// API reference:
+//   https://api.cloudflare.com/#...
+//   GET /...
+func GetClusters() ([]Cluster, error) {
+
+	return []Cluster{}, nil
+}
+
+// GetClusterByID gets a Virtual DNS cluster by its ID.
+// API reference:
+//   https://api.cloudflare.com/#...
+//   GET /...
+func GetClusterByID(id string) (Cluster, error) {
+
+	return Cluster{}, nil
+}
+
+// CreateCluster creates a Virtual DNS cluster against the provided backend IPs.
+// API reference:
+//   https://api.cloudflare.com/#...
+//   POST /...
+func CreateCluster(cluster Cluster) (Cluster, error) {
+
+	return Cluster{}, nil
+}
+
+// ModifyCluster modifies an existing Virtual DNS cluster.
+// API reference:
+//   https://api.cloudflare.com/#...
+//   PATCH /...
+func ModifyCluster(cluster Cluster) (Cluster, error) {
+
+	return Cluster{}, nil
+}
+
+// DeleteCluster deletes an existing Virtual DNS cluster. Note that this will
+// relinquish any Anycast IP addresses assigned to the cluster, and thus drop
+// all queries to those addresses.
+// API reference:
+//   https://api.cloudflare.com/#...
+//   DELETE /...
+func DeleteCluster(cluster Cluster) (Cluster, error) {
+
+	return Cluster{}, nil
+}

--- a/virtualdns/virtualdns.go
+++ b/virtualdns/virtualdns.go
@@ -2,7 +2,12 @@
 // (https://www.cloudflare.com/dns/virtual-dns/).
 package virtualdns
 
-import cloudflare "github.com/cloudflare/cloudflare-go"
+import (
+	"encoding/json"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/pkg/errors"
+)
 
 type Client struct {
 	client *cloudflare.API
@@ -14,11 +19,15 @@ func NewClient(client *cloudflare.API) (*Client, error) {
 	return nil, nil
 }
 
+func (*Client) SetOrg(organizationID string) error {
+
+}
+
 // GetClusters gets a list of the currently configured Virtual DNS clusters.
 // API reference:
 //   https://api.cloudflare.com/#...
 //   GET /...
-func GetClusters() ([]Cluster, error) {
+func (c *Client) GetClusters() ([]Cluster, error) {
 
 	return []Cluster{}, nil
 }
@@ -27,7 +36,7 @@ func GetClusters() ([]Cluster, error) {
 // API reference:
 //   https://api.cloudflare.com/#...
 //   GET /...
-func GetClusterByID(id string) (Cluster, error) {
+func (c *Client) GetClusterByID(id string) (Cluster, error) {
 
 	return Cluster{}, nil
 }
@@ -36,16 +45,30 @@ func GetClusterByID(id string) (Cluster, error) {
 // API reference:
 //   https://api.cloudflare.com/#...
 //   POST /...
-func CreateCluster(cluster Cluster) (Cluster, error) {
+func (c *Client) CreateCluster(cluster Cluster) (Cluster, error) {
+	// TODO(matt): provide an makePath(user) helper that constructs an
+	// /organization/:org_id/... or /user/... path as appropriate.
+	// 'user' and 'org' are enums that make it clearer than passing a boolean.
+	// TODO(matt): Expose makeRequest -or- move it to cloudflare-go/internal/ - ?
+	res, err := api.makeRequest("POST", makePath(c.orgID), cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
 
-	return Cluster{}, nil
+	response := &VirtualDNSResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
 }
 
 // ModifyCluster modifies an existing Virtual DNS cluster.
 // API reference:
 //   https://api.cloudflare.com/#...
 //   PATCH /...
-func ModifyCluster(cluster Cluster) (Cluster, error) {
+func (c *Client) ModifyCluster(cluster Cluster) (Cluster, error) {
 
 	return Cluster{}, nil
 }
@@ -56,7 +79,7 @@ func ModifyCluster(cluster Cluster) (Cluster, error) {
 // API reference:
 //   https://api.cloudflare.com/#...
 //   DELETE /...
-func DeleteCluster(cluster Cluster) (Cluster, error) {
+func (c *Client) DeleteCluster(cluster Cluster) (Cluster, error) {
 
 	return Cluster{}, nil
 }

--- a/virtualdns/virtualdns_types.go
+++ b/virtualdns/virtualdns_types.go
@@ -1,0 +1,32 @@
+package virtualdns
+
+import (
+	"time"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+)
+
+// Cluster represents a Virtual DNS cluster.
+type Cluster struct {
+	DeprecateAnyRequests bool      `json:"deprecate_any_requests,omitempty"`
+	ID                   string    `json:"id,omitempty"`
+	MaximumCacheTTL      int       `json:"maximum_cache_ttl,omitempty"`
+	MinimumCacheTTL      int       `json:"minimum_cache_ttl,omitempty"`
+	ModifiedOn           time.Time `json:"modified_on,omitempty"`
+	Name                 string    `json:"name,omitempty"`
+	OriginIPs            []string  `json:"origin_ips,omitempty"`
+	Ratelimit            int       `json:"ratelimit,omitempty"`
+	VirtualDNSIPs        []string  `json:"virtual_dns_ips,omitempty"`
+}
+
+type VirtualDNSResponse struct {
+	Result Cluster `json:"result"`
+	cloudflare.Response
+	cloudflare.ResultInfo `json:"result_info"`
+}
+
+type VirtualDNSListResponse struct {
+	Result []Cluster `json:"result"`
+	cloudflare.Response
+	cloudflare.ResultInfo `json:"result_info"`
+}


### PR DESCRIPTION
TODO:

- [ ] Remove the existing VirtualDNS methods in the base package
- [ ] Finish implementing all method in the `virtualdns` package
- [ ] Write tests
- [ ] godoc each method.
- [ ] Ensure we can paginate a GET appropriately (and fetch all pages automatically)
- [ ] Support multi-user organizations. e.g. create a `makePath(format)` helper that creates a /user or /organization path as appropriate.
- [ ] Tag a new version (e.g. v0.8.0) to mark breaking change.
