### PR TITLE
application/json should be a default request content type

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -144,6 +144,10 @@ func (api *API) request(method, uri string, reqBody io.Reader) (*http.Response, 
 		req.Header.Set("X-Auth-User-Service-Key", api.APIUserServiceKey)
 	}
 
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
 	resp, err := api.httpClient.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request failed")

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -62,7 +62,18 @@ func TestClient_Headers(t *testing.T) {
 	teardown()
 
 	// it should set X-Auth-User-Service-Key and omit X-Auth-Email and X-Auth-Key when client.authType is AuthUserService
-	// TODO implement the test
+	setup()
+	client.SetAuthType(AuthUserService)
+	client.APIUserServiceKey = "userservicekey"
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
+		assert.Empty(t, r.Header.Get("X-Auth-Email"))
+		assert.Empty(t, r.Header.Get("X-Auth-Key"))
+		assert.Equal(t, "userservicekey", r.Header.Get("X-Auth-User-Service-Key"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+	})
+	client.UserDetails()
+	teardown()
 }
 
 func TestClient_Auth(t *testing.T) {

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -20,18 +20,49 @@ var (
 	server *httptest.Server
 )
 
-func setup() {
+func setup(opts ...Option) {
 	// test server
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
 	// Cloudflare client configured to use test server
-	client, _ = New("deadbeef", "cloudflare@example.org")
+	client, _ = New("deadbeef", "cloudflare@example.org", opts...)
 	client.BaseURL = server.URL
 }
 
 func teardown() {
 	server.Close()
+}
+
+func TestClient_Headers(t *testing.T) {
+	// it should set default headers
+	setup()
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
+		assert.Equal(t, "cloudflare@example.org", r.Header.Get("X-Auth-Email"))
+		assert.Equal(t, "deadbeef", r.Header.Get("X-Auth-Key"))
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+	})
+	client.UserDetails()
+	teardown()
+
+	// it should override appropriate default headers when custom headers given
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/xhtml+xml")
+	headers.Add("X-Random", "a random header")
+	setup(Headers(headers))
+	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
+		assert.Equal(t, "cloudflare@example.org", r.Header.Get("X-Auth-Email"))
+		assert.Equal(t, "deadbeef", r.Header.Get("X-Auth-Key"))
+		assert.Equal(t, "application/xhtml+xml", r.Header.Get("Content-Type"))
+		assert.Equal(t, "a random header", r.Header.Get("X-Random"))
+	})
+	client.UserDetails()
+	teardown()
+
+	// it should set X-Auth-User-Service-Key and omit X-Auth-Email and X-Auth-Key when client.authType is AuthUserService
+	// TODO implement the test
 }
 
 func TestClient_Auth(t *testing.T) {


### PR DESCRIPTION
Turns out the library does not set `Content-Type` in request header. I was getting the following error for my `POST` request(`GET`s work as expected):
```
elvinefendi@Elvins-Pro flarectl (master)$ ./flarectl ch c --zone saastest1.com --hostname shop.elvinefendi.com
error from makeRequest: HTTP status 400: content "{\n  \"result\": {\n    \"ssl\": null\n  },\n  \"success\": false,\n  \"errors\": [\n    {\n      \"code\": 1001,\n      \"message\": \"error: unable to decode json request body. error='mime: no media type'\"\n    }\n  ]\n}\n"
```

The PR makes sure the `Content-Type` is set to `application/json` if it's empty - this fixes above issue.

According to the API docs it talks JSON only, why don't we always set `Content-Type` to `application/json`?