### PR TITLE
Change max per_page to 1000

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -94,7 +94,7 @@ func (api *API) CreateCustomHostname(zoneID string, ch CustomHostname) (*CustomH
 // API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames
 func (api *API) CustomHostnames(zoneID string, page int, filter CustomHostname) ([]CustomHostname, ResultInfo, error) {
 	v := url.Values{}
-	v.Set("per_page", "50")
+	v.Set("per_page", "1000")
 	v.Set("page", strconv.Itoa(page))
 	if filter.Hostname != "" {
 		v.Set("hostname", filter.Hostname)

--- a/dns.go
+++ b/dns.go
@@ -69,8 +69,8 @@ func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) (*DNSRecordResponse
 func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	// Construct a query string
 	v := url.Values{}
-	// Request as many records as possible per page - API max is 50
-	v.Set("per_page", "50")
+	// Request as many records as possible per page - API max is 1000
+	v.Set("per_page", "1000")
 	if rr.Name != "" {
 		v.Set("name", rr.Name)
 	}


### PR DESCRIPTION
The documentation claims that the maximum number of records that can be requested in one result page is 50, but it appears to actually be 1000:

```
$ curl -H ... https://api.cloudflare.com/client/v4/user/billing/history?per_page=1000 | jq .
{
  "result": [],
  "result_info": {
    "page": 1,
    "per_page": 1000,
    "total_pages": 0,
    "count": 0,
    "total_count": 0
  },
  "success": true,
  "errors": [],
  "messages": []
}
$ curl -H ... https://api.cloudflare.com/client/v4/user/billing/history?per_page=1001 | jq .
{
  "success": false,
  "errors": [
    {
      "code": 6008,
      "message": "Invalid request parameters",
      "error_chain": [
        {
          "code": 11000,
          "message": "per_page variable must be a number between 1 and 1000"
        }
      ]
    }
  ],
  "messages": [],
  "result": null
}
```