### PR TITLE
Make CRUD API + pagination treatment consistent across resources [WIP]

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -66,16 +66,17 @@ func (api *API) SetAuthType(authType int) {
 
 // ZoneIDByName retrieves a zone's ID from the name.
 func (api *API) ZoneIDByName(zoneName string) (string, error) {
-	res, err := api.ListZones(zoneName)
+	//TODO: paginate
+	response, err := api.FilterZones(1, zoneName)
 	if err != nil {
 		return "", errors.Wrap(err, "ListZones command failed")
 	}
-	for _, zone := range res {
-		if zone.Name == zoneName {
-			return zone.ID, nil
-		}
+
+	if len(response.Result) == 0 {
+		return "", errors.New("Zone could not be found")
 	}
-	return "", errors.New("Zone could not be found")
+
+	return response.Result[0].ID, nil
 }
 
 // makeRequest makes a HTTP request and returns the body as a byte slice,

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -59,7 +59,7 @@ func (api *API) DeleteCustomHostname(zoneID string, customHostnameID string) err
 	}
 
 	var response *CustomHostnameResponse
-	err = json.Unmarshal(res, &response)
+	err = json.Unmarshal(res, response)
 	if err != nil {
 		return errors.Wrap(err, errUnmarshalError)
 	}
@@ -78,7 +78,7 @@ func (api *API) CreateCustomHostname(zoneID string, ch CustomHostname) (*CustomH
 	}
 
 	var response *CustomHostnameResponse
-	err = json.Unmarshal(res, &response)
+	err = json.Unmarshal(res, response)
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
 	}

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -76,7 +76,7 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 	}
 }
 
-func TestCustomHostname_CustomHostnames(t *testing.T) {
+func TestCustomHostname_ListCustomHostnames(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -111,7 +111,7 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 }`)
 	})
 
-	customHostnames, _, err := client.CustomHostnames("foo", 1, CustomHostname{})
+	response, err := client.ListCustomHostnames("foo", 1)
 
 	want := []CustomHostname{
 		{
@@ -129,7 +129,7 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 	}
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, want, customHostnames)
+		assert.Equal(t, want, response.Result)
 	}
 }
 

--- a/dns.go
+++ b/dns.go
@@ -53,7 +53,7 @@ func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) (*DNSRecordResponse
 	}
 
 	var recordResp *DNSRecordResponse
-	err = json.Unmarshal(res, &recordResp)
+	err = json.Unmarshal(res, recordResp)
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
 	}

--- a/dns_example_test.go
+++ b/dns_example_test.go
@@ -19,7 +19,7 @@ func ExampleAPI_DNSRecords_all() {
 	}
 
 	// Fetch all records for a zone
-	recs, err := api.DNSRecords(zoneID, cloudflare.DNSRecord{})
+	recs, err := api.ListDNSRecords(zoneID, 1)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func ExampleAPI_DNSRecords_filterByContent() {
 
 	// Fetch only records whose content is 127.0.0.1
 	localhost := cloudflare.DNSRecord{Content: "127.0.0.1"}
-	recs, err := api.DNSRecords(zoneID, localhost)
+	recs, err := api.FilterDNSRecords(zoneID, 1, localhost)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func ExampleAPI_DNSRecords_filterByName() {
 	// Fetch records of any type with name "foo.example.com"
 	// The name must be fully-qualified
 	foo := cloudflare.DNSRecord{Name: "foo.example.com"}
-	recs, err := api.DNSRecords(zoneID, foo)
+	recs, err := api.FilterDNSRecords(zoneID, 1, foo)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func ExampleAPI_DNSRecords_filterByType() {
 
 	// Fetch only AAAA type records
 	aaaa := cloudflare.DNSRecord{Type: "AAAA"}
-	recs, err := api.DNSRecords(zoneID, aaaa)
+	recs, err := api.FilterDNSRecords(zoneID, 1, aaaa)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -21,7 +21,7 @@ func Example() {
 	}
 
 	// Fetch all DNS records for example.org
-	records, err := api.DNSRecords(zoneID, cloudflare.DNSRecord{})
+	records, err := api.ListDNSRecords(zoneID, 1)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -42,7 +42,7 @@ func TestOrganizations_ListOrganizations(t *testing.T) {
 }`)
 	})
 
-	user, paginator, err := client.ListOrganizations()
+	response, err := client.ListOrganizations(1)
 
 	want := []Organization{{
 		ID:          "01a7362d577a6c3019a474fd6f485823",
@@ -53,7 +53,7 @@ func TestOrganizations_ListOrganizations(t *testing.T) {
 	}}
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, user, want)
+		assert.Equal(t, response.Result, want)
 	}
 
 	wantPagination := ResultInfo{
@@ -62,7 +62,7 @@ func TestOrganizations_ListOrganizations(t *testing.T) {
 		Count:   1,
 		Total:   2000,
 	}
-	assert.Equal(t, paginator, wantPagination)
+	assert.Equal(t, response.ResultInfo, wantPagination)
 }
 
 func TestOrganizations_OrganizationDetails(t *testing.T) {

--- a/origin_ca.go
+++ b/origin_ca.go
@@ -65,7 +65,7 @@ func (api *API) CreateOriginCertificate(certificate OriginCACertificate) (*Origi
 
 	var originResponse *originCACertificateResponse
 
-	err = json.Unmarshal(res, &originResponse)
+	err = json.Unmarshal(res, originResponse)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
@@ -97,7 +97,7 @@ func (api *API) OriginCertificates(options OriginCACertificateListOptions) ([]Or
 
 	var originResponse *originCACertificateResponseList
 
-	err = json.Unmarshal(res, &originResponse)
+	err = json.Unmarshal(res, originResponse)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
@@ -125,7 +125,7 @@ func (api *API) OriginCertificate(certificateID string) (*OriginCACertificate, e
 
 	var originResponse *originCACertificateResponse
 
-	err = json.Unmarshal(res, &originResponse)
+	err = json.Unmarshal(res, originResponse)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
@@ -153,7 +153,7 @@ func (api *API) RevokeOriginCertificate(certificateID string) (*OriginCACertific
 
 	var originResponse *originCACertificateResponseRevoke
 
-	err = json.Unmarshal(res, &originResponse)
+	err = json.Unmarshal(res, originResponse)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)

--- a/origin_ca_test.go
+++ b/origin_ca_test.go
@@ -54,7 +54,7 @@ func TestOriginCA_CreateOriginCertificate(t *testing.T) {
 	}
 }
 
-func TestOriginCA_OriginCertificates(t *testing.T) {
+func TestOriginCA_FilterOriginCertificates(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -103,9 +103,10 @@ func TestOriginCA_OriginCertificates(t *testing.T) {
 		CSR:             "-----BEGIN CERTIFICATE REQUEST-----MIICvDCCAaQCAQAwdzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFV0YWgxDzANBgNVBAcMBkxpbmRvbjEWMBQGA1UECgwNRGlnaUNlcnQgSW5jLjERMA8GA1UECwwIRGlnaUNlcnQxHTAbBgNVBAMMFGV4YW1wbGUuZGlnaWNlcnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8+To7d+2kPWeBv/orU3LVbJwDrSQbeKamCmowp5bqDxIwV20zqRb7APUOKYoVEFFOEQs6T6gImnIolhbiH6m4zgZ/CPvWBOkZc+c1Po2EmvBz+AD5sBdT5kzGQA6NbWyZGldxRthNLOs1efOhdnWFuhI162qmcflgpiIWDuwq4C9f+YkeJhNn9dF5+owm8cOQmDrV8NNdiTqin8q3qYAHHJRW28glJUCZkTZwIaSR6crBQ8TbYNE0dc+Caa3DOIkz1EOsHWzTx+n0zKfqcbgXi4DJx+C1bjptYPRBPZL8DAeWuA8ebudVT44yEp82G96/Ggcf7F33xMxe0yc+Xa6owIDAQABoAAwDQYJKoZIhvcNAQEFBQADggEBAB0kcrFccSmFDmxox0Ne01UIqSsDqHgL+XmHTXJwre6DhJSZwbvEtOK0G3+dr4Fs11WuUNt5qcLsx5a8uk4G6AKHMzuhLsJ7XZjgmQXGECpYQ4mC3yT3ZoCGpIXbw+iP3lmEEXgaQL0Tx5LFl/okKbKYwIqNiyKWOMj7ZR/wxWg/ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn29XI1PpVUNCPQGn9p/eX6Qo7vpDaPybRtA2R7XLKjQaF9oXWeCUqy1hvJac9QFO297Ob1alpHPoZ7mWiEuJwjBPii6a9M9G30nUo39lBi1w=-----END CERTIFICATE REQUEST-----",
 	}
 
-	certs, err := client.OriginCertificates(OriginCACertificateListOptions{ZoneID: testZoneID})
+	response, err := client.FilterOriginCACertificates(1, OriginCACertificateFilter{ZoneID: testZoneID})
 
 	if assert.NoError(t, err) {
+		certs := response.Result
 		assert.IsType(t, []OriginCACertificate{}, certs, "Expected type []OriginCACertificate and got %v", certs)
 		assert.Equal(t, certs[0], testCertificate)
 	}

--- a/pagerules.go
+++ b/pagerules.go
@@ -104,18 +104,20 @@ type PageRulesResponse struct {
 // CreatePageRule creates a new Page Rule for a zone.
 //
 // API reference: https://api.cloudflare.com/#page-rules-for-a-zone-create-a-page-rule
-func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
+func (api *API) CreatePageRule(zoneID string, rule PageRule) (*PageRuleDetailResponse, error) {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("POST", uri, rule)
 	if err != nil {
-		return errors.Wrap(err, errMakeRequestError)
+		return nil, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PageRuleDetailResponse
-	err = json.Unmarshal(res, &r)
+
+	var pageRuleResp *PageRuleDetailResponse
+	err = json.Unmarshal(res, &pageRuleResp)
 	if err != nil {
-		return errors.Wrap(err, errUnmarshalError)
+		return nil, errors.Wrap(err, errUnmarshalError)
 	}
-	return nil
+
+	return pageRuleResp, nil
 }
 
 // ListPageRules returns all Page Rules for a zone.

--- a/pagerules.go
+++ b/pagerules.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -93,8 +95,8 @@ type PageRuleDetailResponse struct {
 	Result   PageRule `json:"result"`
 }
 
-// PageRulesResponse is the API response, containing an array of PageRules.
-type PageRulesResponse struct {
+// PageRuleListResponse is the API response, containing an array of PageRules.
+type PageRuleListResponse struct {
 	Success  bool       `json:"success"`
 	Errors   []string   `json:"errors"`
 	Messages []string   `json:"messages"`
@@ -123,18 +125,28 @@ func (api *API) CreatePageRule(zoneID string, rule PageRule) (*PageRuleDetailRes
 // ListPageRules returns all Page Rules for a zone.
 //
 // API reference: https://api.cloudflare.com/#page-rules-for-a-zone-list-page-rules
-func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
-	uri := "/zones/" + zoneID + "/pagerules"
+func (api *API) ListPageRules(zoneID string, page int) (*PageRuleListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/pagerules" + query
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []PageRule{}, errors.Wrap(err, errMakeRequestError)
+		return nil, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PageRulesResponse
-	err = json.Unmarshal(res, &r)
-	if err != nil {
-		return []PageRule{}, errors.Wrap(err, errUnmarshalError)
+
+	response := &PageRuleListResponse{}
+	if err = json.Unmarshal(res, &response); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
 	}
-	return r.Result, nil
+
+	return response, nil
 }
 
 // PageRule fetches detail about one Page Rule for a zone.

--- a/pagerules.go
+++ b/pagerules.go
@@ -112,7 +112,7 @@ func (api *API) CreatePageRule(zoneID string, rule PageRule) (*PageRuleDetailRes
 	}
 
 	var pageRuleResp *PageRuleDetailResponse
-	err = json.Unmarshal(res, &pageRuleResp)
+	err = json.Unmarshal(res, pageRuleResp)
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
 	}

--- a/railgun_test.go
+++ b/railgun_test.go
@@ -68,7 +68,7 @@ func TestCreateRailgun(t *testing.T) {
 	}
 }
 
-func TestListRailguns(t *testing.T) {
+func TestFilterRailguns(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -108,24 +108,26 @@ func TestListRailguns(t *testing.T) {
 	activatedOn, _ := time.Parse(time.RFC3339, "2014-01-02T02:20:00Z")
 	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00Z")
-	want := []Railgun{
-		{
-			ID:             "e928d310693a83094309acf9ead50448",
-			Name:           "My Railgun",
-			Status:         "active",
-			Enabled:        true,
-			ZonesConnected: 2,
-			Build:          "b1234",
-			Version:        "2.1",
-			Revision:       "123",
-			ActivationKey:  "e4edc00281cb56ebac22c81be9bac8f3",
-			ActivatedOn:    activatedOn,
-			CreatedOn:      createdOn,
-			ModifiedOn:     modifiedOn,
+	want := RailgunListResponse{
+		Result: []Railgun{
+			{
+				ID:             "e928d310693a83094309acf9ead50448",
+				Name:           "My Railgun",
+				Status:         "active",
+				Enabled:        true,
+				ZonesConnected: 2,
+				Build:          "b1234",
+				Version:        "2.1",
+				Revision:       "123",
+				ActivationKey:  "e4edc00281cb56ebac22c81be9bac8f3",
+				ActivatedOn:    activatedOn,
+				CreatedOn:      createdOn,
+				ModifiedOn:     modifiedOn,
+			},
 		},
 	}
 
-	actual, err := client.ListRailguns(RailgunListOptions{Direction: "desc"})
+	actual, err := client.FilterRailguns(1, RailgunFilter{Direction: "desc"})
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -238,12 +240,12 @@ func TestRailgunZones(t *testing.T) {
 		},
 	}
 
-	actual, err := client.RailgunZones("e928d310693a83094309acf9ead50448")
+	response, err := client.ListRailgunZones("e928d310693a83094309acf9ead50448", 1)
 	if assert.NoError(t, err) {
-		assert.Equal(t, want, actual)
+		assert.Equal(t, want, response.Result)
 	}
 
-	_, err = client.RailgunZones("bar")
+	_, err = client.ListRailgunZones("bar", 1)
 	assert.Error(t, err)
 }
 

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -79,7 +79,7 @@ func TestCreateSSL(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestListSSL(t *testing.T) {
+func TestListZoneCustomSSLs(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -139,12 +139,14 @@ func TestListSSL(t *testing.T) {
 		Priority:     1,
 	}
 
-	actual, err := client.ListSSL("023e105f4ecef8ad9ca31a8372d0c353")
+	response, err := client.ListZoneCustomSSLs("023e105f4ecef8ad9ca31a8372d0c353", 1)
+	actual := response.Result
+
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 
-	_, err = client.ListSSL("bar")
+	_, err = client.ListZoneCustomSSLs("bar", 1)
 	assert.Error(t, err)
 }
 

--- a/virtualdns.go
+++ b/virtualdns.go
@@ -40,7 +40,7 @@ func (api *API) CreateVirtualDNS(v *VirtualDNS) (*VirtualDNS, error) {
 	}
 
 	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
+	err = json.Unmarshal(res, response)
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
 	}
@@ -59,7 +59,7 @@ func (api *API) VirtualDNS(virtualDNSID string) (*VirtualDNS, error) {
 	}
 
 	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
+	err = json.Unmarshal(res, response)
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
 	}
@@ -77,7 +77,7 @@ func (api *API) ListVirtualDNS() ([]*VirtualDNS, error) {
 	}
 
 	response := &VirtualDNSListResponse{}
-	err = json.Unmarshal(res, &response)
+	err = json.Unmarshal(res, response)
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
 	}
@@ -96,7 +96,7 @@ func (api *API) UpdateVirtualDNS(virtualDNSID string, vv VirtualDNS) error {
 	}
 
 	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
+	err = json.Unmarshal(res, response)
 	if err != nil {
 		return errors.Wrap(err, errUnmarshalError)
 	}
@@ -116,7 +116,7 @@ func (api *API) DeleteVirtualDNS(virtualDNSID string) error {
 	}
 
 	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
+	err = json.Unmarshal(res, response)
 	if err != nil {
 		return errors.Wrap(err, errUnmarshalError)
 	}

--- a/waf.go
+++ b/waf.go
@@ -2,6 +2,8 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"net/url"
+	"strconv"
 
 	"github.com/pkg/errors"
 )
@@ -17,8 +19,8 @@ type WAFPackage struct {
 	ActionMode    string `json:"action_mode"`
 }
 
-// WAFPackagesResponse represents the response from the WAF packages endpoint.
-type WAFPackagesResponse struct {
+// WAFPackageListResponse represents the response from the WAF packages endpoint.
+type WAFPackageListResponse struct {
 	Response
 	Result     []WAFPackage `json:"result"`
 	ResultInfo ResultInfo   `json:"result_info"`
@@ -47,28 +49,28 @@ type WAFRulesResponse struct {
 }
 
 // ListWAFPackages returns a slice of the WAF packages for the given zone.
-func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
-	var p WAFPackagesResponse
-	var packages []WAFPackage
-	var res []byte
-	var err error
-	uri := "/zones/" + zoneID + "/firewall/waf/packages"
-	res, err = api.makeRequest("GET", uri, nil)
+func (api *API) ListWAFPackages(zoneID string, page int) (*WAFPackageListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/firewall/waf/packages" + query
+	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []WAFPackage{}, errors.Wrap(err, errMakeRequestError)
+		return nil, errors.Wrap(err, errMakeRequestError)
 	}
-	err = json.Unmarshal(res, &p)
-	if err != nil {
-		return []WAFPackage{}, errors.Wrap(err, errUnmarshalError)
+
+	response := &WAFPackageListResponse{}
+	if err := json.Unmarshal(res, &response); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
 	}
-	if !p.Success {
-		// TODO: Provide an actual error message instead of always returning nil
-		return []WAFPackage{}, err
-	}
-	for pi := range p.Result {
-		packages = append(packages, p.Result[pi])
-	}
-	return packages, nil
+
+	return response, nil
 }
 
 // ListWAFRules returns a slice of the WAF rules for the given WAF package.

--- a/zone_example_test.go
+++ b/zone_example_test.go
@@ -14,7 +14,7 @@ func ExampleAPI_ListZones_all() {
 	}
 
 	// Fetch a slice of all zones available to this account.
-	zones, err := api.ListZones()
+	zones, err := api.ListZones(1)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func ExampleAPI_ListZones_filter() {
 	}
 
 	// Fetch a slice of zones example.org and example.net.
-	zones, err := api.ListZones("example.org", "example.net")
+	zones, err := api.ListZones(1, "example.org", "example.net")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR is a (breaking) change to the `CreatePageRule` signature,
making it consistent with other `Create~` functions:
```go
func (api *API) Create~(zoneID string, ~) (*~Response, error)
```

Aside from motivations of consistency, without this API the user is
unable to discover the server-created ID for the page rule without
enumerating `ListPageRule` before and after creation - and assuming they
are the only user at that instant.

C.f. discussion in #108; ping @elithrar

Example use: (Should I add a test? I can't seem to make existing `*_test.go` files fail, so I'm not clear if they're running when I do `go test`, or how to add one and be sure it's running.)
```go
package main

import (
    "fmt"
    "os"
    cloudflare "github.com/cloudflare/cloudflare-go"
)

func main() {
    domain := os.Getenv("CLOUDFLARE_DOMAIN")
    api, err := cloudflare.New(os.Getenv("CLOUDFLARE_TOKEN"), os.Getenv("CLOUDFLARE_EMAIL"))
    if err != nil {
        fmt.Print(err)
        return
    }

    rule := cloudflare.PageRule{
        Targets: []cloudflare.PageRuleTarget{
            cloudflare.PageRuleTarget{
                Target: "url",
                Constraint: struct {
                     Operator string `json:"operator"`
                     Value    string `json:"value"`
                }{
                     Operator: "matches",
                     Value:    fmt.Sprintf("test.%s", domain),
                },
            },
        },
        Actions: []cloudflare.PageRuleAction{
            cloudflare.PageRuleAction{
                ID:    "always_online",
                Value: "on",
            },
        },
        Priority: 1,
        Status:   "active",
    }

    zoneID, err := api.ZoneIDByName(domain)
    if err != nil {
        fmt.Printf("Error finding zone %q: %s", domain, err)
        return
    }

    r, err := api.CreatePageRule(zoneID, rule)
    if err != nil {
        fmt.Printf("Failed to create page rule: %s", err)
        return nil
    }

    fmt.Printf("Result: %q", r.Result)
}
```