### PR TITLE
[feat] Zone Lockdowns & User-Agent Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The current feature list includes:
 - [x] User Administration (partial)
 - [x] Virtual DNS Management
 - [x] Custom hostnames
+- [x] Zone Lockdown and User-Agent Block rules
 - [ ] Organization Administration
 - [ ] [Railgun](https://www.cloudflare.com/railgun/) administration
 - [ ] [Keyless SSL](https://blog.cloudflare.com/keyless-ssl-the-nitty-gritty-technical-details/)

--- a/lockdown.go
+++ b/lockdown.go
@@ -1,0 +1,150 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// ZoneLockdown represents a Zone Lockdown rule. A rule only permits access to
+// the provided URL pattern(s) from the given IP address(es) or subnet(s).
+type ZoneLockdown struct {
+	ID             string               `json:"id"`
+	Description    string               `json:"description"`
+	URLs           []string             `json:"urls"`
+	Configurations []ZoneLockdownConfig `json:"configurations"`
+	Paused         bool                 `json:"paused"`
+}
+
+// ZoneLockdownConfig represents a Zone Lockdown config, which comprises
+// a Target ("ip" or "ip_range") and a Value (an IP address or IP+mask,
+// respectively.)
+type ZoneLockdownConfig struct {
+	Target string `json:"target"`
+	Value  string `json:"value"`
+}
+
+// ZoneLockdownResponse represents a response from the Zone Lockdown endpoint.
+type ZoneLockdownResponse struct {
+	Result ZoneLockdown `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// ZoneLockdownListResponse represents a response from the List Zone Lockdown
+// endpoint.
+type ZoneLockdownListResponse struct {
+	Result []ZoneLockdown `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// CreateZoneLockdown creates a Zone ZoneLockdown rule for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-create-a-ZoneLockdown-rule
+func (api *API) CreateZoneLockdown(zoneID string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns"
+	res, err := api.makeRequest("POST", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateZoneLockdown updates a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-update-ZoneLockdown-rule
+func (api *API) UpdateZoneLockdown(zoneID string, id string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns"
+	res, err := api.makeRequest("PUT", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// DeleteZoneLockdown deletes a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-delete-ZoneLockdown-rule
+func (api *API) DeleteZoneLockdown(zoneID string, id string) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns/" + id
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ZoneLockdown retrieves a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-ZoneLockdown-rule-details
+func (api *API) ZoneLockdown(zoneID string, id string) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns/" + id
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ListZoneLockdowns retrieves a list of Zone ZoneLockdown rules for a given
+// zone ID by page number.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-list-ZoneLockdown-rules
+func (api *API) ListZoneLockdowns(zoneID string, page int) (*ZoneLockdownListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/firewall/lockdowns" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/lockdown_example_test.go
+++ b/lockdown_example_test.go
@@ -1,0 +1,31 @@
+package cloudflare_test
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+)
+
+func ExampleAPI_ListZoneLockdowns_all() {
+	api, err := cloudflare.New("deadbeef", "test@example.org")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	zoneID, err := api.ZoneIDByName("example.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Fetch all Zone Lockdown rules for a zone, by page.
+	rules, err := api.ListZoneLockdowns(zoneID, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, r := range rules.Result {
+		fmt.Printf("%s: %s\n", strings.Join(r.URLs, ", "), r.Configurations)
+	}
+}

--- a/user_agent.go
+++ b/user_agent.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// UserAgentRule represents a User-Agent Block. These rules can be used to
+// challenge, block or whitelist specific User-Agents for a given zone.
+type UserAgentRule struct {
+	ID            string              `json:"id"`
+	Description   string              `json:"description"`
+	Mode          string              `json:"mode"`
+	Configuration UserAgentRuleConfig `json:"configuration"`
+	Paused        bool                `json:"paused"`
+}
+
+// UserAgentRuleConfig represents a Zone Lockdown config, which comprises
+// a Target ("ip" or "ip_range") and a Value (an IP address or IP+mask,
+// respectively.)
+type UserAgentRuleConfig ZoneLockdownConfig
+
+// UserAgentRuleResponse represents a response from the Zone Lockdown endpoint.
+type UserAgentRuleResponse struct {
+	Result UserAgentRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// UserAgentRuleListResponse represents a response from the List Zone Lockdown endpoint.
+type UserAgentRuleListResponse struct {
+	Result []UserAgentRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// CreateUserAgentRule creates a User-Agent Block rule for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-create-a-useragent-rule
+func (api *API) CreateUserAgentRule(zoneID string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
+	switch ld.Mode {
+	case "block", "challenge", "js_challenge", "whitelist":
+		break
+	default:
+		return nil, errors.New(`the User-Agent Block rule mode must be one of "block", "challenge", "js_challenge", "whitelist"`)
+	}
+
+	uri := "/zones/" + zoneID + "/firewall/ua_rules"
+	res, err := api.makeRequest("POST", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateUserAgentRule updates a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-update-useragent-rule
+func (api *API) UpdateUserAgentRule(zoneID string, id string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules"
+	res, err := api.makeRequest("PUT", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// DeleteUserAgentRule deletes a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-delete-useragent-rule
+func (api *API) DeleteUserAgentRule(zoneID string, id string) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UserAgentRule retrieves a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-useragent-rule-details
+func (api *API) UserAgentRule(zoneID string, id string) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ListUserAgentRules retrieves a list of User-Agent Block rules for a given zone ID by page number.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-list-useragent-rules
+func (api *API) ListUserAgentRules(zoneID string, page int) (*UserAgentRuleListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/firewall/ua_rules" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/user_agent_example_test.go
+++ b/user_agent_example_test.go
@@ -1,0 +1,30 @@
+package cloudflare_test
+
+import (
+	"fmt"
+	"log"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+)
+
+func ExampleAPI_ListUserAgentRules_all() {
+	api, err := cloudflare.New("deadbeef", "test@example.org")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	zoneID, err := api.ZoneIDByName("example.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Fetch all Zone Lockdown rules for a zone, by page.
+	rules, err := api.ListUserAgentRules(zoneID, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, r := range rules.Result {
+		fmt.Printf("%s: %s\n", r.Configuration.Target, r.Configuration.Value)
+	}
+}


### PR DESCRIPTION
Adds support for:

* User-Agent Blocking rules - https://api.cloudflare.com/#user-agent-blocking-rules-properties
* Zone Lockdown rules - https://api.cloudflare.com/#zone-lockdown-properties

Future PR will include support in flarectl for these endpoints ([WIP branch here](https://github.com/cloudflare/cloudflare-go/tree/elithrar/flarectl-zone-lockdown)) as well as godoc-style examples for usage.