### PR TITLE
[flarectl] Adds User-Agent blocking to flarectl

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/codegangsta/cli"
@@ -75,9 +76,12 @@ func checkFlags(c *cli.Context, flags ...string) error {
 	for _, flag := range flags {
 		if c.String(flag) == "" {
 			cli.ShowSubcommandHelp(c)
-			return fmt.Errorf("%s not specified", flag)
+			err := errors.Errorf("error: the required flag %q was empty or not provided", flag)
+			fmt.Fprintln(os.Stderr, err)
+			return err
 		}
 	}
+
 	return nil
 }
 
@@ -358,7 +362,105 @@ func main() {
 				},
 			},
 		},
-
+		{
+			Name:    "user-agents",
+			Aliases: []string{"ua"},
+			Usage:   "User-Agent blocking",
+			Subcommands: []cli.Command{
+				{
+					Name:    "list",
+					Aliases: []string{"l"},
+					Action:  userAgentList,
+					Usage:   "List User-Agent blocks for a zone",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+						cli.IntFlag{
+							Name:  "page",
+							Usage: "result page to return",
+						},
+					},
+				},
+				{
+					Name:    "create",
+					Aliases: []string{"c"},
+					Action:  userAgentCreate,
+					Usage:   "Create a User-Agent blocking rule",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+						cli.StringFlag{
+							Name:  "mode",
+							Usage: "the blocking mode: block, challenge, js_challenge, whitelist",
+						},
+						cli.StringFlag{
+							Name:  "value",
+							Usage: "the exact User-Agent to block",
+						},
+						cli.BoolFlag{
+							Name:  "paused",
+							Usage: "whether the rule should be paused (default: false)",
+						},
+						cli.StringFlag{
+							Name:  "description",
+							Usage: "a description for the rule",
+						},
+					},
+				},
+				{
+					Name:    "update",
+					Aliases: []string{"u"},
+					Action:  userAgentUpdate,
+					Usage:   "Update an existing User-Agent block",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+						cli.StringFlag{
+							Name:  "id",
+							Usage: "User-Agent blocking rule ID",
+						},
+						cli.StringFlag{
+							Name:  "mode",
+							Usage: "the blocking mode: block, challenge, js_challenge, whitelist",
+						},
+						cli.StringFlag{
+							Name:  "value",
+							Usage: "the exact User-Agent to block",
+						},
+						cli.BoolFlag{
+							Name:  "paused",
+							Usage: "whether the rule should be paused (default: false)",
+						},
+						cli.StringFlag{
+							Name:  "description",
+							Usage: "a description for the rule",
+						},
+					},
+				},
+				{
+					Name:    "delete",
+					Aliases: []string{"d"},
+					Action:  userAgentDelete,
+					Usage:   "Delete a User-Agent block",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+						cli.StringFlag{
+							Name:  "id",
+							Usage: "User-Agent blocking rule ID",
+						},
+					},
+				},
+			},
+		},
 		{
 			Name:    "pagerules",
 			Aliases: []string{"p"},

--- a/cmd/flarectl/user_agent.go
+++ b/cmd/flarectl/user_agent.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/codegangsta/cli"
+)
+
+func formatUserAgentRule(rule cloudflare.UserAgentRule) table {
+	return table{
+		"ID":          rule.ID,
+		"Description": rule.Description,
+		"Mode":        rule.Mode,
+		"Value":       rule.Configuration.Value,
+		"Paused":      strconv.FormatBool(rule.Paused),
+	}
+}
+
+func userAgentCreate(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	if err := checkFlags(c, "zone", "mode", "value"); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	userAgentRule := cloudflare.UserAgentRule{
+		Description: c.String("description"),
+		Mode:        c.String("mode"),
+		Paused:      c.Bool("paused"),
+		Configuration: cloudflare.UserAgentRuleConfig{
+			Target: "ua",
+			Value:  c.String("value"),
+		},
+	}
+
+	resp, err := api.CreateUserAgentRule(zoneID, userAgentRule)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating User-Agent block rule: ", err)
+		return
+	}
+
+	output := []table{
+		formatUserAgentRule(resp.Result),
+	}
+
+	makeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+}
+
+func userAgentUpdate(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if err := checkFlags(c, "zone", "id", "mode", "value"); err != nil {
+		return
+	}
+
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	userAgentRule := cloudflare.UserAgentRule{
+		Description: c.String("description"),
+		Mode:        c.String("mode"),
+		Paused:      c.Bool("paused"),
+		Configuration: cloudflare.UserAgentRuleConfig{
+			Target: "ua",
+			Value:  c.String("value"),
+		},
+	}
+
+	resp, err := api.UpdateUserAgentRule(zoneID, c.String("id"), userAgentRule)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error updating User-Agent block rule: ", err)
+		return
+	}
+
+	output := []table{
+		formatUserAgentRule(resp.Result),
+	}
+
+	makeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+}
+
+func userAgentDelete(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if err := checkFlags(c, "zone", "id"); err != nil {
+		return
+	}
+
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	resp, err := api.DeleteUserAgentRule(zoneID, c.String("id"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error deleting User-Agent block rule: ", err)
+		return
+	}
+
+	output := []table{
+		formatUserAgentRule(resp.Result),
+	}
+
+	makeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+}
+
+func userAgentList(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	if err := checkFlags(c, "zone", "page"); err != nil {
+		return
+	}
+
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	resp, err := api.ListUserAgentRules(zoneID, c.Int("page"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error listing User-Agent block rules: ", err)
+		return
+	}
+
+	output := make([]table, 0, len(resp.Result))
+	for _, rule := range resp.Result {
+		output = append(output, formatUserAgentRule(rule))
+	}
+
+	makeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+}

--- a/user_agent.go
+++ b/user_agent.go
@@ -67,7 +67,7 @@ func (api *API) CreateUserAgentRule(zoneID string, ld UserAgentRule) (*UserAgent
 //
 // API reference: https://api.cloudflare.com/#user-agent-blocking-rules-update-useragent-rule
 func (api *API) UpdateUserAgentRule(zoneID string, id string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
-	uri := "/zones/" + zoneID + "/firewall/ua_rules"
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
 	res, err := api.makeRequest("PUT", uri, ld)
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)


### PR DESCRIPTION
Adds the `user-agents` (shortname: `ua`) sub-command for managing User-Agent Blocking rules:

```
$ flarectl user-agents
NAME:
   flarectl user-agents - User-Agent blocking

USAGE:
   flarectl user-agents command [command options] [arguments...]

COMMANDS:
   list, l      List User-Agent blocks for a zone
   create, c    Create a User-Agent blocking rule
   update, u    Update an existing User-Agent block
   delete, d    Delete a User-Agent block
   help, h      Shows a list of commands or help for one command

OPTIONS:
   --help, -h   show help
```

Example:

```sh
ID                               Description                          Mode         Value                                                                                                                 Paused 
-------------------------------- ------------------------------------ ------------ --------------------------------------------------------------------------------------------------------------------- ------ 
62d49d9eacca445b9973f583688b74e7 Block the worst browser in the world block        Wawoo Browser 90210                                                                                                   false  
1ab4054cca55471387e407b35c6cc267 block IE6                            block        Mozilla/6.0 (osh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4       false  
95ccf4e26e714d7c8e55d9a858258061 block IE6                            block        Mozilla/5.0 (osh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4       false  
fdff66612b0a4d73ae72a0f13e7c6693 block IE6                            js_challenge Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/603.2.4 (KHTML, like Gecko) Version/10.1.1 Safari/603.2.4 false  
```