### PR TITLE
Add FollowRedirects and AllowInsecure property to LoadBalancerMonitor

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -28,19 +28,21 @@ type LoadBalancerOrigin struct {
 
 // LoadBalancerMonitor represents a load balancer monitor's properties.
 type LoadBalancerMonitor struct {
-	ID            string              `json:"id,omitempty"`
-	CreatedOn     *time.Time          `json:"created_on,omitempty"`
-	ModifiedOn    *time.Time          `json:"modified_on,omitempty"`
-	Type          string              `json:"type"`
-	Description   string              `json:"description"`
-	Method        string              `json:"method"`
-	Path          string              `json:"path"`
-	Header        map[string][]string `json:"header"`
-	Timeout       int                 `json:"timeout"`
-	Retries       int                 `json:"retries"`
-	Interval      int                 `json:"interval"`
-	ExpectedBody  string              `json:"expected_body"`
-	ExpectedCodes string              `json:"expected_codes"`
+	ID              string              `json:"id,omitempty"`
+	CreatedOn       *time.Time          `json:"created_on,omitempty"`
+	ModifiedOn      *time.Time          `json:"modified_on,omitempty"`
+	Type            string              `json:"type"`
+	Description     string              `json:"description"`
+	Method          string              `json:"method"`
+	Path            string              `json:"path"`
+	Header          map[string][]string `json:"header"`
+	Timeout         int                 `json:"timeout"`
+	Retries         int                 `json:"retries"`
+	Interval        int                 `json:"interval"`
+	ExpectedBody    string              `json:"expected_body"`
+	ExpectedCodes   string              `json:"expected_codes"`
+	FollowRedirects bool                `json:"follow_redirects"`
+	AllowInsecure   bool                `json:"allow_insecure"`
 }
 
 // LoadBalancer represents a load balancer's properties.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -366,7 +366,9 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
               "retries": 0,
               "interval": 90,
               "expected_body": "alive",
-              "expected_codes": "2xx"
+              "expected_codes": "2xx",
+              "follow_redirects": false,
+              "allow_insecure": false
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -393,7 +395,9 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
                 "retries": 0,
                 "interval": 90,
                 "expected_body": "alive",
-                "expected_codes": "2xx"
+                "expected_codes": "2xx",
+                "follow_redirects": false,
+                "allow_insecure": false
             }
         }`)
 	}

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -636,7 +636,9 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "retries": 0,
                 "interval": 90,
                 "expected_body": "kicking",
-                "expected_codes": "200"
+                "expected_codes": "200",
+                "follow_redirects": false,
+                "allow_insecure": false
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -663,7 +665,9 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "retries": 0,
                 "interval": 90,
                 "expected_body": "kicking",
-                "expected_codes": "200"
+                "expected_codes": "200",
+                "follow_redirects": false,
+                "allow_insecure": false
             }
         }`)
 	}


### PR DESCRIPTION
Although the documentation at https://api.cloudflare.com/#organization-load-balancer-monitors-list-monitors doesn't show the `follow_redirects` and `allow_insecure` properties yet I do see them in the response and I can use them when creating _organization load balancer monitors_.