### PR TITLE
Rate limiting (for a zone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The current feature list includes:
 * [x] [Origin CA](https://blog.cloudflare.com/universal-ssl-encryption-all-the-way-to-the-origin-for-free/)
 * [x] [Load Balancing](https://blog.cloudflare.com/introducing-load-balancing-intelligent-failover-with-cloudflare/)
 * [x] Firewall (partial)
+* [x] Rate Limiting
 
 Pull Requests are welcome, but please open an issue (or comment in an existing
 issue) to discuss any non-trivial changes before submitting code.

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -227,3 +227,10 @@ func (api *API) Raw(method, endpoint string, data interface{}) (json.RawMessage,
 	}
 	return r.Result, nil
 }
+
+// PaginationOptions can be passed to a list request to configure paging
+// These values will be defaulted if omitted, and PerPage has min/max limits set by resource
+type PaginationOptions struct {
+	Page    int `json:"page,omitempty"`
+	PerPage int `json:"per_page,omitempty"`
+}

--- a/rate_limiting.go
+++ b/rate_limiting.go
@@ -2,16 +2,17 @@ package cloudflare
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"net/url"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 // RateLimit is a policy than can be applied to limit traffic within a customer domain
 type RateLimit struct {
 	ID          string                  `json:"id,omitempty"`
-	Disabled    bool                    `json:"disabled,omitempty"` // api defaults to false
-	Description string                  `json:"description"`
+	Disabled    bool                    `json:"disabled,omitempty"`
+	Description string                  `json:"description,omitempty"`
 	Match       RateLimitTrafficMatcher `json:"match"`
 	Bypass      []RateLimitKeyValue     `json:"bypass,omitempty"`
 	Threshold   int                     `json:"threshold"`
@@ -21,8 +22,8 @@ type RateLimit struct {
 
 // RateLimitTrafficMatcher contains the rules that will be used to apply a rate limit to traffic
 type RateLimitTrafficMatcher struct {
-	Request  RateLimitRequestMatcher  `json:"request,omitempty"`
-	Response RateLimitResponseMatcher `json:"response,omitempty"`
+	Request  RateLimitRequestMatcher  `json:"request"`
+	Response RateLimitResponseMatcher `json:"response"`
 }
 
 // RateLimitRequestMatcher contains the matching rules pertaining to requests
@@ -35,7 +36,7 @@ type RateLimitRequestMatcher struct {
 // RateLimitResponseMatcher contains the matching rules pertaining to responses
 type RateLimitResponseMatcher struct {
 	Statuses      []int `json:"status,omitempty"`
-	OriginTraffic bool  `json:"origin_traffic,omitempty"`
+	OriginTraffic *bool `json:"origin_traffic,omitempty"` // api defaults to true so we need an explicit empty value
 }
 
 // RateLimitKeyValue is k-v formatted as expected in the rate limit description
@@ -46,9 +47,9 @@ type RateLimitKeyValue struct {
 
 // RateLimitAction is the action that will be taken when the rate limit threshold is reached
 type RateLimitAction struct {
-	Mode     string                  `json:"mode"`
-	Timeout  int                     `json:"timeout"`
-	Response RateLimitActionResponse `json:"response"`
+	Mode     string                   `json:"mode"`
+	Timeout  int                      `json:"timeout"`
+	Response *RateLimitActionResponse `json:"response"`
 }
 
 // RateLimitActionResponse is the response that will be returned when rate limit action is triggered

--- a/rate_limiting.go
+++ b/rate_limiting.go
@@ -1,0 +1,150 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+)
+
+// RateLimit is a policy than can be applied to limit traffic within a customer domain
+type RateLimit struct {
+	ID          string                  `json:"id,omitempty"`
+	Disabled    bool                    `json:"disabled,omitempty"` // api defaults to false
+	Description string                  `json:"description"`
+	Match       RateLimitTrafficMatcher `json:"match"`
+	Bypass      []RateLimitKeyValue     `json:"bypass,omitempty"`
+	Threshold   int                     `json:"threshold"`
+	Period      int                     `json:"period"`
+	Action      RateLimitAction         `json:"action"`
+}
+
+// RateLimitTrafficMatcher contains the rules that will be used to apply a rate limit to traffic
+type RateLimitTrafficMatcher struct {
+	Request  RateLimitRequestMatcher  `json:"request,omitempty"`
+	Response RateLimitResponseMatcher `json:"response,omitempty"`
+}
+
+// RateLimitRequestMatcher contains the matching rules pertaining to requests
+type RateLimitRequestMatcher struct {
+	Methods    []string `json:"methods,omitempty"`
+	Schemes    []string `json:"schemes,omitempty"`
+	URLPattern string   `json:"url,omitempty"`
+}
+
+// RateLimitResponseMatcher contains the matching rules pertaining to responses
+type RateLimitResponseMatcher struct {
+	Statuses      []int `json:"status,omitempty"`
+	OriginTraffic bool  `json:"origin_traffic,omitempty"`
+}
+
+// RateLimitKeyValue is k-v formatted as expected in the rate limit description
+type RateLimitKeyValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// RateLimitAction is the action that will be taken when the rate limit threshold is reached
+type RateLimitAction struct {
+	Mode     string                  `json:"mode"`
+	Timeout  int                     `json:"timeout"`
+	Response RateLimitActionResponse `json:"response"`
+}
+
+// RateLimitActionResponse is the response that will be returned when rate limit action is triggered
+type RateLimitActionResponse struct {
+	ContentType string `json:"content_type"`
+	Body        string `json:"body"`
+}
+
+type rateLimitResponse struct {
+	Response
+	Result RateLimit `json:"result"`
+}
+
+type rateLimitListResponse struct {
+	Response
+	Result     []RateLimit `json:"result"`
+	ResultInfo ResultInfo  `json:"result_info"`
+}
+
+// CreateRateLimit creates a new rate limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-create-a-ratelimit
+func (api *API) CreateRateLimit(zoneID string, limit RateLimit) (RateLimit, error) {
+	uri := "/zones/" + zoneID + "/rate_limits"
+	res, err := api.makeRequest("POST", uri, limit)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return RateLimit{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListRateLimits returns all Rate Limits for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-list-rate-limits
+func (api *API) ListRateLimits(zoneID string) ([]RateLimit, error) {
+	uri := "/zones/" + zoneID + "/rate_limits"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []RateLimit{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitListResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []RateLimit{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// RateLimit fetches detail about one Rate Limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-rate-limit-details
+func (api *API) RateLimit(zoneID, limitID string) (RateLimit, error) {
+	uri := "/zones/" + zoneID + "/rate_limits/" + limitID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// UpdateRateLimit lets you replace a Rate Limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-update-rate-limit
+func (api *API) UpdateRateLimit(zoneID, limitID string, limit RateLimit) (RateLimit, error) {
+	uri := "/zones/" + zoneID + "/rate_limits/" + limitID
+	res, err := api.makeRequest("PUT", uri, limit)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return RateLimit{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteRateLimit deletes a Rate Limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-delete-rate-limit
+func (api *API) DeleteRateLimit(zoneID, limitID string) error {
+	uri := "/zones/" + zoneID + "/rate_limits/" + limitID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}

--- a/rate_limiting_example_test.go
+++ b/rate_limiting_example_test.go
@@ -2,8 +2,9 @@ package cloudflare_test
 
 import (
 	"fmt"
-	cloudflare "github.com/cloudflare/cloudflare-go"
 	"log"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
 )
 
 const (

--- a/rate_limiting_example_test.go
+++ b/rate_limiting_example_test.go
@@ -46,7 +46,7 @@ func ExampleAPI_CreateRateLimit() {
 	fmt.Printf("%+v\n", rateLimit)
 }
 
-func ExampleAPI_ListRateLimitsAll() {
+func ExampleAPI_ListRateLimits() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -57,7 +57,11 @@ func ExampleAPI_ListRateLimitsAll() {
 		log.Fatal(err)
 	}
 
-	rateLimits, err := api.ListRateLimits(zoneID)
+	pageOpts := cloudflare.PaginationOptions{
+		PerPage: 5,
+		Page:    1,
+	}
+	rateLimits, _, err := api.ListRateLimits(zoneID, pageOpts)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/rate_limiting_example_test.go
+++ b/rate_limiting_example_test.go
@@ -1,0 +1,105 @@
+package cloudflare_test
+
+import (
+	"fmt"
+	cloudflare "github.com/cloudflare/cloudflare-go"
+	"log"
+)
+
+const (
+	apiKey = "deadbeef"
+	user   = "test@example.org"
+	domain = "example.com"
+)
+
+var exampleNewRateLimit = cloudflare.RateLimit{
+	Description: "test",
+	Match: cloudflare.RateLimitTrafficMatcher{
+		Request: cloudflare.RateLimitRequestMatcher{
+			URLPattern: "exampledomain.com/test-rate-limit",
+		},
+	},
+	Threshold: 0,
+	Period:    0,
+	Action: cloudflare.RateLimitAction{
+		Mode:    "ban",
+		Timeout: 60,
+	},
+}
+
+func ExampleAPI_CreateRateLimit() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	zoneID, err := api.ZoneIDByName(domain)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rateLimit, err := api.CreateRateLimit(zoneID, exampleNewRateLimit)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", rateLimit)
+}
+
+func ExampleAPI_ListRateLimitsAll() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	zoneID, err := api.ZoneIDByName(domain)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rateLimits, err := api.ListRateLimits(zoneID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", rateLimits)
+	for _, r := range rateLimits {
+		fmt.Printf("%+v\n", r)
+	}
+}
+
+func ExampleAPI_GetRateLimit() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	zoneID, err := api.ZoneIDByName(domain)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rateLimits, err := api.RateLimit(zoneID, "my_rate_limit_id")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", rateLimits)
+}
+
+func ExampleAPI_DeleteRateLimit() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	zoneID, err := api.ZoneIDByName(domain)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = api.DeleteRateLimit(zoneID, "my_rate_limit_id")
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -40,6 +41,7 @@ const (
 `
 )
 
+var expectedOriginTraffic = true
 var expectedRateLimitStruct = RateLimit{
 	ID:          "72dae2fc158942f2adb1dd2a3d4143bc",
 	Disabled:    false,
@@ -51,7 +53,7 @@ var expectedRateLimitStruct = RateLimit{
 			URLPattern: "exampledomain.com/test-rate-limit",
 		},
 		Response: RateLimitResponseMatcher{
-			OriginTraffic: true,
+			OriginTraffic: &expectedOriginTraffic,
 		},
 	},
 	Threshold: 50,
@@ -72,7 +74,7 @@ var expectedRateLimitStructUpdated = RateLimit{
 			URLPattern: "exampledomain.com/test-rate-limit",
 		},
 		Response: RateLimitResponseMatcher{
-			OriginTraffic: true,
+			OriginTraffic: &expectedOriginTraffic,
 		},
 	},
 	Threshold: 50,

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -1,0 +1,279 @@
+package cloudflare
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+const (
+	rateLimitID                = "72dae2fc158942f2adb1dd2a3d4143bc"
+	testZoneID                 = "abcd123"
+	serverRateLimitDescription = `{
+	"id": "72dae2fc158942f2adb1dd2a3d4143bc",
+	"disabled": false,
+	"description": "test",
+	"match": {
+	"request": {
+	  "methods": [
+		"_ALL_"
+	  ],
+	  "schemes": [
+		"_ALL_"
+	  ],
+	  "url": "exampledomain.com/test-rate-limit"
+	},
+	"response": {
+	  "origin_traffic": true
+	}
+	},
+	"login_protect": false,
+	"threshold": 50,
+	"period": 1,
+	"action": {
+		"mode": "ban",
+		"timeout": 60
+	}
+}
+`
+)
+
+var expectedRateLimitStruct = RateLimit{
+	ID:          "72dae2fc158942f2adb1dd2a3d4143bc",
+	Disabled:    false,
+	Description: "test",
+	Match: RateLimitTrafficMatcher{
+		Request: RateLimitRequestMatcher{
+			Methods:    []string{"_ALL_"},
+			Schemes:    []string{"_ALL_"},
+			URLPattern: "exampledomain.com/test-rate-limit",
+		},
+		Response: RateLimitResponseMatcher{
+			OriginTraffic: true,
+		},
+	},
+	Threshold: 50,
+	Period:    1,
+	Action: RateLimitAction{
+		Mode:    "ban",
+		Timeout: 60,
+	},
+}
+var expectedRateLimitStructUpdated = RateLimit{
+	ID:          "72dae2fc158942f2adb1dd2a3d4143bc",
+	Disabled:    false,
+	Description: "test",
+	Match: RateLimitTrafficMatcher{
+		Request: RateLimitRequestMatcher{
+			Methods:    []string{"_ALL_"},
+			Schemes:    []string{"_ALL_"},
+			URLPattern: "exampledomain.com/test-rate-limit",
+		},
+		Response: RateLimitResponseMatcher{
+			OriginTraffic: true,
+		},
+	},
+	Threshold: 50,
+	Period:    1,
+	Action: RateLimitAction{
+		Mode:    "ban",
+		Timeout: 60,
+	},
+}
+
+func TestListRateLimits(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": [
+			%s
+		  ],
+		  "success": true,
+		  "errors": null,
+		  "messages": null,
+		  "result_info": {
+			"page": 1,
+			"per_page": 25,
+			"count": 1,
+			"total_count": 1
+		  }
+		}
+		`, serverRateLimitDescription)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/rate_limits", handler)
+	want := []RateLimit{expectedRateLimitStruct}
+
+	actual, err := client.ListRateLimits(testZoneID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetRateLimit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": %s,
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}
+		`, serverRateLimitDescription)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/rate_limits/"+rateLimitID, handler)
+	want := expectedRateLimitStruct
+
+	actual, err := client.RateLimit(testZoneID, rateLimitID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateRateLimit(t *testing.T) {
+	setup()
+	defer teardown()
+	newRateLimit := RateLimit{
+		Description: "test",
+		Match: RateLimitTrafficMatcher{
+			Request: RateLimitRequestMatcher{
+				URLPattern: "exampledomain.com/test-rate-limit",
+			},
+		},
+		Period:    1,
+		Threshold: 50,
+		Action: RateLimitAction{
+			Mode:    "ban",
+			Timeout: 60,
+		},
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": %s,
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}
+		`, serverRateLimitDescription)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/rate_limits", handler)
+	want := expectedRateLimitStruct
+
+	actual, err := client.CreateRateLimit(testZoneID, newRateLimit)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateRateLimitWithZeroedThreshold(t *testing.T) {
+	setup()
+	defer teardown()
+	newRateLimit := RateLimit{
+		Description: "test",
+		Match: RateLimitTrafficMatcher{
+			Request: RateLimitRequestMatcher{
+				URLPattern: "exampledomain.com/test-rate-limit",
+			},
+		},
+		Period:    0, // 0 is the default values if int fields are not set
+		Threshold: 0,
+		Action: RateLimitAction{
+			Mode:    "ban",
+			Timeout: 60,
+		},
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.WriteHeader(400)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "result": null,
+		  "success": false,
+		  "errors": [{ "message": "ratelimit.api.validation_error:threshold is too low and must be at least 2,sample_rate is too low and must be at least 1 second" } ],
+		  "messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/rate_limits", handler)
+
+	actual, err := client.CreateRateLimit(testZoneID, newRateLimit)
+	assert.Error(t, err)
+	assert.Equal(t, RateLimit{}, actual)
+}
+
+func TestUpdateRateLimit(t *testing.T) {
+	setup()
+	defer teardown()
+	newRateLimit := RateLimit{
+		Description: "test-2",
+		Match: RateLimitTrafficMatcher{
+			Request: RateLimitRequestMatcher{
+				URLPattern: "exampledomain.com/test-rate-limit-2",
+			},
+		},
+		Period:    2,
+		Threshold: 100,
+		Action: RateLimitAction{
+			Mode:    "ban",
+			Timeout: 600,
+		},
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": %s,
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}
+		`, serverRateLimitDescription)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/rate_limits/"+rateLimitID, handler)
+	want := expectedRateLimitStruct
+
+	actual, err := client.UpdateRateLimit(testZoneID, rateLimitID, newRateLimit)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeleteRateLimit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "result": null,
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/rate_limits/"+rateLimitID, handler)
+
+	err := client.DeleteRateLimit(testZoneID, rateLimitID)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Adds support for the rate limiting API. Mostly standard CRUD calls to API with marshalling etc. For listing, I allowed the caller to specify pagination options or call ListAll directly 