### PR TITLE
Added CheckRegions field to LoadBalancerPool

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -18,7 +18,10 @@ type LoadBalancerPool struct {
 	Monitor           string               `json:"monitor,omitempty"`
 	Origins           []LoadBalancerOrigin `json:"origins"`
 	NotificationEmail string               `json:"notification_email,omitempty"`
-	CheckRegions      []string             `json:"check_regions"`
+
+	// CheckRegions defines the geographic region(s) from where to run health-checks from - e.g. "WNAM", "WEU", "SAF", "SAM".
+	// Providing a null/empty value means "all regions", which may not be available to all plan types.
+	CheckRegions []string `json:"check_regions"`
 }
 
 type LoadBalancerOrigin struct {

--- a/load_balancing.go
+++ b/load_balancing.go
@@ -18,6 +18,7 @@ type LoadBalancerPool struct {
 	Monitor           string               `json:"monitor,omitempty"`
 	Origins           []LoadBalancerOrigin `json:"origins"`
 	NotificationEmail string               `json:"notification_email,omitempty"`
+	CheckRegions      []string             `json:"check_regions"`
 }
 
 type LoadBalancerOrigin struct {

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -32,7 +32,10 @@ func TestCreateLoadBalancerPool(t *testing.T) {
                   "enabled": true
                 }
               ],
-              "notification_email": "someone@example.com"
+              "notification_email": "someone@example.com",
+              "check_regions": [
+                "WEU"
+              ]
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -54,7 +57,10 @@ func TestCreateLoadBalancerPool(t *testing.T) {
                   "enabled": true
                 }
               ],
-              "notification_email": "someone@example.com"
+              "notification_email": "someone@example.com",
+              "check_regions": [
+                "WEU"
+              ]
             }
         }`)
 	}
@@ -78,6 +84,9 @@ func TestCreateLoadBalancerPool(t *testing.T) {
 			},
 		},
 		NotificationEmail: "someone@example.com",
+		CheckRegions: []string{
+			"WEU",
+		},
 	}
 	request := LoadBalancerPool{
 		Description: "Primary data center - Provider XYZ",
@@ -92,6 +101,9 @@ func TestCreateLoadBalancerPool(t *testing.T) {
 			},
 		},
 		NotificationEmail: "someone@example.com",
+		CheckRegions: []string{
+			"WEU",
+		},
 	}
 
 	actual, err := client.CreateLoadBalancerPool(request)

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -285,7 +285,10 @@ func TestModifyLoadBalancerPool(t *testing.T) {
                   "enabled": false
                 }
               ],
-              "notification_email": "nobody@example.com"
+              "notification_email": "nobody@example.com",
+              "check_regions": [
+                "WEU"
+              ]
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -306,7 +309,10 @@ func TestModifyLoadBalancerPool(t *testing.T) {
                   "enabled": false
                 }
               ],
-              "notification_email": "nobody@example.com"
+              "notification_email": "nobody@example.com",
+              "check_regions": [
+                "WEU"
+              ]
             }
         }`)
 	}
@@ -329,6 +335,9 @@ func TestModifyLoadBalancerPool(t *testing.T) {
 			},
 		},
 		NotificationEmail: "nobody@example.com",
+		CheckRegions: []string{
+			"WEU",
+		},
 	}
 	request := LoadBalancerPool{
 		ID:          "17b5962d775c646f3f9725cbc7a53df4",
@@ -343,6 +352,9 @@ func TestModifyLoadBalancerPool(t *testing.T) {
 			},
 		},
 		NotificationEmail: "nobody@example.com",
+		CheckRegions: []string{
+			"WEU",
+		},
 	}
 
 	actual, err := client.ModifyLoadBalancerPool(request)


### PR DESCRIPTION
This adds the `CheckRegions` field to `LoadBalancerPool`.
This makes it possible to set the check regions via the API.
Without this modifying a LoadBalancerPool would set the check regions to `null` meaning all regions, resulting in the error `Probing from every data centre is not allowed with this subscription. Please chooseregions to probe from.: validation failed` when using a free account.