### PR TITLE
Api client rate limiting

### DIFF
--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -27,6 +27,9 @@ func setup(opts ...Option) {
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
+	// disable rate limits in testing - prepended so any provided value overrides this
+	opts = append([]Option{RateLimit(100000)}, opts...)
+
 	// Cloudflare client configured to use test server
 	client, _ = New("deadbeef", "cloudflare@example.org", opts...)
 	client.BaseURL = server.URL
@@ -105,7 +108,7 @@ func TestClient_Auth(t *testing.T) {
 
 func TestClient_RateLimiting(t *testing.T) {
 	// trading off accuracy against test time
-	opt := RateLimited(1000)
+	opt := RateLimit(1000)
 	numSamples := 30
 
 	setup(opt)

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"time"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -99,4 +101,69 @@ func TestClient_Auth(t *testing.T) {
 	_, err := IPs()
 
 	assert.NoError(t, err)
+}
+
+func TestClient_RateLimiting(t *testing.T) {
+	// trading off accuracy against test time
+	opt := RateLimited(1000)
+	numSamples := 30
+
+	setup(opt)
+	defer teardown()
+
+	// could test any function, using ListLoadBalancerPools
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+            "success": true,
+            "errors": [],
+            "messages": [],
+            "result": [
+                {
+                    "id": "17b5962d775c646f3f9725cbc7a53df4",
+                    "created_on": "2014-01-01T05:20:00.12345Z",
+                    "modified_on": "2014-02-01T05:20:00.12345Z",
+                    "description": "Primary data center - Provider XYZ",
+                    "name": "primary-dc-1",
+                    "enabled": true,
+                    "monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+                    "origins": [
+                      {
+                        "name": "app-server-1",
+                        "address": "0.0.0.0",
+                        "enabled": true
+                      }
+                    ],
+                    "notification_email": "someone@example.com"
+                }
+            ],
+            "result_info": {
+                "page": 1,
+                "per_page": 20,
+                "count": 1,
+                "total_count": 2000
+            }
+        }`)
+	}
+
+	mux.HandleFunc("/user/load_balancers/pools", handler)
+
+	// bucket starts full so empty it since this test has a small sample size
+	client.ListLoadBalancerPools()
+
+	// start timing requests
+	startAll := time.Now()
+	for i := 0; i < numSamples; i++ {
+		client.ListLoadBalancerPools()
+	}
+	totalTime := time.Since(startAll)
+
+	// rate limit of 1000 rps, we made 30 requests in the time period ( req/time = rate (rps) )
+	// => 30/tmin = 1000 => tmin = 30/1000 = 0.03 sec  is the minimum amount of time the client requests should take
+	// this is a relatively small sample size, seems that rps limit is only enforced in aggregate
+	// so give a 5% margin of error
+	if totalTime < time.Duration(28500)*time.Microsecond {
+		t.Errorf("List calls took less than minimum allowed time (47.5ms): %s\n", time.Since(startAll).String())
+	}
 }

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -26,7 +26,7 @@ func setup(opts ...Option) {
 	server = httptest.NewServer(mux)
 
 	// disable rate limits and retries in testing - prepended so any provided value overrides this
-	opts = append([]Option{RateLimit(100000), UsingRetryPolicy(0, 0, 0)}, opts...)
+	opts = append([]Option{UsingRateLimit(100000), UsingRetryPolicy(0, 0, 0)}, opts...)
 
 	// Cloudflare client configured to use test server
 	client, _ = New("deadbeef", "cloudflare@example.org", opts...)

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -105,7 +105,7 @@ func TestClient_Auth(t *testing.T) {
 }
 
 func TestClient_RetryCanSucceedAfterErrors(t *testing.T) {
-	setup(UsingRetryPolicy(3, 0, 1))
+	setup(UsingRetryPolicy(2, 0, 1))
 	defer teardown()
 
 	requestsReceived := 0
@@ -133,10 +133,6 @@ func TestClient_RetryCanSucceedAfterErrors(t *testing.T) {
 				"messages": [],
 				"result": []
 			}`)
-		} else if requestsReceived == 2 {
-			requestsReceived += 1
-			// TODO clean this up as panics end up in the test output
-			panic("this panic is meant to occur, it simulatesthe api client receiving no response")
 		} else {
 			// return success response
 			fmt.Fprint(w, `{

--- a/options.go
+++ b/options.go
@@ -35,12 +35,13 @@ func UsingOrganization(orgID string) Option {
 	}
 }
 
-// RateLimited applies a non-default rate limit to client API requests
-func RateLimited(rps float64) Option {
+// RateLimit applies a non-default rate limit to client API requests
+func RateLimit(rps float64) Option {
 	return func(api *API) error {
 		// because ratelimiter doesnt do any windowing
 		// setting burst makes it difficult to enforce a fixed rate
 		// so setting it equal to 1 this effectively disables bursting
+		// TODO validate this value in some allowed range
 		api.rateLimiter = rate.NewLimiter(rate.Limit(rps), 1)
 		return nil
 	}

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package cloudflare
 
-import "net/http"
+import (
+	"net/http"
+
+	"golang.org/x/time/rate"
+)
 
 // Option is a functional option for configuring the API client.
 type Option func(*API) error
@@ -27,6 +31,17 @@ func Headers(headers http.Header) Option {
 func UsingOrganization(orgID string) Option {
 	return func(api *API) error {
 		api.organizationID = orgID
+		return nil
+	}
+}
+
+// RateLimited applies a non-default rate limit to client API requests
+func RateLimited(rps float64) Option {
+	return func(api *API) error {
+		// because ratelimiter doesnt do any windowing
+		// setting burst makes it difficult to enforce a fixed rate
+		// so setting it equal to 1 this effectively disables bursting
+		api.rateLimiter = rate.NewLimiter(rate.Limit(rps), 1)
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -3,6 +3,8 @@ package cloudflare
 import (
 	"net/http"
 
+	"time"
+
 	"golang.org/x/time/rate"
 )
 
@@ -43,6 +45,18 @@ func RateLimit(rps float64) Option {
 		// so setting it equal to 1 this effectively disables bursting
 		// TODO validate this value in some allowed range
 		api.rateLimiter = rate.NewLimiter(rate.Limit(rps), 1)
+		return nil
+	}
+}
+
+func UsingRetryPolicy(maxRetries int, minRetryDelaySecs int, maxRetryDelaySecs int) Option {
+	// seconds is very granular for a minimum delay - but this is only in case of failure
+	return func(api *API) error {
+		api.retryPolicy = RetryPolicy{
+			MaxRetries:    maxRetries,
+			MinRetryDelay: time.Duration(minRetryDelaySecs) * time.Second,
+			MaxRetryDelay: time.Duration(maxRetryDelaySecs) * time.Second,
+		}
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -38,17 +38,20 @@ func UsingOrganization(orgID string) Option {
 }
 
 // RateLimit applies a non-default rate limit to client API requests
+// If not specified the default of 4rps will be applied
 func RateLimit(rps float64) Option {
 	return func(api *API) error {
 		// because ratelimiter doesnt do any windowing
 		// setting burst makes it difficult to enforce a fixed rate
 		// so setting it equal to 1 this effectively disables bursting
-		// TODO validate this value in some allowed range
+		// this doesn't check for sensible values, ultimately the api will enforce that the value is ok
 		api.rateLimiter = rate.NewLimiter(rate.Limit(rps), 1)
 		return nil
 	}
 }
 
+// UsingRetry policy applies a non-default number of retrys and min/max retry delays
+// This will be used when the client exponentially backs off after errored requests
 func UsingRetryPolicy(maxRetries int, minRetryDelaySecs int, maxRetryDelaySecs int) Option {
 	// seconds is very granular for a minimum delay - but this is only in case of failure
 	return func(api *API) error {

--- a/options.go
+++ b/options.go
@@ -37,7 +37,7 @@ func UsingOrganization(orgID string) Option {
 	}
 }
 
-// RateLimit applies a non-default rate limit to client API requests
+// UsingRateLimit applies a non-default rate limit to client API requests
 // If not specified the default of 4rps will be applied
 func UsingRateLimit(rps float64) Option {
 	return func(api *API) error {
@@ -50,7 +50,7 @@ func UsingRateLimit(rps float64) Option {
 	}
 }
 
-// UsingRetry policy applies a non-default number of retrys and min/max retry delays
+// UsingRetryPolicy applies a non-default number of retries and min/max retry delays
 // This will be used when the client exponentially backs off after errored requests
 func UsingRetryPolicy(maxRetries int, minRetryDelaySecs int, maxRetryDelaySecs int) Option {
 	// seconds is very granular for a minimum delay - but this is only in case of failure
@@ -60,6 +60,15 @@ func UsingRetryPolicy(maxRetries int, minRetryDelaySecs int, maxRetryDelaySecs i
 			MinRetryDelay: time.Duration(minRetryDelaySecs) * time.Second,
 			MaxRetryDelay: time.Duration(maxRetryDelaySecs) * time.Second,
 		}
+		return nil
+	}
+}
+
+// UsingLogger can be set if you want to get log output from this API instance
+// By default no log output is emitted
+func UsingLogger(logger Logger) Option {
+	return func(api *API) error {
+		api.logger = logger
 		return nil
 	}
 }

--- a/options.go
+++ b/options.go
@@ -39,7 +39,7 @@ func UsingOrganization(orgID string) Option {
 
 // RateLimit applies a non-default rate limit to client API requests
 // If not specified the default of 4rps will be applied
-func RateLimit(rps float64) Option {
+func UsingRateLimit(rps float64) Option {
 	return func(api *API) error {
 		// because ratelimiter doesnt do any windowing
 		// setting burst makes it difficult to enforce a fixed rate


### PR DESCRIPTION
This allows the client to be well behaved w.r.t. api request rate and also to retry in case of errors. I've tried to put in some sensible defaults, hopefully those do make sense given typical usage

- rate limiting for clients based on golang rate.limiter (leaky bucket)
- no bursting, clients can specify a max rps as a float which is applied uniformly
  - at the moment, clients can specify anything (ultimately the api will enforce limits). are there separate limits we should put on this?
  - default: 4 rps
- in case of errors (connection error/5xx/429), the client will retry up to a specified number of times
  - this is also the default approach taken in the hashicorp retry http library, but I am unsure of this safety-wise. Thoughts??
- each time retrying, the client will exponentially backoff (pow 2), starting from a specified minimum time up to a limited specified maximum
  - defaults: 3 retries, min delay 1 second, max delay 30 seconds (config accepts delays as integer seconds)