### PR TITLE
flarectl : Add switches to control output of IP sections

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -22,9 +22,13 @@ func main() {
 			Usage:   "Print Cloudflare IP ranges",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "type",
+					Name:  "ip-type",
 					Usage: "type of IPs ( ipv4 | ipv6 | all )",
 					Value: "all",
+				},
+				cli.BoolFlag{
+					Name:  "ip-only",
+					Usage: "show only addresses",
 				},
 			},
 		},

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -69,6 +69,13 @@ func main() {
 			Aliases: []string{"i"},
 			Action:  ips,
 			Usage:   "Print Cloudflare IP ranges",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "type",
+					Usage: "type of IPs ( ipv4 | ipv6 | all )",
+					Value: "all",
+				},
+			},
 		},
 		{
 			Name:    "user",

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -1,62 +1,13 @@
 package main
 
 import (
-	"fmt"
-	"log"
 	"os"
-
-	"github.com/olekukonko/tablewriter"
-
-	"github.com/pkg/errors"
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/codegangsta/cli"
 )
 
 var api *cloudflare.API
-
-// writeTable outputs tabular data to stdout.
-func writeTable(data [][]string, cols ...string) {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader(cols)
-	table.SetBorder(false)
-	table.AppendBulk(data)
-
-	table.Render()
-}
-
-func checkEnv() error {
-	if api == nil {
-		var err error
-		api, err = cloudflare.New(os.Getenv("CF_API_KEY"), os.Getenv("CF_API_EMAIL"))
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	if api.APIKey == "" {
-		return errors.New("API key not defined")
-	}
-	if api.APIEmail == "" {
-		return errors.New("API email not defined")
-	}
-
-	return nil
-}
-
-// Utility function to check if CLI flags were given.
-func checkFlags(c *cli.Context, flags ...string) error {
-	for _, flag := range flags {
-		if c.String(flag) == "" {
-			cli.ShowSubcommandHelp(c)
-			err := errors.Errorf("error: the required flag %q was empty or not provided", flag)
-			fmt.Fprintln(os.Stderr, err)
-			return err
-		}
-	}
-
-	return nil
-}
 
 func main() {
 	app := cli.NewApp()

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -55,16 +55,37 @@ func checkFlags(c *cli.Context, flags ...string) error {
 	return nil
 }
 
-func ips(*cli.Context) {
-	ips, _ := cloudflare.IPs()
-	fmt.Println("IPv4 ranges:")
-	for _, r := range ips.IPv4CIDRs {
-		fmt.Println(" ", r)
+func ips(c *cli.Context) {
+
+	if c.String("ip-type") == "all" {
+		_getIps("ipv4", c.Bool("ip-only"))
+		_getIps("ipv6", c.Bool("ip-only"))
+	} else {
+		_getIps(c.String("ip-type"), c.Bool("ip-only"))
 	}
-	fmt.Println()
-	fmt.Println("IPv6 ranges:")
-	for _, r := range ips.IPv6CIDRs {
-		fmt.Println(" ", r)
+}
+
+//
+// gets type of IPs to retrieve and returns results
+//
+func _getIps(ipType string, showMsgType bool) {
+	ips, _ := cloudflare.IPs()
+
+	switch ipType {
+	case "ipv4":
+		if showMsgType != true {
+			fmt.Println("IPv4 ranges:")
+		}
+		for _, r := range ips.IPv4CIDRs {
+			fmt.Println(" ", r)
+		}
+	case "ipv6":
+		if showMsgType != true {
+			fmt.Println("IPv6 ranges:")
+		}
+		for _, r := range ips.IPv6CIDRs {
+			fmt.Println(" ", r)
+		}
 	}
 }
 

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -2,11 +2,58 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"strings"
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/codegangsta/cli"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
 )
+
+// writeTable outputs tabular data to stdout.
+func writeTable(data [][]string, cols ...string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(cols)
+	table.SetBorder(false)
+	table.AppendBulk(data)
+
+	table.Render()
+}
+
+func checkEnv() error {
+	if api == nil {
+		var err error
+		api, err = cloudflare.New(os.Getenv("CF_API_KEY"), os.Getenv("CF_API_EMAIL"))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	if api.APIKey == "" {
+		return errors.New("API key not defined")
+	}
+	if api.APIEmail == "" {
+		return errors.New("API email not defined")
+	}
+
+	return nil
+}
+
+// Utility function to check if CLI flags were given.
+func checkFlags(c *cli.Context, flags ...string) error {
+	for _, flag := range flags {
+		if c.String(flag) == "" {
+			cli.ShowSubcommandHelp(c)
+			err := errors.Errorf("error: the required flag %q was empty or not provided", flag)
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+	}
+
+	return nil
+}
 
 func ips(*cli.Context) {
 	ips, _ := cloudflare.IPs()


### PR DESCRIPTION
This pull request modify the flarectl to be more robust in automation tasks. Changes include 
* Moving function from main to utils
* adding new function to query ips based on their type (ipv4|ipv6) 
* option to supress message displayed which type of IP we are dealing with 

## Help output 
```shell
./flarectl ips --help
NAME:
   flarectl ips - Print Cloudflare IP ranges

USAGE:
   flarectl ips [command options] [arguments...]

OPTIONS:
   --ip-type value  type of IPs ( ipv4 | ipv6 | all ) (default: "all")
   --ip-only        show only addresses
```


##  Normal behavior is maintained 
```shell
./flarectl ips
IPv4 ranges:
  173.245.48.0/20
  103.21.244.0/22
  103.22.200.0/22
  103.31.4.0/22
  141.101.64.0/18
  108.162.192.0/18
  190.93.240.0/20
  188.114.96.0/20
  197.234.240.0/22
  198.41.128.0/17
  162.158.0.0/15
  104.16.0.0/12
  172.64.0.0/13
  131.0.72.0/22
IPv6 ranges:
  2400:cb00::/32
  2606:4700::/32
  2803:f800::/32
  2405:b500::/32
  2405:8100::/32
  2a06:98c0::/29
  2c0f:f248::/32
```

## Just `ipv4` without message 
```shell
./flarectl ips --ip-type ipv4 --ip-only
  173.245.48.0/20
  103.21.244.0/22
  103.22.200.0/22
  103.31.4.0/22
  141.101.64.0/18
  108.162.192.0/18
  190.93.240.0/20
  188.114.96.0/20
  197.234.240.0/22
  198.41.128.0/17
  162.158.0.0/15
  104.16.0.0/12
  172.64.0.0/13
  131.0.72.0/22
```

## Automation of whitelisting Cloudflare IPs 
```shell
./flarectl ips --ip-type ipv4 --ip-only | xargs -L 1 -I % iptables -I INPUT -p tcp -m multiport --dports http,https -s % -j ACCEPT
```

which in return produces something in lines of 
```
iptables -I INPUT -p tcp -m multiport --dports http,https -s 173.245.48.0/20 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 103.21.244.0/22 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 103.22.200.0/22 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 103.31.4.0/22 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 141.101.64.0/18 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 108.162.192.0/18 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 190.93.240.0/20 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 188.114.96.0/20 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 197.234.240.0/22 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 198.41.128.0/17 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 162.158.0.0/15 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 104.16.0.0/12 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 172.64.0.0/13 -j ACCEPT
iptables -I INPUT -p tcp -m multiport --dports http,https -s 131.0.72.0/22 -j ACCEPT
```

I think this is quite useful in scenarios where we automate actions and do not want to play around with parsing output to remove unnecessary messages 
