### PR TITLE
create page rule to return the page rule object - quick fix?

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,6 +6,12 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 )
 
+const (
+	user   = "cloudflare@example.org"
+	domain = "example.com"
+	apiKey = "deadbeef"
+)
+
 func Example() {
 	api, err := cloudflare.New("deadbeef", "cloudflare@example.org")
 	if err != nil {

--- a/page_rules.go
+++ b/page_rules.go
@@ -104,18 +104,18 @@ type PageRulesResponse struct {
 // CreatePageRule creates a new Page Rule for a zone.
 //
 // API reference: https://api.cloudflare.com/#page-rules-for-a-zone-create-a-page-rule
-func (api *API) CreatePageRule(zoneID string, rule PageRule) error {
+func (api *API) CreatePageRule(zoneID string, rule PageRule) (*PageRule, error) {
 	uri := "/zones/" + zoneID + "/pagerules"
 	res, err := api.makeRequest("POST", uri, rule)
 	if err != nil {
-		return errors.Wrap(err, errMakeRequestError)
+		return nil, errors.Wrap(err, errMakeRequestError)
 	}
 	var r PageRuleDetailResponse
 	err = json.Unmarshal(res, &r)
 	if err != nil {
-		return errors.Wrap(err, errUnmarshalError)
+		return nil, errors.Wrap(err, errUnmarshalError)
 	}
-	return nil
+	return &r.Result, nil
 }
 
 // ListPageRules returns all Page Rules for a zone.

--- a/page_rules_example_test.go
+++ b/page_rules_example_test.go
@@ -7,22 +7,31 @@ import (
 	cloudflare "github.com/cloudflare/cloudflare-go"
 )
 
-var exampleNewRateLimit = cloudflare.RateLimit{
-	Description: "test",
-	Match: cloudflare.RateLimitTrafficMatcher{
-		Request: cloudflare.RateLimitRequestMatcher{
-			URLPattern: "exampledomain.com/test-rate-limit",
+var exampleNewPageRule = cloudflare.PageRule{
+	Actions: []cloudflare.PageRuleAction{
+		{
+			ID:    "always_online",
+			Value: "on",
+		},
+		{
+			ID:    "ssl",
+			Value: "flexible",
 		},
 	},
-	Threshold: 0,
-	Period:    0,
-	Action: cloudflare.RateLimitAction{
-		Mode:    "ban",
-		Timeout: 60,
+	Targets: []cloudflare.PageRuleTarget{
+		{
+			Target: "url",
+			Constraint: struct {
+				Operator string "json:\"operator\""
+				Value    string "json:\"value\""
+			}{Operator: "matches", Value: fmt.Sprintf("example.%s", domain)},
+		},
 	},
+	Priority: 1,
+	Status:   "active",
 }
 
-func ExampleAPI_CreateRateLimit() {
+func ExampleAPI_CreatePageRule() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -33,15 +42,15 @@ func ExampleAPI_CreateRateLimit() {
 		log.Fatal(err)
 	}
 
-	rateLimit, err := api.CreateRateLimit(zoneID, exampleNewRateLimit)
+	pageRule, err := api.CreatePageRule(zoneID, exampleNewPageRule)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("%+v\n", rateLimit)
+	fmt.Printf("%+v\n", pageRule)
 }
 
-func ExampleAPI_ListRateLimits() {
+func ExampleAPI_ListPageRules() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -52,22 +61,18 @@ func ExampleAPI_ListRateLimits() {
 		log.Fatal(err)
 	}
 
-	pageOpts := cloudflare.PaginationOptions{
-		PerPage: 5,
-		Page:    1,
-	}
-	rateLimits, _, err := api.ListRateLimits(zoneID, pageOpts)
+	pageRules, err := api.ListPageRules(zoneID)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("%+v\n", rateLimits)
-	for _, r := range rateLimits {
+	fmt.Printf("%+v\n", pageRules)
+	for _, r := range pageRules {
 		fmt.Printf("%+v\n", r)
 	}
 }
 
-func ExampleAPI_RateLimit() {
+func ExampleAPI_PageRule() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -78,15 +83,15 @@ func ExampleAPI_RateLimit() {
 		log.Fatal(err)
 	}
 
-	rateLimits, err := api.RateLimit(zoneID, "my_rate_limit_id")
+	pageRules, err := api.PageRule(zoneID, "my_page_rule_id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("%+v\n", rateLimits)
+	fmt.Printf("%+v\n", pageRules)
 }
 
-func ExampleAPI_DeleteRateLimit() {
+func ExampleAPI_DeletePageRule() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -97,7 +102,7 @@ func ExampleAPI_DeleteRateLimit() {
 		log.Fatal(err)
 	}
 
-	err = api.DeleteRateLimit(zoneID, "my_rate_limit_id")
+	err = api.DeletePageRule(zoneID, "my_page_rule_id")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/page_rules_test.go
+++ b/page_rules_test.go
@@ -1,0 +1,198 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	pageRuleID                = "15dae2fc158942f2adb1dd2a3d4273bc"
+	serverPageRuleDescription = `{
+    "id": "%s",
+    "targets": [
+      {
+        "target": "url",
+        "constraint": {
+          "operator": "matches",
+          "value": "example.%s"
+        }
+      }
+    ],
+    "actions": [
+      {
+        "id": "always_online",
+        "value": "on"
+      },
+      {
+        "id": "ssl",
+        "value": "flexible"
+      }
+    ],
+    "priority": 1,
+    "status": "active",
+    "created_on": "%[3]s",
+    "modified_on": "%[3]s"
+  }
+`
+)
+
+var testTimestamp = time.Now().UTC()
+var expectedPageRuleStruct = PageRule{
+	ID: pageRuleID,
+	Actions: []PageRuleAction{
+		{
+			ID:    "always_online",
+			Value: "on",
+		},
+		{
+			ID:    "ssl",
+			Value: "flexible",
+		},
+	},
+	Targets: []PageRuleTarget{
+		{
+			Target: "url",
+			Constraint: struct {
+				Operator string "json:\"operator\""
+				Value    string "json:\"value\""
+			}{Operator: "matches", Value: fmt.Sprintf("example.%s", testZoneID)},
+		},
+	},
+	Priority:   1,
+	Status:     "active",
+	CreatedOn:  testTimestamp,
+	ModifiedOn: testTimestamp,
+}
+
+func TestListPageRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": [
+			%s
+		  ],
+		  "success": true,
+		  "errors": null,
+		  "messages": null,
+		  "result_info": {
+			"page": 1,
+			"per_page": 25,
+			"count": 1,
+			"total_count": 1
+		  }
+		}
+		`, fmt.Sprintf(serverPageRuleDescription, pageRuleID, testZoneID, testTimestamp.Format(time.RFC3339Nano)))
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/pagerules", handler)
+	want := []PageRule{expectedPageRuleStruct}
+
+	actual, err := client.ListPageRules(testZoneID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetPageRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": %s,
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}
+		`, fmt.Sprintf(serverPageRuleDescription, pageRuleID, testZoneID, testTimestamp.Format(time.RFC3339Nano)))
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/pagerules/"+pageRuleID, handler)
+	want := expectedPageRuleStruct
+
+	actual, err := client.PageRule(testZoneID, pageRuleID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreatePageRule(t *testing.T) {
+	setup()
+	defer teardown()
+	newPageRule := PageRule{
+		Actions: []PageRuleAction{
+			{
+				ID:    "always_online",
+				Value: "on",
+			},
+			{
+				ID:    "ssl",
+				Value: "flexible",
+			},
+		},
+		Targets: []PageRuleTarget{
+			{
+				Target: "url",
+				Constraint: struct {
+					Operator string "json:\"operator\""
+					Value    string "json:\"value\""
+				}{Operator: "matches", Value: fmt.Sprintf("example.%s", testZoneID)},
+			},
+		},
+		Priority: 1,
+		Status:   "active",
+	}
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": %s,
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}
+		`, fmt.Sprintf(serverPageRuleDescription, pageRuleID, testZoneID, testTimestamp.Format(time.RFC3339Nano)))
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/pagerules", handler)
+	want := &expectedPageRuleStruct
+
+	actual, err := client.CreatePageRule(testZoneID, newPageRule)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeletePageRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "result": null,
+		  "success": true,
+		  "errors": null,
+		  "messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/pagerules/"+pageRuleID, handler)
+
+	err := client.DeletePageRule(testZoneID, pageRuleID)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Does the simplest possible thing to get creation of page rules to be usable in terraform or other automation by returning the page rule object. I also added a bunch of tests while I'm here

I'm aware there is related some discussion and parallel work going on in #154, happy to align with that just trying to get something in quickly

Of course - this is still a breaking change