### PR TITLE
fix(api): accept 2xx responses without error

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -109,15 +109,18 @@ func (api *API) makeRequestWithAuthType(method, uri string, params interface{}, 
 		return nil, errors.Wrap(err, "could not read response body")
 	}
 
-	switch resp.StatusCode {
-	case http.StatusOK:
-		break
-	case http.StatusUnauthorized:
+	switch {
+	case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
+	case resp.StatusCode == http.StatusUnauthorized:
 		return nil, errors.Errorf("HTTP status %d: invalid credentials", resp.StatusCode)
-	case http.StatusForbidden:
+	case resp.StatusCode == http.StatusForbidden:
 		return nil, errors.Errorf("HTTP status %d: insufficient permissions", resp.StatusCode)
-	case http.StatusServiceUnavailable, http.StatusBadGateway, http.StatusGatewayTimeout,
-		522, 523, 524:
+	case resp.StatusCode == http.StatusServiceUnavailable,
+		resp.StatusCode == http.StatusBadGateway,
+		resp.StatusCode == http.StatusGatewayTimeout,
+		resp.StatusCode == 522,
+		resp.StatusCode == 523,
+		resp.StatusCode == 524:
 		return nil, errors.Errorf("HTTP status %d: service failure", resp.StatusCode)
 	default:
 		var s string

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -35,6 +35,7 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 		assert.Equal(t, "POST", r.Method, "Expected method 'POST', got %s", r.Method)
 
 		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, `
 {
   "success": true,


### PR DESCRIPTION
Many of our API endpoints that create objects now return 201 Created
instead of 200 OK. The API implementation here was previously only
accepting http.StatusOK as valid.

This change allows all currently defined 2xx status codes.

Bug: #173