### PR TITLE
[bugfix] Fix session_affinity none handling

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -62,7 +62,7 @@ type LoadBalancer struct {
 	RegionPools  map[string][]string `json:"region_pools"`
 	PopPools     map[string][]string `json:"pop_pools"`
 	Proxied      bool                `json:"proxied"`
-	Persistence  string              `json:"session_affinity"`
+	Persistence  string              `json:"session_affinity,omitempty"`
 }
 
 // loadBalancerPoolResponse represents the response from the load balancer pool endpoints.


### PR DESCRIPTION
This fixes a bug where the marshalled JSON request sets the "session_affinity" field to `null`, which is not supported by the API as per https://github.com/terraform-providers/terraform-provider-cloudflare/pull/57#issuecomment-386656370

