### PR TITLE
Fix Zone Owner object

### DIFF
--- a/zone.go
+++ b/zone.go
@@ -11,9 +11,10 @@ import (
 
 // Owner describes the resource owner.
 type Owner struct {
-	ID        string `json:"id"`
-	Email     string `json:"email"`
-	OwnerType string `json:"owner_type"`
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+	Type  string `json:"type"`
 }
 
 // Zone describes a Cloudflare zone.

--- a/zone.go
+++ b/zone.go
@@ -11,10 +11,10 @@ import (
 
 // Owner describes the resource owner.
 type Owner struct {
-	ID    string `json:"id"`
-	Email string `json:"email"`
-	Name  string `json:"name"`
-	Type  string `json:"type"`
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	Name      string `json:"name"`
+	OwnerType string `json:"type"`
 }
 
 // Zone describes a Cloudflare zone.


### PR DESCRIPTION
1. `owner_type` was renamed to `type`, though this isn't reflected in the documentation yet
2. When a zone is owned by an organization instead of a user, the `email` field is replaced by a `name` field