### PR TITLE
DNSRecord.Priority is a string now

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -25,7 +25,7 @@ type DNSRecord struct {
 	ModifiedOn time.Time   `json:"modified_on,omitempty"`
 	Data       interface{} `json:"data,omitempty"` // data returned by: SRV, LOC
 	Meta       interface{} `json:"meta,omitempty"`
-	Priority   int         `json:"priority,omitempty"`
+	Priority   string      `json:"priority,omitempty"`
 }
 
 // DNSRecordResponse represents the response from the DNS endpoint.


### PR DESCRIPTION
I encountered an error using `terraform` with the latest version of the Terraform Cloudflare provider, which uses the latest version of this library:

```
error unmarshalling the JSON response: json: cannot unmarshal string into Go struct field DNSRecord.priority of type int
```

It appears that the Cloudflare API no longer returns the `DNSRecord.priority` as an int, but as a string. It appears that this changed sometime between yesterday at 1:47pm PT and today at 7:12pm PT.

When I patched this library, updated my local `terraform-cloudflare-provider` to use the patch, and ran `terraform plan` using the patched `terraform-cloudflare-provider`, things started working again.