### PR TITLE
Add `Accounts` API endpoints

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -43,10 +43,10 @@ type AccountDetailResponse struct {
 	Result   Account  `json:"result"`
 }
 
-// ListAccounts returns all accounts the logged in user has access to.
+// Accounts returns all accounts the logged in user has access to.
 //
 // API reference: https://api.cloudflare.com/#accounts-list-accounts
-func (api *API) ListAccounts(pageOpts PaginationOptions) ([]Account, ResultInfo, error) {
+func (api *API) Accounts(pageOpts PaginationOptions) ([]Account, ResultInfo, error) {
 	v := url.Values{}
 	if pageOpts.PerPage > 0 {
 		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))

--- a/accounts.go
+++ b/accounts.go
@@ -1,0 +1,58 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// AccountSettings outlines the available options for an account.
+type AccountSettings struct {
+	EnforceTwoFactor bool `json:"enforce_twofactor"`
+}
+
+// Account represents the root object that owns resources.
+type Account struct {
+	ID       string          `json:"id,omitempty"`
+	Name     string          `json:"name,omitempty"`
+	Settings AccountSettings `json:"settings"`
+}
+
+// AccountListResponse represents the response from the list accounts endpoint.
+type AccountListResponse struct {
+	Result []Account `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// ListAccounts returns all accounts the logged in user has access to.
+//
+// API reference: https://api.cloudflare.com/#accounts-list-accounts
+func (api *API) ListAccounts(pageOpts PaginationOptions) ([]Account, ResultInfo, error) {
+	v := url.Values{}
+	if pageOpts.PerPage > 0 {
+		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
+	}
+	if pageOpts.Page > 0 {
+		v.Set("page", strconv.Itoa(pageOpts.Page))
+	}
+
+	uri := "/accounts"
+	if len(v) > 0 {
+		uri = uri + "?" + v.Encode()
+	}
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []Account{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accListResponse AccountListResponse
+	err = json.Unmarshal(res, &accListResponse)
+	if err != nil {
+		return []Account{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return accListResponse.Result, accListResponse.ResultInfo, nil
+}

--- a/accounts.go
+++ b/accounts.go
@@ -35,6 +35,14 @@ type AccountListResponse struct {
 	ResultInfo `json:"result_info"`
 }
 
+// AccountDetailResponse is the API response, containing a single Account.
+type AccountDetailResponse struct {
+	Success  bool     `json:"success"`
+	Errors   []string `json:"errors"`
+	Messages []string `json:"messages"`
+	Result   Account  `json:"result"`
+}
+
 // ListAccounts returns all accounts the logged in user has access to.
 //
 // API reference: https://api.cloudflare.com/#accounts-list-accounts
@@ -65,7 +73,7 @@ func (api *API) ListAccounts(pageOpts PaginationOptions) ([]Account, ResultInfo,
 	return accListResponse.Result, accListResponse.ResultInfo, nil
 }
 
-// Account returns a single account based on the ID.Account
+// Account returns a single account based on the ID.
 //
 // API reference: https://api.cloudflare.com/#accounts-account-details
 func (api *API) Account(accountID string) (Account, ResultInfo, error) {
@@ -83,4 +91,24 @@ func (api *API) Account(accountID string) (Account, ResultInfo, error) {
 	}
 
 	return accResponse.Result, accResponse.ResultInfo, nil
+}
+
+// UpdateAccount allows management of an account using the account ID.
+//
+// API reference: https://api.cloudflare.com/#accounts-update-account
+func (api *API) UpdateAccount(accountID string, account Account) (Account, error) {
+	uri := "/accounts/" + accountID
+
+	res, err := api.makeRequest("PUT", uri, account)
+	if err != nil {
+		return Account{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var a AccountDetailResponse
+	err = json.Unmarshal(res, &a)
+	if err != nil {
+		return Account{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return a.Result, nil
 }

--- a/accounts.go
+++ b/accounts.go
@@ -20,6 +20,14 @@ type Account struct {
 	Settings AccountSettings `json:"settings"`
 }
 
+// AccountResponse represents the response from the accounts endpoint for a
+// single account ID.
+type AccountResponse struct {
+	Result Account `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
 // AccountListResponse represents the response from the list accounts endpoint.
 type AccountListResponse struct {
 	Result []Account `json:"result"`
@@ -55,4 +63,24 @@ func (api *API) ListAccounts(pageOpts PaginationOptions) ([]Account, ResultInfo,
 		return []Account{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return accListResponse.Result, accListResponse.ResultInfo, nil
+}
+
+// Account returns a single account based on the ID.Account
+//
+// API reference: https://api.cloudflare.com/#accounts-account-details
+func (api *API) Account(accountID string) (Account, ResultInfo, error) {
+	uri := "/accounts/" + accountID
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return Account{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accResponse AccountResponse
+	err = json.Unmarshal(res, &accResponse)
+	if err != nil {
+		return Account{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accResponse.Result, accResponse.ResultInfo, nil
 }

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var expectedListAccountsStruct = Account{
+var expectedAccountStruct = Account{
 	ID:   "01a7362d577a6c3019a474fd6f485823",
 	Name: "Cloudflare Demo",
 	Settings: AccountSettings{
@@ -47,9 +47,47 @@ func TestListAccounts(t *testing.T) {
 	}
 
 	mux.HandleFunc("/accounts", handler)
-	want := []Account{expectedListAccountsStruct}
+	want := []Account{expectedAccountStruct}
 
 	actual, _, err := client.ListAccounts(PaginationOptions{})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestAccount(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "01a7362d577a6c3019a474fd6f485823",
+				"name": "Cloudflare Demo",
+				"settings": {
+					"enforce_twofactor": false
+				}
+			},
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823", handler)
+	want := expectedAccountStruct
+
+	actual, _, err := client.Account("01a7362d577a6c3019a474fd6f485823")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -1,0 +1,57 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var expectedListAccountsStruct = Account{
+	ID:   "01a7362d577a6c3019a474fd6f485823",
+	Name: "Cloudflare Demo",
+	Settings: AccountSettings{
+		EnforceTwoFactor: false,
+	},
+}
+
+func TestListAccounts(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "01a7362d577a6c3019a474fd6f485823",
+					"name": "Cloudflare Demo",
+					"settings": {
+						"enforce_twofactor": false
+					}
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts", handler)
+	want := []Account{expectedListAccountsStruct}
+
+	actual, _, err := client.ListAccounts(PaginationOptions{})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -91,5 +92,62 @@ func TestAccount(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateAccount(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method, "Expected method 'PUT', got %s", r.Method)
+		b, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+
+		if assert.NoError(t, err) {
+			assert.JSONEq(t, `{
+				"id":"01a7362d577a6c3019a474fd6f485823",
+				"name":"Cloudflare Demo - New",
+				"settings":{
+					"enforce_twofactor":false
+					}
+				}`, string(b), "JSON payload not equal")
+		}
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "01a7362d577a6c3019a474fd6f485823",
+				"name": "Cloudflare Demo - New",
+				"settings": {
+					"enforce_twofactor": false
+				}
+			}
+		}`)
+	})
+
+	oldAccountDetails := Account{
+		ID:   "01a7362d577a6c3019a474fd6f485823",
+		Name: "Cloudflare Demo - Old",
+		Settings: AccountSettings{
+			EnforceTwoFactor: false,
+		},
+	}
+
+	newAccountDetails := Account{
+		ID:   "01a7362d577a6c3019a474fd6f485823",
+		Name: "Cloudflare Demo - New",
+		Settings: AccountSettings{
+			EnforceTwoFactor: false,
+		},
+	}
+
+	account, err := client.UpdateAccount(newAccountDetails.ID, newAccountDetails)
+	if assert.NoError(t, err) {
+		assert.NotEqual(t, oldAccountDetails.Name, account.Name)
+		assert.Equal(t, account.Name, "Cloudflare Demo - New")
 	}
 }

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -17,7 +17,7 @@ var expectedAccountStruct = Account{
 	},
 }
 
-func TestListAccounts(t *testing.T) {
+func TestAccounts(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -50,7 +50,7 @@ func TestListAccounts(t *testing.T) {
 	mux.HandleFunc("/accounts", handler)
 	want := []Account{expectedAccountStruct}
 
-	actual, _, err := client.ListAccounts(PaginationOptions{})
+	actual, _, err := client.Accounts(PaginationOptions{})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)


### PR DESCRIPTION
This introduces the ability to manage Cloudflare Accounts via the API. 

I initially went to implement the Organisations however I noticed the API docs mention this is deprecated and instead we should use Accounts.

From https://api.cloudflare.com/#organizations-properties:

> NOTE: This API is deprecated, please use equivalent /accounts API endpoints where possible. Account APIs provide a broader range of features, and are backwards-compatible to organization APIs.

So instead, this PR implements (and tests) the following:

- List all accounts that the current logged in user has access to 
  (https://api.cloudflare.com/#accounts-list-accounts)
- A single account lookup based on account ID 
  (https://api.cloudflare.com/#accounts-account-details)
- Update an account based on the account ID 
 (https://api.cloudflare.com/#accounts-update-account)

I haven't added the functionality to `flarectl` as it seems slightly neglected and I'm unsure if that is still something that is being maintained. If we would like the functionality to be added, I'm more than happy to implement it.