### PR TITLE
Add account role endpoints

### DIFF
--- a/account_roles.go
+++ b/account_roles.go
@@ -1,0 +1,80 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// AccountRole defines the roles that a member can have attached.
+type AccountRole struct {
+	ID          string                           `json:"id"`
+	Name        string                           `json:"name"`
+	Description string                           `json:"description"`
+	Permissions map[string]AccountRolePermission `json:"permissions"`
+}
+
+// AccountRolePermission is the shared structure for all permissions
+// that can be assigned to a member.
+type AccountRolePermission struct {
+	Read bool `json:"read"`
+	Edit bool `json:"edit"`
+}
+
+// AccountRolesListResponse represents the list response from the
+// account roles.
+type AccountRolesListResponse struct {
+	Result []AccountRole `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// AccountRoleDetailResponse is the API response, containing a single
+// account role.
+type AccountRoleDetailResponse struct {
+	Success  bool        `json:"success"`
+	Errors   []string    `json:"errors"`
+	Messages []string    `json:"messages"`
+	Result   AccountRole `json:"result"`
+}
+
+// AccountRoles returns all roles of an account.
+//
+// API reference: https://api.cloudflare.com/#account-roles-list-roles
+func (api *API) AccountRoles(accountID string) ([]AccountRole, error) {
+	uri := "/accounts/" + accountID + "/roles"
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []AccountRole{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accountRolesListResponse AccountRolesListResponse
+	err = json.Unmarshal(res, &accountRolesListResponse)
+	if err != nil {
+		return []AccountRole{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accountRolesListResponse.Result, nil
+}
+
+// AccountRole returns the details of a single account role.
+//
+// API reference: https://api.cloudflare.com/#account-roles-role-details
+func (api *API) AccountRole(accountID string, roleID string) (AccountRole, error) {
+	uri := fmt.Sprintf("/accounts/%s/roles/%s", accountID, roleID)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return AccountRole{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accountRole AccountRoleDetailResponse
+	err = json.Unmarshal(res, &accountRole)
+	if err != nil {
+		return AccountRole{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accountRole.Result, nil
+}

--- a/account_roles_test.go
+++ b/account_roles_test.go
@@ -1,0 +1,112 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var expectedAccountRole = AccountRole{
+	ID:          "3536bcfad5faccb999b47003c79917fb",
+	Name:        "Account Administrator",
+	Description: "Administrative access to the entire Account",
+	Permissions: map[string]AccountRolePermission{
+		"dns_records": {Read: true, Edit: true},
+		"lb":          {Read: true, Edit: false},
+	},
+}
+
+func TestAccountRoles(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "3536bcfad5faccb999b47003c79917fb",
+					"name": "Account Administrator",
+					"description": "Administrative access to the entire Account",
+					"permissions": {
+						"dns_records": {
+							"read": true,
+							"edit": true
+						},
+						"lb": {
+							"read": true,
+							"edit": false
+						}
+					}
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/roles", handler)
+	want := []AccountRole{expectedAccountRole}
+
+	actual, err := client.AccountRoles("01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestAccountRole(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "3536bcfad5faccb999b47003c79917fb",
+				"name": "Account Administrator",
+				"description": "Administrative access to the entire Account",
+				"permissions": {
+					"dns_records": {
+						"read": true,
+						"edit": true
+					},
+					"lb": {
+						"read": true,
+						"edit": false
+					}
+				}
+			},
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/roles/3536bcfad5faccb999b47003c79917fb", handler)
+
+	actual, err := client.AccountRole("01a7362d577a6c3019a474fd6f485823", "3536bcfad5faccb999b47003c79917fb")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAccountRole, actual)
+	}
+}


### PR DESCRIPTION
Updates the library with the ability to fetch account roles and their
details.

- `AccountRoles` (https://api.cloudflare.com/#account-roles-list-roles)
- `AccountRole` (https://api.cloudflare.com/#account-roles-role-details)