### PR TITLE
Add Golang 1.10.x to the test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     - go: 1.7.x
     - go: 1.8.x
     - go: 1.9.x
+    - go: 1.10.x
     - go: tip
   allow_failures:
     - go: tip


### PR DESCRIPTION
1.10 was released earlier this year so let's test against it and ensure
we're not creating any issues with newer versions of golang.

See https://blog.golang.org/go1.10