### PR TITLE
Allow `1.x` latest to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     - go: tip
   allow_failures:
     - go: tip
+    - go: 1.x
+      env: LATEST=true
 
 before_install:
   - go get github.com/mitchellh/gox


### PR DESCRIPTION
While running #196 in CI, we got failures related to `gofmt` failing on
alignment within struct literals. Take for instance, the following:

```
User: AccountMemberUserDetails{
  ID:        "7c5dae5552338874e5053f2534d2767a",
  FirstName: "John",
  LastName:  "Appleseeds",
  Email:     "new-user@example.com",
  TwoFactorAuthenticationEnabled: false,
}
```

Up until 1.10.x this passed `gofmt` with flying colours. However, the
`1.x` step (using 1.11beta1) now fails since the heuristics have changed
in golang/go@542ea5a and it now expects the following format:

```
User: AccountMemberUserDetails{
  ID:                             "7c5dae5552338874e5053f2534d2767a",
  FirstName:                      "John",
  LastName:                       "Appleseeds",
  Email:                          "new-user@example.com",
  TwoFactorAuthenticationEnabled: false,
}
```

The problem with just updating the format to what is expected is that
`gofmt` 1.7 through to 1.10 expects the old format and fails the build.

To address this, I'm moving the `1.x` step running `LATEST=true` into
the `allow_failures` so that it won't fail the build however it will
still run the test suite as intended. Once we move forward to using 1.11
by default, we can move this back to it's normal position in the build
matrix.

Fixes https://travis-ci.org/cloudflare/cloudflare-go/jobs/397558038