### PR TITLE
Add correlate (nat support) to rate limiting

### DIFF
--- a/rate_limiting.go
+++ b/rate_limiting.go
@@ -18,6 +18,7 @@ type RateLimit struct {
 	Threshold   int                     `json:"threshold"`
 	Period      int                     `json:"period"`
 	Action      RateLimitAction         `json:"action"`
+	Correlate   RateLimitCorrelate      `json:"correlate"`
 }
 
 // RateLimitTrafficMatcher contains the rules that will be used to apply a rate limit to traffic
@@ -56,6 +57,11 @@ type RateLimitAction struct {
 type RateLimitActionResponse struct {
 	ContentType string `json:"content_type"`
 	Body        string `json:"body"`
+}
+
+// RateLimitCorrelate pertainings to NAT support
+type RateLimitCorrelate struct {
+	By string `json:"by"`
 }
 
 type rateLimitResponse struct {

--- a/rate_limiting_example_test.go
+++ b/rate_limiting_example_test.go
@@ -20,6 +20,9 @@ var exampleNewRateLimit = cloudflare.RateLimit{
 		Mode:    "ban",
 		Timeout: 60,
 	},
+	Correlate: cloudflare.RateLimitCorrelate{
+		By: "nat"
+	},
 }
 
 func ExampleAPI_CreateRateLimit() {

--- a/rate_limiting_example_test.go
+++ b/rate_limiting_example_test.go
@@ -21,7 +21,7 @@ var exampleNewRateLimit = cloudflare.RateLimit{
 		Timeout: 60,
 	},
 	Correlate: cloudflare.RateLimitCorrelate{
-		By: "nat"
+		By: "nat",
 	},
 }
 

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,7 +67,7 @@ var expectedRateLimitStruct = RateLimit{
 		Timeout: 60,
 	},
 	Correlate: cloudflare.RateLimitCorrelate{
-		By: "nat"
+		By: "nat",
 	},
 }
 var expectedRateLimitStructUpdated = RateLimit{
@@ -90,7 +91,7 @@ var expectedRateLimitStructUpdated = RateLimit{
 		Timeout: 60,
 	},
 	Correlate: cloudflare.RateLimitCorrelate{
-		By: "nat"
+		By: "nat",
 	},
 }
 
@@ -261,7 +262,7 @@ func TestCreateRateLimit(t *testing.T) {
 			Timeout: 60,
 		},
 		Correlate{
-			By: "nat"
+			By: "nat",
 		},
 	}
 

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,7 +65,7 @@ var expectedRateLimitStruct = RateLimit{
 		Mode:    "ban",
 		Timeout: 60,
 	},
-	Correlate: cloudflare.RateLimitCorrelate{
+	Correlate: RateLimitCorrelate{
 		By: "nat",
 	},
 }

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -36,6 +36,9 @@ const (
 	"action": {
 		"mode": "ban",
 		"timeout": 60
+	},
+	"correlate": {
+		"by": "nat"
 	}
 }
 `
@@ -62,6 +65,9 @@ var expectedRateLimitStruct = RateLimit{
 		Mode:    "ban",
 		Timeout: 60,
 	},
+	Correlate: cloudflare.RateLimitCorrelate{
+		By: "nat"
+	},
 }
 var expectedRateLimitStructUpdated = RateLimit{
 	ID:          "72dae2fc158942f2adb1dd2a3d4143bc",
@@ -82,6 +88,9 @@ var expectedRateLimitStructUpdated = RateLimit{
 	Action: RateLimitAction{
 		Mode:    "ban",
 		Timeout: 60,
+	},
+	Correlate: cloudflare.RateLimitCorrelate{
+		By: "nat"
 	},
 }
 
@@ -250,6 +259,9 @@ func TestCreateRateLimit(t *testing.T) {
 		Action: RateLimitAction{
 			Mode:    "ban",
 			Timeout: 60,
+		},
+		Correlate{
+			By: "nat"
 		},
 	}
 

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -90,7 +90,7 @@ var expectedRateLimitStructUpdated = RateLimit{
 		Mode:    "ban",
 		Timeout: 60,
 	},
-	Correlate: cloudflare.RateLimitCorrelate{
+	Correlate: RateLimitCorrelate{
 		By: "nat",
 	},
 }
@@ -261,7 +261,7 @@ func TestCreateRateLimit(t *testing.T) {
 			Mode:    "ban",
 			Timeout: 60,
 		},
-		Correlate{
+		Correlate: RateLimitCorrelate{
 			By: "nat",
 		},
 	}


### PR DESCRIPTION
Add correlate (nat support) to rate limiting so that the property can be configured.

I have another PR to add this to the Terraform Cloudflare provider.