### PR TITLE
Refactor API to accept an interface for the HTTP client

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -25,6 +25,11 @@ const (
 	AuthUserService
 )
 
+// HTTPRequester abstracts the http.Client implementation
+type HTTPRequester interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // API holds the configuration for the current API client. A client should not
 // be modified concurrently.
 type API struct {
@@ -34,7 +39,7 @@ type API struct {
 	BaseURL           string
 	organizationID    string
 	headers           http.Header
-	httpClient        *http.Client
+	httpClient        HTTPRequester
 	authType          int
 	rateLimiter       *rate.Limiter
 	retryPolicy       RetryPolicy

--- a/options.go
+++ b/options.go
@@ -11,8 +11,8 @@ import (
 // Option is a functional option for configuring the API client.
 type Option func(*API) error
 
-// HTTPClient accepts a custom *http.Client for making API calls.
-func HTTPClient(client *http.Client) Option {
+// HTTPClient accepts a custom HTTPRequester for making API calls.
+func HTTPClient(client HTTPRequester) Option {
 	return func(api *API) error {
 		api.httpClient = client
 		return nil


### PR DESCRIPTION
It is possible to provide an alternative client other than the
http.DefaultClient, however it is not possible to use another
implementation. An alternative implementation may be useful for
OpenTracing or a circuit breaker, for example.

Use an interface abstracting the implementation for the HTTP client,
rather than depending on a specific implementation.

The `HTTPRequester` name isn't ideal, but `HTTPClient` is already taken
by the options function.