### PR TITLE
Add support to makeRequest for passing a raw request body.

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -108,9 +108,13 @@ func (api *API) makeRequestWithAuthType(method, uri string, params interface{}, 
 	var jsonBody []byte
 	var err error
 	if params != nil {
-		jsonBody, err = json.Marshal(params)
-		if err != nil {
-			return nil, errors.Wrap(err, "error marshalling params to JSON")
+		if paramBytes, ok := params.([]byte); ok {
+			jsonBody = paramBytes
+		} else {
+			jsonBody, err = json.Marshal(params)
+			if err != nil {
+				return nil, errors.Wrap(err, "error marshalling params to JSON")
+			}
 		}
 	} else {
 		jsonBody = nil

--- a/workers.go
+++ b/workers.go
@@ -2,8 +2,9 @@ package cloudflare
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // WorkerRequestParams provides parameters for worker requests for both enterprise and standard requests

--- a/workers_test.go
+++ b/workers_test.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (


### PR DESCRIPTION
While adding support to `cf` for workers I noticed I could not
get UploadWorker to succeed. I tracked down the issue to be all
the confusing string interpolation going on here.

 - Script string is passed to UploadWorker
 - UploadWorker passes script string to makeRequest as bytes
 - makeRequest json.Marshals this byte array which mangles it

If we attempt to cast the params passed to makeRequest as a byte
array and just avoid marshalling when the params looks like bytes
then we can upload the script raw without issues.