### PR TITLE
Fix worker enterprise API behavior

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -65,8 +65,8 @@ type WorkerScriptResponse struct {
 //
 // API reference: https://api.cloudflare.com/#worker-script-delete-worker
 func (api *API) DeleteWorker(requestParams *WorkerRequestParams) (WorkerScriptResponse, error) {
-	// if organization ID is defined and ScriptName is provided we will treat as org request
-	if api.organizationID != "" && requestParams.ScriptName != "" {
+	// if ScriptName is provided we will treat as org request
+	if requestParams.ScriptName != "" {
 		return api.deleteWorkerWithName(requestParams.ScriptName)
 	}
 	uri := "/zones/" + requestParams.ZoneID + "/workers/script"
@@ -108,7 +108,7 @@ func (api *API) deleteWorkerWithName(scriptName string) (WorkerScriptResponse, e
 //
 // API reference: https://api.cloudflare.com/#worker-script-download-worker
 func (api *API) DownloadWorker(requestParams *WorkerRequestParams) (WorkerScriptResponse, error) {
-	if api.organizationID != "" && requestParams.ScriptName != "" {
+	if requestParams.ScriptName != "" {
 		return api.downloadWorkerWithName(requestParams.ScriptName)
 	}
 	uri := "/zones/" + requestParams.ZoneID + "/workers/script"
@@ -168,7 +168,7 @@ func (api *API) ListWorkerScripts() (WorkerListResponse, error) {
 //
 // API reference: https://api.cloudflare.com/#worker-script-upload-worker
 func (api *API) UploadWorker(requestParams *WorkerRequestParams, data string) (WorkerScriptResponse, error) {
-	if api.organizationID != "" && requestParams.ScriptName != "" {
+	if requestParams.ScriptName != "" {
 		return api.uploadWorkerWithName(requestParams.ScriptName, data)
 	}
 	uri := "/zones/" + requestParams.ZoneID + "/workers/script"

--- a/workers.go
+++ b/workers.go
@@ -210,9 +210,8 @@ func (api *API) uploadWorkerWithName(scriptName string, data string) (WorkerScri
 func getRoutesPathComponent(api *API) string {
 	if api.organizationID == "" {
 		return "filters"
-	} else {
-		return "routes"
 	}
+	return "routes"
 }
 
 // CreateWorkerRoute creates worker route for a zone

--- a/workers.go
+++ b/workers.go
@@ -207,11 +207,20 @@ func (api *API) uploadWorkerWithName(scriptName string, data string) (WorkerScri
 	return r, nil
 }
 
+func getRoutesPathComponent(api *API) string {
+	if api.organizationID == "" {
+		return "filters"
+	} else {
+		return "routes"
+	}
+}
+
 // CreateWorkerRoute creates worker route for a zone
 //
 // API reference: https://api.cloudflare.com/#worker-filters-create-filter
 func (api *API) CreateWorkerRoute(zoneID string, route WorkerRoute) (WorkerRouteResponse, error) {
-	uri := "/zones/" + zoneID + "/workers/filters"
+	pathComponent := getRoutesPathComponent(api)
+	uri := "/zones/" + zoneID + "/workers/" + pathComponent
 	res, err := api.makeRequest("POST", uri, route)
 	if err != nil {
 		return WorkerRouteResponse{}, errors.Wrap(err, errMakeRequestError)
@@ -228,7 +237,8 @@ func (api *API) CreateWorkerRoute(zoneID string, route WorkerRoute) (WorkerRoute
 //
 // API reference: https://api.cloudflare.com/#worker-filters-delete-filter
 func (api *API) DeleteWorkerRoute(zoneID string, routeID string) (WorkerRouteResponse, error) {
-	uri := "/zones/" + zoneID + "/workers/filters/" + routeID
+	pathComponent := getRoutesPathComponent(api)
+	uri := "/zones/" + zoneID + "/workers/" + pathComponent + "/" + routeID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
 		return WorkerRouteResponse{}, errors.Wrap(err, errMakeRequestError)
@@ -245,7 +255,8 @@ func (api *API) DeleteWorkerRoute(zoneID string, routeID string) (WorkerRouteRes
 //
 // API reference: https://api.cloudflare.com/#worker-filters-list-filters
 func (api *API) ListWorkerRoutes(zoneID string) (WorkerRoutesResponse, error) {
-	uri := "/zones/" + zoneID + "/workers/filters"
+	pathComponent := getRoutesPathComponent(api)
+	uri := "/zones/" + zoneID + "/workers/" + pathComponent
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
 		return WorkerRoutesResponse{}, errors.Wrap(err, errMakeRequestError)
@@ -262,7 +273,8 @@ func (api *API) ListWorkerRoutes(zoneID string) (WorkerRoutesResponse, error) {
 //
 // API reference: https://api.cloudflare.com/#worker-filters-update-filter
 func (api *API) UpdateWorkerRoute(zoneID string, routeID string, route WorkerRoute) (WorkerRouteResponse, error) {
-	uri := "/zones/" + zoneID + "/workers/filters/" + routeID
+	pathComponent := getRoutesPathComponent(api)
+	uri := "/zones/" + zoneID + "/workers/" + pathComponent + "/" + routeID
 	res, err := api.makeRequest("PUT", uri, route)
 	if err != nil {
 		return WorkerRouteResponse{}, errors.Wrap(err, errMakeRequestError)

--- a/workers_test.go
+++ b/workers_test.go
@@ -124,6 +124,14 @@ func TestWorkers_DeleteWorkerWithName(t *testing.T) {
 	}
 }
 
+func TestWorkers_DeleteWorkerWithNameErrorsWithoutOrgId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.DeleteWorker(&WorkerRequestParams{ScriptName: "bar"})
+	assert.Error(t, err)
+}
+
 func TestWorkers_DownloadWorker(t *testing.T) {
 	setup()
 	defer teardown()
@@ -162,6 +170,14 @@ func TestWorkers_DownloadWorkerWithName(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, want.Script, res.Script)
 	}
+}
+
+func TestWorkers_DownloadWorkerWithNameErrorsWithoutOrgId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.DownloadWorker(&WorkerRequestParams{ScriptName: "bar"})
+	assert.Error(t, err)
 }
 
 func TestWorkers_ListWorkerScripts(t *testing.T) {
@@ -247,6 +263,14 @@ func TestWorkers_UploadWorkerWithName(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, res)
 	}
+}
+
+func TestWorkers_UploadWorkerWithNameErrorsWithoutOrgId(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.UploadWorker(&WorkerRequestParams{ScriptName: "bar"}, workerScript)
+	assert.Error(t, err)
 }
 
 func TestWorkers_CreateWorkerRoute(t *testing.T) {


### PR DESCRIPTION
Workers have a separate API for enterprise customers that supports multi-script functionality https://developers.cloudflare.com/workers/api/config-api-for-enterprise/

This PR addresses 2 issues with using the enterprise API
- Currently if an enterprise user tries to set a `ScriptName` but forgets to set their `organizationID`, calls to create/update/delete a worker will just silently ignore their `ScriptName` parameter which is probably not what they want. This PR changes it so that if a `ScriptName` is provided, it will return an error unless the `organizationID` is also set
- The enterprise API has different endpoints for setting routes that allows for mapping routes to a particular script. This PR will use those endpoints (`/routes/`) instead of the non-enterprise endpoints (`/filters/`) when an `organizationID` is set