### PR TITLE
feat(api): initial context support

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -101,18 +101,22 @@ func (api *API) ZoneIDByName(zoneName string) (string, error) {
 // makeRequest makes a HTTP request and returns the body as a byte slice,
 // closing it before returnng. params will be serialized to JSON.
 func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, error) {
-	return api.makeRequestWithAuthType(method, uri, params, api.authType)
+	return api.makeRequestWithAuthType(context.TODO(), method, uri, params, api.authType)
+}
+
+func (api *API) makeRequestContext(ctx context.Context, method, uri string, params interface{}) ([]byte, error) {
+	return api.makeRequestWithAuthType(ctx, method, uri, params, api.authType)
 }
 
 func (api *API) makeRequestWithHeaders(method, uri string, params interface{}, headers http.Header) ([]byte, error) {
-	return api.makeRequestWithAuthTypeAndHeaders(method, uri, params, api.authType, headers)
+	return api.makeRequestWithAuthTypeAndHeaders(context.TODO(), method, uri, params, api.authType, headers)
 }
 
-func (api *API) makeRequestWithAuthType(method, uri string, params interface{}, authType int) ([]byte, error) {
-	return api.makeRequestWithAuthTypeAndHeaders(method, uri, params, authType, nil)
+func (api *API) makeRequestWithAuthType(ctx context.Context, method, uri string, params interface{}, authType int) ([]byte, error) {
+	return api.makeRequestWithAuthTypeAndHeaders(ctx, method, uri, params, authType, nil)
 }
 
-func (api *API) makeRequestWithAuthTypeAndHeaders(method, uri string, params interface{}, authType int, headers http.Header) ([]byte, error) {
+func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, uri string, params interface{}, authType int, headers http.Header) ([]byte, error) {
 	// Replace nil with a JSON object if needed
 	var jsonBody []byte
 	var err error
@@ -155,7 +159,7 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(method, uri string, params int
 		if err != nil {
 			return nil, errors.Wrap(err, "Error caused by request rate limiting")
 		}
-		resp, respErr = api.request(method, uri, reqBody, authType, headers)
+		resp, respErr = api.request(ctx, method, uri, reqBody, authType, headers)
 
 		// retry if the server is rate limiting us or if it failed
 		// assumes server operations are rolled back on failure
@@ -214,11 +218,12 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(method, uri string, params int
 // request makes a HTTP request to the given API endpoint, returning the raw
 // *http.Response, or an error if one occurred. The caller is responsible for
 // closing the response body.
-func (api *API) request(method, uri string, reqBody io.Reader, authType int, headers http.Header) (*http.Response, error) {
+func (api *API) request(ctx context.Context, method, uri string, reqBody io.Reader, authType int, headers http.Header) (*http.Response, error) {
 	req, err := http.NewRequest(method, api.BaseURL+uri, reqBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request creation failed")
 	}
+	req.WithContext(ctx)
 
 	combinedHeaders := make(http.Header)
 	copyHeader(combinedHeaders, api.headers)

--- a/origin_ca.go
+++ b/origin_ca.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"time"
@@ -57,7 +58,7 @@ type originCACertificateResponseRevoke struct {
 // API reference: https://api.cloudflare.com/#cloudflare-ca-create-certificate
 func (api *API) CreateOriginCertificate(certificate OriginCACertificate) (*OriginCACertificate, error) {
 	uri := "/certificates"
-	res, err := api.makeRequestWithAuthType("POST", uri, certificate, AuthUserService)
+	res, err := api.makeRequestWithAuthType(context.TODO(), "POST", uri, certificate, AuthUserService)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)
@@ -89,7 +90,7 @@ func (api *API) OriginCertificates(options OriginCACertificateListOptions) ([]Or
 		v.Set("zone_id", options.ZoneID)
 	}
 	uri := "/certificates" + "?" + v.Encode()
-	res, err := api.makeRequestWithAuthType("GET", uri, nil, AuthUserService)
+	res, err := api.makeRequestWithAuthType(context.TODO(), "GET", uri, nil, AuthUserService)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)
@@ -117,7 +118,7 @@ func (api *API) OriginCertificates(options OriginCACertificateListOptions) ([]Or
 // API reference: https://api.cloudflare.com/#cloudflare-ca-certificate-details
 func (api *API) OriginCertificate(certificateID string) (*OriginCACertificate, error) {
 	uri := "/certificates/" + certificateID
-	res, err := api.makeRequestWithAuthType("GET", uri, nil, AuthUserService)
+	res, err := api.makeRequestWithAuthType(context.TODO(), "GET", uri, nil, AuthUserService)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)
@@ -145,7 +146,7 @@ func (api *API) OriginCertificate(certificateID string) (*OriginCACertificate, e
 // API reference: https://api.cloudflare.com/#cloudflare-ca-revoke-certificate
 func (api *API) RevokeOriginCertificate(certificateID string) (*OriginCACertificateID, error) {
 	uri := "/certificates/" + certificateID
-	res, err := api.makeRequestWithAuthType("DELETE", uri, nil, AuthUserService)
+	res, err := api.makeRequestWithAuthType(context.TODO(), "DELETE", uri, nil, AuthUserService)
 
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)


### PR DESCRIPTION
Add initial context support to the un-exported request infrastructure.
This will us to begin excepting context from user-facing endpoint
methods.