### PR TITLE
Added support for universal ssl setting

### DIFF
--- a/universal_ssl.go
+++ b/universal_ssl.go
@@ -1,0 +1,50 @@
+package cloudflare
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// UniversalSSLSetting represents a universal ssl setting's properties.
+type UniversalSSLSetting struct {
+	Enabled bool `json:"enabled"`
+}
+
+type universalSSLSettingResponse struct {
+	Response
+	Result UniversalSSLSetting `json:"result"`
+}
+
+// UniversalSSLSettingDetails returns the details for a universal ssl setting
+//
+// API reference: https://api.cloudflare.com/#universal-ssl-settings-for-a-zone-universal-ssl-settings-details
+func (api *API) UniversalSSLSettingDetails(zoneID string) (UniversalSSLSetting, error) {
+	uri := "/zones/" + zoneID + "/ssl/universal/settings"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return UniversalSSLSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r universalSSLSettingResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return UniversalSSLSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// EditUniversalSSLSetting edits the uniersal ssl setting for a zone
+//
+// API reference: https://api.cloudflare.com/#universal-ssl-settings-for-a-zone-edit-universal-ssl-settings
+func (api *API) EditUniversalSSLSetting(zoneID string, setting UniversalSSLSetting) (UniversalSSLSetting, error) {
+	uri := "/zones/" + zoneID + "/ssl/universal/settings"
+	res, err := api.makeRequest("PATCH", uri, setting)
+	if err != nil {
+		return UniversalSSLSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r universalSSLSettingResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return UniversalSSLSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+
+}

--- a/universal_ssl_test.go
+++ b/universal_ssl_test.go
@@ -1,0 +1,80 @@
+package cloudflare
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniversalSSLSettingDetails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testZoneID := "abcd123"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "enabled": true
+			}
+		  }`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/universal/settings", handler)
+
+	want := UniversalSSLSetting{
+		Enabled: true,
+	}
+
+	got, err := client.UniversalSSLSettingDetails(testZoneID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestEditUniversalSSLSetting(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testZoneID := "abcd123"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "Expected method 'PATCH', got %s", r.Method)
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		defer r.Body.Close()
+
+		assert.Equal(t, `{"enabled":true}`, string(body))
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "enabled": true
+			}
+		  }`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/universal/settings", handler)
+
+	want := UniversalSSLSetting{
+		Enabled: true,
+	}
+
+	got, err := client.EditUniversalSSLSetting(testZoneID, want)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}


### PR DESCRIPTION
Added support for getting and updating universal ssl setting for a specified zone.

API reference: https://api.cloudflare.com/#universal-ssl-settings-for-a-zone-properties