### PR TITLE
Add settings object to the custom_hostnames payload

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -8,13 +8,22 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CustomHostnameSSLSettings represents the SSL settings for a custom hostname.
+type CustomHostnameSSLSettings struct {
+	HTTP2         string   `json:"http2,omitempty"`
+	TLS13         string   `json:"tls_1_3,omitempty"`
+	MinTLSVersion string   `json:"min_tls_version,omitempty"`
+	Ciphers       []string `json:"ciphers,omitempty"`
+}
+
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
 type CustomHostnameSSL struct {
-	Status      string `json:"status,omitempty"`
-	Method      string `json:"method,omitempty"`
-	Type        string `json:"type,omitempty"`
-	CnameTarget string `json:"cname_target,omitempty"`
-	CnameName   string `json:"cname_name,omitempty"`
+	Status      string                    `json:"status,omitempty"`
+	Method      string                    `json:"method,omitempty"`
+	Type        string                    `json:"type,omitempty"`
+	CnameTarget string                    `json:"cname_target,omitempty"`
+	CnameName   string                    `json:"cname_name,omitempty"`
+	Settings    CustomHostnameSSLSettings `json:"settings,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -49,7 +49,10 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
       "method": "cname",
       "type": "dv",
       "cname_target": "dcv.digicert.com",
-      "cname_name": "810b7d5f01154524b961ba0cd578acc2.app.example.com"
+      "cname_name": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+      "settings": {
+        "http2": "on"
+      }
     }
   }
 }`)
@@ -67,6 +70,9 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 				Status:      "pending_validation",
 				CnameTarget: "dcv.digicert.com",
 				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				Settings: CustomHostnameSSLSettings{
+					HTTP2: "on",
+				},
 			},
 		},
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
@@ -150,7 +156,12 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
     "ssl": {
       "type": "dv",
       "method": "http",
-      "status": "active"
+      "status": "active",
+      "settings": {
+        "ciphers": ["ECDHE-RSA-AES128-GCM-SHA256","AES128-SHA"],
+        "http2": "on",
+        "min_tls_version": "1.2"
+      }
     },
     "custom_metadata": {
       "origin": "a.custom.origin"
@@ -168,6 +179,11 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
 			Status: "active",
 			Method: "http",
 			Type:   "dv",
+			Settings: CustomHostnameSSLSettings{
+				HTTP2:         "on",
+				MinTLSVersion: "1.2",
+				Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "AES128-SHA"},
+			},
 		},
 		CustomMetadata: CustomMetadata{"origin": "a.custom.origin"},
 	}


### PR DESCRIPTION
The custom_hostnames api can accept a `settings` object in the create and update methods. It also returns the `settings` object in its responses.
I've updated the tests (and manually tested against the real API)