### PR TITLE
Add firewall rules and filter support

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -200,6 +200,11 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(method, uri string, params int
 		resp.StatusCode == 523,
 		resp.StatusCode == 524:
 		return nil, errors.Errorf("HTTP status %d: service failure", resp.StatusCode)
+	// This isn't a great solution due to the way the `default` case is
+	// a catch all and that the `filters/validate-expr` returns a HTTP 400
+	// yet the clients need to use the HTTP body.
+	case resp.StatusCode == 400 && strings.HasSuffix(resp.Request.URL.Path, "/filters/validate-expr"):
+		return nil, errors.Errorf("%s", respBody)
 	default:
 		var s string
 		if respBody != nil {

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -202,7 +202,7 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(method, uri string, params int
 		return nil, errors.Errorf("HTTP status %d: service failure", resp.StatusCode)
 	// This isn't a great solution due to the way the `default` case is
 	// a catch all and that the `filters/validate-expr` returns a HTTP 400
-	// yet the clients need to use the HTTP body.
+	// yet the clients need to use the HTTP body as a JSON string.
 	case resp.StatusCode == 400 && strings.HasSuffix(resp.Request.URL.Path, "/filters/validate-expr"):
 		return nil, errors.Errorf("%s", respBody)
 	default:

--- a/filter.go
+++ b/filter.go
@@ -59,7 +59,7 @@ type FilterValidationExpressionMessage struct {
 
 // Filter returns a single filter in a zone based on the filter ID.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/get/#get-by-filter-id
 func (api *API) Filter(zoneID, filterID string) (Filter, error) {
 	uri := fmt.Sprintf("/zones/%s/filters/%s", zoneID, filterID)
 
@@ -79,7 +79,7 @@ func (api *API) Filter(zoneID, filterID string) (Filter, error) {
 
 // Filters returns all filters for a zone.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/get/#get-all-filters
 func (api *API) Filters(zoneID string, pageOpts PaginationOptions) ([]Filter, error) {
 	uri := "/zones/" + zoneID + "/filters"
 	v := url.Values{}
@@ -112,7 +112,7 @@ func (api *API) Filters(zoneID string, pageOpts PaginationOptions) ([]Filter, er
 
 // CreateFilters creates new filters.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/post/
 func (api *API) CreateFilters(zoneID string, filters []Filter) ([]Filter, error) {
 	uri := "/zones/" + zoneID + "/filters"
 
@@ -132,7 +132,7 @@ func (api *API) CreateFilters(zoneID string, filters []Filter) ([]Filter, error)
 
 // UpdateFilter updates a single filter.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/put/#update-a-single-filter
 func (api *API) UpdateFilter(zoneID string, filter Filter) (Filter, error) {
 	if filter.ID == "" {
 		return Filter{}, errors.Errorf("filter ID cannot be empty")
@@ -156,7 +156,7 @@ func (api *API) UpdateFilter(zoneID string, filter Filter) (Filter, error) {
 
 // UpdateFilters updates many filters at once.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/put/#update-multiple-filters
 func (api *API) UpdateFilters(zoneID string, filters []Filter) ([]Filter, error) {
 	for _, filter := range filters {
 		if filter.ID == "" {
@@ -182,7 +182,7 @@ func (api *API) UpdateFilters(zoneID string, filters []Filter) ([]Filter, error)
 
 // DeleteFilter deletes a single filter.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/delete/#delete-a-single-filter
 func (api *API) DeleteFilter(zoneID, filterID string) error {
 	if filterID == "" {
 		return errors.Errorf("filter ID cannot be empty")
@@ -200,7 +200,7 @@ func (api *API) DeleteFilter(zoneID, filterID string) error {
 
 // DeleteFilters deletes multiple filters.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/delete/#delete-multiple-filters
 func (api *API) DeleteFilters(zoneID string, filterIDs []string) error {
 	ids := strings.Join(filterIDs, ",")
 	uri := fmt.Sprintf("/zones/%s/filters?id=%s", zoneID, ids)
@@ -215,7 +215,7 @@ func (api *API) DeleteFilters(zoneID string, filterIDs []string) error {
 
 // ValidateFilterExpression checks correctness of a filter expression.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-filters/validation/
 func (api *API) ValidateFilterExpression(expression string) error {
 	uri := fmt.Sprintf("/filters/validate-expr")
 	expressionPayload := FilterValidateExpression{Expression: expression}

--- a/filter.go
+++ b/filter.go
@@ -110,3 +110,47 @@ func (api *API) Filters(zoneID string, pageOpts PaginationOptions) ([]Filter, er
 	return filtersResponse.Result, nil
 }
 
+// CreateFilters creates new filters.
+//
+// API reference: TBC
+func (api *API) CreateFilters(zoneID string, filters []Filter) ([]Filter, error) {
+	uri := "/zones/" + zoneID + "/filters"
+
+	res, err := api.makeRequest("POST", uri, filters)
+	if err != nil {
+		return []Filter{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var filtersResponse FiltersDetailResponse
+	err = json.Unmarshal(res, &filtersResponse)
+	if err != nil {
+		return []Filter{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return filtersResponse.Result, nil
+}
+
+// UpdateFilter updates a single filter.
+//
+// API reference: TBC
+func (api *API) UpdateFilter(zoneID string, filter Filter) (Filter, error) {
+	if filter.ID == "" {
+		return Filter{}, errors.Errorf("filter ID cannot be empty")
+	}
+
+	uri := fmt.Sprintf("/zones/%s/filters/%s", zoneID, filter.ID)
+
+	res, err := api.makeRequest("PUT", uri, filter)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var filterResponse FilterDetailResponse
+	err = json.Unmarshal(res, &filterResponse)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return filterResponse.Result, nil
+}
+

--- a/filter.go
+++ b/filter.go
@@ -154,3 +154,29 @@ func (api *API) UpdateFilter(zoneID string, filter Filter) (Filter, error) {
 	return filterResponse.Result, nil
 }
 
+// UpdateFilters updates many filters at once.
+//
+// API reference: TBC
+func (api *API) UpdateFilters(zoneID string, filters []Filter) ([]Filter, error) {
+	for _, filter := range filters {
+		if filter.ID == "" {
+			return []Filter{}, errors.Errorf("filter ID cannot be empty")
+		}
+	}
+
+	uri := "/zones/" + zoneID + "/filters"
+
+	res, err := api.makeRequest("PUT", uri, filters)
+	if err != nil {
+		return []Filter{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var filtersResponse FiltersDetailResponse
+	err = json.Unmarshal(res, &filtersResponse)
+	if err != nil {
+		return []Filter{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return filtersResponse.Result, nil
+}
+

--- a/filter.go
+++ b/filter.go
@@ -180,3 +180,36 @@ func (api *API) UpdateFilters(zoneID string, filters []Filter) ([]Filter, error)
 	return filtersResponse.Result, nil
 }
 
+// DeleteFilter deletes a single filter.
+//
+// API reference: TBC
+func (api *API) DeleteFilter(zoneID, filterID string) error {
+	if filterID == "" {
+		return errors.Errorf("filter ID cannot be empty")
+	}
+
+	uri := fmt.Sprintf("/zones/%s/filters/%s", zoneID, filterID)
+
+	_, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	return nil
+}
+
+// DeleteFilters deletes multiple filters.
+//
+// API reference: TBC
+func (api *API) DeleteFilters(zoneID string, filterIDs []string) error {
+	ids := strings.Join(filterIDs, ",")
+	uri := fmt.Sprintf("/zones/%s/filters?id=%s", zoneID, ids)
+
+	_, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	return nil
+}
+

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,78 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Filter holds the structure of the filter type.
+type Filter struct {
+	ID          string `json:"id,omitempty"`
+	Expression  string `json:"expression"`
+	Paused      bool   `json:"paused"`
+	Description string `json:"description"`
+
+	// Property is mentioned in documentation however isn't populated in
+	// any of the API requests. For now, let's just omit it unless it's
+	// provided.
+	Ref string `json:"ref,omitempty"`
+}
+
+// FiltersDetailResponse is the API response that is returned
+// for requesting all filters on a zone.
+type FiltersDetailResponse struct {
+	Result     []Filter `json:"result"`
+	ResultInfo `json:"result_info"`
+	Response
+}
+
+// FilterDetailResponse is the API response that is returned
+// for requesting a single filter on a zone.
+type FilterDetailResponse struct {
+	Result     Filter `json:"result"`
+	ResultInfo `json:"result_info"`
+	Response
+}
+
+// FilterValidateExpression represents the JSON payload for checking
+// an expression.
+type FilterValidateExpression struct {
+	Expression string `json:"expression"`
+}
+
+// FilterValidateExpressionResponse represents the API response for
+// checking the expression. It conforms to the JSON API approach however
+// we don't need all of the fields exposed.
+type FilterValidateExpressionResponse struct {
+	Success bool                                `json:"success"`
+	Errors  []FilterValidationExpressionMessage `json:"errors"`
+}
+
+type FilterValidationExpressionMessage struct {
+	Message string `json:"message"`
+}
+
+// Filter returns a single filter in a zone based on the filter ID.
+//
+// API reference: TBC
+func (api *API) Filter(zoneID, filterID string) (Filter, error) {
+	uri := fmt.Sprintf("/zones/%s/filters/%s", zoneID, filterID)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var filterResponse FilterDetailResponse
+	err = json.Unmarshal(res, &filterResponse)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return filterResponse.Result, nil
+}

--- a/filter.go
+++ b/filter.go
@@ -76,3 +76,37 @@ func (api *API) Filter(zoneID, filterID string) (Filter, error) {
 
 	return filterResponse.Result, nil
 }
+
+// Filters returns all filters for a zone.
+//
+// API reference: TBC
+func (api *API) Filters(zoneID string, pageOpts PaginationOptions) ([]Filter, error) {
+	uri := "/zones/" + zoneID + "/filters"
+	v := url.Values{}
+
+	if pageOpts.PerPage > 0 {
+		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
+	}
+
+	if pageOpts.Page > 0 {
+		v.Set("page", strconv.Itoa(pageOpts.Page))
+	}
+
+	if len(v) > 0 {
+		uri = uri + "?" + v.Encode()
+	}
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []Filter{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var filtersResponse FiltersDetailResponse
+	err = json.Unmarshal(res, &filtersResponse)
+	if err != nil {
+		return []Filter{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return filtersResponse.Result, nil
+}
+

--- a/filter.go
+++ b/filter.go
@@ -53,6 +53,8 @@ type FilterValidateExpressionResponse struct {
 	Errors  []FilterValidationExpressionMessage `json:"errors"`
 }
 
+// FilterValidationExpressionMessage holds the message value from the
+// API response for validating expressions.
 type FilterValidationExpressionMessage struct {
 	Message string `json:"message"`
 }

--- a/filter.go
+++ b/filter.go
@@ -213,3 +213,28 @@ func (api *API) DeleteFilters(zoneID string, filterIDs []string) error {
 	return nil
 }
 
+// ValidateFilterExpression checks correctness of a filter expression.
+//
+// API reference: TBC
+func (api *API) ValidateFilterExpression(expression string) error {
+	uri := fmt.Sprintf("/filters/validate-expr")
+	expressionPayload := FilterValidateExpression{Expression: expression}
+
+	_, err := api.makeRequest("POST", uri, expressionPayload)
+	if err != nil {
+		var filterValidationResponse FilterValidateExpressionResponse
+
+		jsonErr := json.Unmarshal([]byte(err.Error()), &filterValidationResponse)
+		if jsonErr != nil {
+			return errors.Wrap(jsonErr, errUnmarshalError)
+		}
+
+		if filterValidationResponse.Success != true {
+			// Unsure why but the API returns `errors` as an array but it only
+			// ever shows the issue with one problem at a time ¯\_(ツ)_/¯
+			return errors.Errorf(filterValidationResponse.Errors[0].Message)
+		}
+	}
+
+	return nil
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -229,3 +229,91 @@ func TestCreateMultipleFilters(t *testing.T) {
 	}
 }
 
+func TestUpdateSingleFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": {
+					"id": "60ee852f9cbb4802978d15600c7f3110",
+					"paused": false,
+					"description": "IP of example.org",
+					"expression": "ip.src eq 93.184.216.0"
+			},
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110", handler)
+	want := Filter{
+		ID:          "60ee852f9cbb4802978d15600c7f3110",
+		Paused:      false,
+		Description: "IP of example.org",
+		Expression:  "ip.src eq 93.184.216.0",
+	}
+
+	actual, err := client.UpdateFilter("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateMultipleFilters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [
+				{
+					"id": "60ee852f9cbb4802978d15600c7f3110",
+					"paused": false,
+					"description": "IP of example.org",
+					"expression": "ip.src eq 93.184.216.0"
+				},
+				{
+					"id": "c218c536b2bd406f958f278cf0fa8c0f",
+					"paused": false,
+					"description": "IP of example.com",
+					"expression": "ip.src ne 127.0.0.1"
+				}
+			],
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	want := []Filter{
+		Filter{
+			ID:          "60ee852f9cbb4802978d15600c7f3110",
+			Paused:      false,
+			Description: "IP of example.org",
+			Expression:  "ip.src eq 93.184.216.0",
+		},
+		Filter{
+			ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+			Paused:      false,
+			Description: "IP of example.com",
+			Expression:  "ip.src ne 127.0.0.1",
+		},
+	}
+
+	actual, err := client.UpdateFilters("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+

--- a/filter_test.go
+++ b/filter_test.go
@@ -49,3 +49,91 @@ func TestFilter(t *testing.T) {
 	}
 }
 
+func TestFilters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [
+					{
+						"id": "b7ff25282d394be7b945e23c7106ce8a",
+						"paused": false,
+						"description": "Login from office",
+						"expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
+					},
+					{
+						"id": "c218c536b2bd406f958f278cf0fa8c0f",
+						"paused": false,
+						"description": "Login",
+						"expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
+					},
+					{
+						"id": "f2a64520581a4209aab12187a0081364",
+						"paused": false,
+						"description": "not /api",
+						"expression": "not http.request.uri.path matches \"^/api/.*$\""
+			}, {
+						"id": "14217d7bd5ab435e84b1bd468bf4fb9f",
+						"paused": false,
+						"description": "/api",
+						"expression": "http.request.uri.path matches \"^/api/.*$\""
+			}, {
+						"id": "60ee852f9cbb4802978d15600c7f3110",
+						"paused": false,
+						"expression": "ip.src eq 93.184.216.0"
+			} ],
+				"success": true,
+				"errors": null,
+				"messages": null,
+				"result_info": {
+					"page": 1,
+					"per_page": 25,
+					"count": 5,
+					"total_count": 5,
+					"total_pages": 1
+			} }
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	want := []Filter{
+		Filter{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from office",
+			Expression:  "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+		},
+		Filter{
+			ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+			Paused:      false,
+			Description: "Login",
+			Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+		},
+		Filter{
+			ID:          "f2a64520581a4209aab12187a0081364",
+			Paused:      false,
+			Description: "not /api",
+			Expression:  "not http.request.uri.path matches \"^/api/.*$\"",
+		},
+		Filter{
+			ID:          "14217d7bd5ab435e84b1bd468bf4fb9f",
+			Paused:      false,
+			Description: "/api",
+			Expression:  "http.request.uri.path matches \"^/api/.*$\"",
+		}, Filter{
+			ID:         "60ee852f9cbb4802978d15600c7f3110",
+			Paused:     false,
+			Expression: "ip.src eq 93.184.216.0",
+		},
+	}
+
+	actual, err := client.Filters("d56084adb405e0b7e32c52321bf07be6", pageOpts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+

--- a/filter_test.go
+++ b/filter_test.go
@@ -344,20 +344,6 @@ func TestDeleteFilterWithMissingID(t *testing.T) {
 	setup()
 	defer teardown()
 
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, `{
-			"result": [],
-			"success": true,
-			"errors": null,
-			"messages": null
-		}
-		`)
-	}
-
-	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110", handler)
-
 	err := client.DeleteFilter("d56084adb405e0b7e32c52321bf07be6", "")
 	assert.EqualError(t, err, "filter ID cannot be empty")
 }

--- a/filter_test.go
+++ b/filter_test.go
@@ -137,3 +137,95 @@ func TestFilters(t *testing.T) {
 	}
 }
 
+func TestCreateSingleFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [
+				{
+					"id": "b7ff25282d394be7b945e23c7106ce8a",
+					"paused": false,
+					"description": "Login from office",
+					"expression": "ip.src eq 127.0.0.1"
+				}
+			],
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	want := []Filter{
+		Filter{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from office",
+			Expression:  "ip.src eq 127.0.0.1",
+		},
+	}
+
+	actual, err := client.CreateFilters("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateMultipleFilters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [
+				{
+					"id": "b7ff25282d394be7b945e23c7106ce8a",
+					"paused": false,
+					"description": "Login from office",
+					"expression": "ip.src eq 127.0.0.1"
+				},
+				{
+					"id": "b7ff25282d394be7b945e23c7106ce8a",
+					"paused": false,
+					"description": "Login from second office",
+					"expression": "ip.src eq 10.0.0.1"
+				}
+			],
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	want := []Filter{
+		Filter{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from office",
+			Expression:  "ip.src eq 127.0.0.1",
+		},
+		Filter{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from second office",
+			Expression:  "ip.src eq 10.0.0.1",
+		},
+	}
+
+	actual, err := client.CreateFilters("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+

--- a/filter_test.go
+++ b/filter_test.go
@@ -317,3 +317,47 @@ func TestUpdateMultipleFilters(t *testing.T) {
 	}
 }
 
+func TestDeleteFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [],
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110", handler)
+
+	err := client.DeleteFilter("d56084adb405e0b7e32c52321bf07be6", "60ee852f9cbb4802978d15600c7f3110")
+	assert.Nil(t, err)
+	assert.NoError(t, err)
+}
+
+func TestDeleteFilterWithMissingID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [],
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110", handler)
+
+	err := client.DeleteFilter("d56084adb405e0b7e32c52321bf07be6", "")
+	assert.EqualError(t, err, "filter ID cannot be empty")
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,51 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var pageOpts = PaginationOptions{
+	PerPage: 25,
+	Page:    1,
+}
+
+func TestFilter(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": {
+				"id": "b7ff25282d394be7b945e23c7106ce8a",
+				"paused": false,
+				"description": "Login from office",
+				"expression": "ip.src eq 127.0.0.1"
+			},
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters/b7ff25282d394be7b945e23c7106ce8a", handler)
+	want := Filter{
+		ID:          "b7ff25282d394be7b945e23c7106ce8a",
+		Paused:      false,
+		Description: "Login from office",
+		Expression:  "ip.src eq 127.0.0.1",
+	}
+
+	actual, err := client.Filter("d56084adb405e0b7e32c52321bf07be6", "b7ff25282d394be7b945e23c7106ce8a")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -41,7 +41,7 @@ type FirewallRuleResponse struct {
 
 // FirewallRules returns all firewall rules.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/get/#get-all-rules
 func (api *API) FirewallRules(zoneID string, pageOpts PaginationOptions) ([]FirewallRule, error) {
 	uri := fmt.Sprintf("/zones/%s/firewall/rules", zoneID)
 	v := url.Values{}
@@ -74,7 +74,7 @@ func (api *API) FirewallRules(zoneID string, pageOpts PaginationOptions) ([]Fire
 
 // FirewallRule returns a single firewall rule based on the ID.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/get/#get-by-rule-id
 func (api *API) FirewallRule(zoneID, firewallRuleID string) (FirewallRule, error) {
 	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", zoneID, firewallRuleID)
 
@@ -94,7 +94,7 @@ func (api *API) FirewallRule(zoneID, firewallRuleID string) (FirewallRule, error
 
 // CreateFirewallRules creates new firewall rules.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/post/
 func (api *API) CreateFirewallRules(zoneID string, firewallRules []FirewallRule) ([]FirewallRule, error) {
 	uri := fmt.Sprintf("/zones/%s/firewall/rules", zoneID)
 
@@ -114,7 +114,7 @@ func (api *API) CreateFirewallRules(zoneID string, firewallRules []FirewallRule)
 
 // UpdateFirewallRule updates a single firewall rule.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/put/#update-a-single-rule
 func (api *API) UpdateFirewallRule(zoneID string, firewallRule FirewallRule) (FirewallRule, error) {
 	if firewallRule.ID == "" {
 		return FirewallRule{}, errors.Errorf("firewall rule ID cannot be empty")
@@ -138,7 +138,7 @@ func (api *API) UpdateFirewallRule(zoneID string, firewallRule FirewallRule) (Fi
 
 // UpdateFirewallRules updates a single firewall rule.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/put/#update-multiple-rules
 func (api *API) UpdateFirewallRules(zoneID string, firewallRules []FirewallRule) ([]FirewallRule, error) {
 	for _, firewallRule := range firewallRules {
 		if firewallRule.ID == "" {
@@ -164,7 +164,7 @@ func (api *API) UpdateFirewallRules(zoneID string, firewallRules []FirewallRule)
 
 // DeleteFirewallRule updates a single firewall rule.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/delete/#delete-a-single-rule
 func (api *API) DeleteFirewallRule(zoneID, firewallRuleID string) error {
 	if firewallRuleID == "" {
 		return errors.Errorf("firewall rule ID cannot be empty")
@@ -182,7 +182,7 @@ func (api *API) DeleteFirewallRule(zoneID, firewallRuleID string) error {
 
 // DeleteFirewallRules updates a single firewall rule.
 //
-// API reference: TBC
+// API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/delete/#delete-multiple-rules
 func (api *API) DeleteFirewallRules(zoneID string, firewallRuleIDs []string) error {
 	ids := strings.Join(firewallRuleIDs, ",")
 	uri := fmt.Sprintf("/zones/%s/firewall/rules?id=%s", zoneID, ids)

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -72,3 +72,23 @@ func (api *API) FirewallRules(zoneID string, pageOpts PaginationOptions) ([]Fire
 	return firewallDetailResponse.Result, nil
 }
 
+// FirewallRule returns a single firewall rule based on the ID.
+//
+// API reference: TBC
+func (api *API) FirewallRule(zoneID, firewallRuleID string) (FirewallRule, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", zoneID, firewallRuleID)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return FirewallRule{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var firewallRuleResponse FirewallRuleResponse
+	err = json.Unmarshal(res, &firewallRuleResponse)
+	if err != nil {
+		return FirewallRule{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return firewallRuleResponse.Result, nil
+}
+

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -162,3 +162,35 @@ func (api *API) UpdateFirewallRules(zoneID string, firewallRules []FirewallRule)
 	return firewallRulesDetailResponse.Result, nil
 }
 
+// DeleteFirewallRule updates a single firewall rule.
+//
+// API reference: TBC
+func (api *API) DeleteFirewallRule(zoneID, firewallRuleID string) error {
+	if firewallRuleID == "" {
+		return errors.Errorf("firewall rule ID cannot be empty")
+	}
+
+	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", zoneID, firewallRuleID)
+
+	_, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	return nil
+}
+
+// DeleteFirewallRules updates a single firewall rule.
+//
+// API reference: TBC
+func (api *API) DeleteFirewallRules(zoneID string, firewallRuleIDs []string) error {
+	ids := strings.Join(firewallRuleIDs, ",")
+	uri := fmt.Sprintf("/zones/%s/firewall/rules?id=%s", zoneID, ids)
+
+	_, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	return nil
+}

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -92,3 +92,23 @@ func (api *API) FirewallRule(zoneID, firewallRuleID string) (FirewallRule, error
 	return firewallRuleResponse.Result, nil
 }
 
+// CreateFirewallRules creates new firewall rules.
+//
+// API reference: TBC
+func (api *API) CreateFirewallRules(zoneID string, firewallRules []FirewallRule) ([]FirewallRule, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/rules", zoneID)
+
+	res, err := api.makeRequest("POST", uri, firewallRules)
+	if err != nil {
+		return []FirewallRule{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var firewallRulesDetailResponse FirewallRulesDetailResponse
+	err = json.Unmarshal(res, &firewallRulesDetailResponse)
+	if err != nil {
+		return []FirewallRule{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return firewallRulesDetailResponse.Result, nil
+}
+

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -112,3 +112,53 @@ func (api *API) CreateFirewallRules(zoneID string, firewallRules []FirewallRule)
 	return firewallRulesDetailResponse.Result, nil
 }
 
+// UpdateFirewallRule updates a single firewall rule.
+//
+// API reference: TBC
+func (api *API) UpdateFirewallRule(zoneID string, firewallRule FirewallRule) (FirewallRule, error) {
+	if firewallRule.ID == "" {
+		return FirewallRule{}, errors.Errorf("firewall rule ID cannot be empty")
+	}
+
+	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", zoneID, firewallRule.ID)
+
+	res, err := api.makeRequest("POST", uri, firewallRule)
+	if err != nil {
+		return FirewallRule{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var firewallRuleResponse FirewallRuleResponse
+	err = json.Unmarshal(res, &firewallRuleResponse)
+	if err != nil {
+		return FirewallRule{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return firewallRuleResponse.Result, nil
+}
+
+// UpdateFirewallRules updates a single firewall rule.
+//
+// API reference: TBC
+func (api *API) UpdateFirewallRules(zoneID string, firewallRules []FirewallRule) ([]FirewallRule, error) {
+	for _, firewallRule := range firewallRules {
+		if firewallRule.ID == "" {
+			return []FirewallRule{}, errors.Errorf("firewall ID cannot be empty")
+		}
+	}
+
+	uri := fmt.Sprintf("/zones/%s/firewall/rules", zoneID)
+
+	res, err := api.makeRequest("POST", uri, firewallRules)
+	if err != nil {
+		return []FirewallRule{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var firewallRulesDetailResponse FirewallRulesDetailResponse
+	err = json.Unmarshal(res, &firewallRulesDetailResponse)
+	if err != nil {
+		return []FirewallRule{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return firewallRulesDetailResponse.Result, nil
+}
+

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -151,3 +151,53 @@ func TestFirewallRules(t *testing.T) {
 	}
 }
 
+func TestFirewallRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result":{
+				"id":"f2d427378e7542acb295380d352e2ebd",
+				"paused":false,
+				"description":"do not challenge login from office",
+				"action":"allow",
+				"priority":null,
+				"filter":{
+					"id":"b7ff25282d394be7b945e23c7106ce8a",
+					"expression":"ip.src in {127.0.0.1} ~ \"^.*/login.php$\")",
+					"paused":false,
+					"description":"Login from office"
+				}
+			},
+			"success":true,
+			"errors":null,
+			"messages":null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/f2d427378e7542acb295380d352e2ebd", handler)
+	want := FirewallRule{
+		ID:          "f2d427378e7542acb295380d352e2ebd",
+		Paused:      false,
+		Description: "do not challenge login from office",
+		Action:      "allow",
+		Priority:    nil,
+		Filter: Filter{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Expression:  "ip.src in {127.0.0.1} ~ \"^.*/login.php$\")",
+			Paused:      false,
+			Description: "Login from office",
+		},
+	}
+
+	actual, err := client.FirewallRule("d56084adb405e0b7e32c52321bf07be6", "f2d427378e7542acb295380d352e2ebd")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -201,3 +201,137 @@ func TestFirewallRule(t *testing.T) {
 	}
 }
 
+func TestCreateSingleFirewallRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result":[
+				{
+					"id":"f2d427378e7542acb295380d352e2ebd",
+					"paused":false,
+					"description":"do not challenge login from office",
+					"action":"allow",
+					"priority":null,
+					"filter":{
+						"id":"b7ff25282d394be7b945e23c7106ce8a",
+						"expression":"ip.src in {127.0.0.0/24}",
+						"paused":false,
+						"description":"Login from office"
+					}
+				}
+			],
+			"success":true,
+			"errors":null,
+			"messages":null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	want := []FirewallRule{
+		FirewallRule{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "ip.src in {127.0.0.0/24}",
+				Paused:      false,
+				Description: "Login from office",
+			},
+		},
+	}
+
+	actual, err := client.CreateFirewallRules("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateMultipleFirewallRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result":[
+				{
+					"id":"f2d427378e7542acb295380d352e2ebd",
+					"paused":false,
+					"description":"do not challenge login from office",
+					"action":"allow",
+					"priority":null,
+					"filter":{
+						"id":"b7ff25282d394be7b945e23c7106ce8a",
+						"expression":"ip.src in {127.0.0.0/24}",
+						"paused":false,
+						"description":"Login from office"
+					}
+				},
+				{
+					"id":"cbf4b7a5a2a24e59a03044d6d44ceb09",
+					"paused":false,
+					"description":"challenge login",
+					"action":"challenge",
+					"priority":null,
+					"filter":{
+						"id":"c218c536b2bd406f958f278cf0fa8c0f",
+						"expression":"(http.request.uri.path ~ \"^.*/wp-login.php$\")",
+						"paused":false,
+						"description":"Login"
+					}
+				}
+			],
+			"success":true,
+			"errors":null,
+			"messages":null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	want := []FirewallRule{
+		FirewallRule{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "ip.src in {127.0.0.0/24}",
+				Paused:      false,
+				Description: "Login from office",
+			},
+		},
+		FirewallRule{
+			ID:          "cbf4b7a5a2a24e59a03044d6d44ceb09",
+			Paused:      false,
+			Description: "challenge login",
+			Action:      "challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+				Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\")",
+				Paused:      false,
+				Description: "Login",
+			},
+		},
+	}
+
+	actual, err := client.CreateFirewallRules("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -335,3 +335,155 @@ func TestCreateMultipleFirewallRules(t *testing.T) {
 	}
 }
 
+func TestUpdateFirewallRuleWithMissingID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	want := FirewallRule{
+		ID:          "",
+		Paused:      false,
+		Description: "challenge site",
+		Action:      "challenge",
+		Priority:    nil,
+		Filter: Filter{
+			ID:          "f2a64520581a4209aab12187a0081364",
+			Expression:  "not http.request.uri.path matches \"^/api/.*$\"",
+			Paused:      false,
+			Description: "not /api",
+		},
+	}
+
+	_, err := client.UpdateFirewallRule("d56084adb405e0b7e32c52321bf07be6", want)
+	assert.EqualError(t, err, "firewall rule ID cannot be empty")
+}
+
+func TestUpdateSingleFirewallRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result":{
+				"id":"52161eb6af4241bb9d4b32394be72fdf",
+				"paused":false,
+				"description":"challenge site",
+				"action":"challenge",
+				"priority":null,
+				"filter":{
+					"id":"f2a64520581a4209aab12187a0081364",
+					"expression":"not http.request.uri.path matches \"^/api/.*$\"",
+					"paused":false,
+					"description":"not /api"
+				}
+			},
+			"success":true,
+			"errors":null,
+			"messages":null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/52161eb6af4241bb9d4b32394be72fdf", handler)
+	want := FirewallRule{
+		ID:          "52161eb6af4241bb9d4b32394be72fdf",
+		Paused:      false,
+		Description: "challenge site",
+		Action:      "challenge",
+		Priority:    nil,
+		Filter: Filter{
+			ID:          "f2a64520581a4209aab12187a0081364",
+			Expression:  "not http.request.uri.path matches \"^/api/.*$\"",
+			Paused:      false,
+			Description: "not /api",
+		},
+	}
+
+	actual, err := client.UpdateFirewallRule("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateMultipleFirewallRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result":[
+				{
+					"id":"f2d427378e7542acb295380d352e2ebd",
+					"paused":false,
+					"description":"do not challenge login from office",
+					"action":"allow",
+					"priority":null,
+					"filter":{
+						"id":"b7ff25282d394be7b945e23c7106ce8a",
+						"expression":"ip.src in {127.0.0.0/24}",
+						"paused":false,
+						"description":"Login from office"
+					}
+				},
+				{
+					"id":"cbf4b7a5a2a24e59a03044d6d44ceb09",
+					"paused":false,
+					"description":"challenge login",
+					"action":"challenge",
+					"priority":null,
+					"filter":{
+						"id":"c218c536b2bd406f958f278cf0fa8c0f",
+						"expression":"(http.request.uri.path ~ \"^.*/wp-login.php$\")",
+						"paused":false,
+						"description":"Login"
+					}
+				}
+			],
+			"success":true,
+			"errors":null,
+			"messages":null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	want := []FirewallRule{
+		FirewallRule{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "ip.src in {127.0.0.0/24}",
+				Paused:      false,
+				Description: "Login from office",
+			},
+		},
+		FirewallRule{
+			ID:          "cbf4b7a5a2a24e59a03044d6d44ceb09",
+			Paused:      false,
+			Description: "challenge login",
+			Action:      "challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+				Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\")",
+				Paused:      false,
+				Description: "Login",
+			},
+		},
+	}
+
+	actual, err := client.UpdateFirewallRules("d56084adb405e0b7e32c52321bf07be6", want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -487,3 +487,32 @@ func TestUpdateMultipleFirewallRules(t *testing.T) {
 	}
 }
 
+func TestDeleteSingleFirewallRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [],
+			"success": true,
+			"errors": null,
+			"messages": null
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/f2d427378e7542acb295380d352e2ebd", handler)
+
+	err := client.DeleteFirewallRule("d56084adb405e0b7e32c52321bf07be6", "f2d427378e7542acb295380d352e2ebd")
+	assert.NoError(t, err)
+}
+
+func TestDeleteFirewallRuleWithMissingID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	err := client.DeleteFirewallRule("d56084adb405e0b7e32c52321bf07be6", "")
+	assert.EqualError(t, err, "firewall rule ID cannot be empty")
+}

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -1,0 +1,153 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var firewallRulePageOpts = PaginationOptions{
+	PerPage: 25,
+	Page:    1,
+}
+
+func TestFirewallRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result":[
+				{
+					"id":"4ae338944d6143378c3cf05a7c77d983",
+					"paused":false,
+					"description":"allow API traffic without challenge",
+					"action":"allow",
+					"priority":null,
+					"filter":{
+						"id":"14217d7bd5ab435e84b1bd468bf4fb9f",
+						"expression":"http.request.uri.path matches \"^/api/.*$\"",
+						"paused":false,
+						"description":"/api"
+					}
+				},
+				{
+					"id":"f2d427378e7542acb295380d352e2ebd",
+					"paused":false,
+					"description":"do not challenge login from office",
+					"action":"allow",
+					"priority":null,
+					"filter":{
+						"id":"b7ff25282d394be7b945e23c7106ce8a",
+						"expression":"(http.request.uri.path ~ \"^.*/xmlrpc.php$\"",
+						"paused":false,
+						"description":"wordpress xmlrpc"
+					}
+				},
+				{
+					"id":"cbf4b7a5a2a24e59a03044d6d44ceb09",
+					"paused":false,
+					"description":"challenge login",
+					"action":"challenge",
+					"priority":null,
+					"filter":{
+						"id":"c218c536b2bd406f958f278cf0fa8c0f",
+						"expression":"(http.request.uri.path ~ \"^.*/wp-login.php$\"",
+						"paused":false,
+						"description":"Login"
+					}
+				},
+				{
+					"id":"52161eb6af4241bb9d4b32394be72fdf",
+					"paused":false,
+					"description":"JS challenge site",
+					"action":"js_challenge",
+					"priority":null,
+					"filter":{
+						"id":"f2a64520581a4209aab12187a0081364",
+						"expression":"not http.request.uri.path matches \"^/api/.*$\"",
+						"paused":false,
+						"description":"not /api"
+					}
+				}
+			],
+			"success":true,
+			"errors":null,
+			"messages":null,
+			"result_info":{
+				"page":1,
+				"per_page":25,
+				"count":4,
+				"total_count":4
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	want := []FirewallRule{
+		FirewallRule{
+			ID:          "4ae338944d6143378c3cf05a7c77d983",
+			Paused:      false,
+			Description: "allow API traffic without challenge",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "14217d7bd5ab435e84b1bd468bf4fb9f",
+				Expression:  "http.request.uri.path matches \"^/api/.*$\"",
+				Paused:      false,
+				Description: "/api",
+			},
+		},
+		FirewallRule{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "(http.request.uri.path ~ \"^.*/xmlrpc.php$\"",
+				Paused:      false,
+				Description: "wordpress xmlrpc",
+			},
+		},
+		FirewallRule{
+			ID:          "cbf4b7a5a2a24e59a03044d6d44ceb09",
+			Paused:      false,
+			Description: "challenge login",
+			Action:      "challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+				Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\"",
+				Paused:      false,
+				Description: "Login",
+			},
+		},
+		FirewallRule{
+			ID:          "52161eb6af4241bb9d4b32394be72fdf",
+			Paused:      false,
+			Description: "JS challenge site",
+			Action:      "js_challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "f2a64520581a4209aab12187a0081364",
+				Expression:  "not http.request.uri.path matches \"^/api/.*$\"",
+				Paused:      false,
+				Description: "not /api",
+			},
+		},
+	}
+
+	actual, err := client.FirewallRules("d56084adb405e0b7e32c52321bf07be6", firewallRulePageOpts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+


### PR DESCRIPTION
This adds in the support for the freshly [announced firewall rules](https://blog.cloudflare.com/announcing-firewall-rules/) and has full API coverage for all methods.

cc @patryk 