### PR TITLE
Rename TestClient_Auth to Test_IPs and mock properly

### DIFF
--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -79,31 +79,6 @@ func TestClient_Headers(t *testing.T) {
 	teardown()
 }
 
-func TestClient_Auth(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/ips", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
-		assert.Equal(t, "cloudflare@example.com", r.Header.Get("X-Auth-Email"))
-		assert.Equal(t, "deadbeef", r.Header.Get("X-Auth-Token"))
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "response": {
-    "ipv4_cidrs": ["199.27.128.0/21"],
-    "ipv6_cidrs": ["199.27.128.0/21"]
-  }
-}`)
-	})
-
-	_, err := IPs()
-
-	assert.NoError(t, err)
-}
-
 func TestClient_RetryCanSucceedAfterErrors(t *testing.T) {
 	setup(UsingRetryPolicy(2, 0, 1))
 	defer teardown()

--- a/ips_test.go
+++ b/ips_test.go
@@ -1,0 +1,67 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type MockTransport struct {
+	http.Transport
+	Server *httptest.Server
+	Path   string
+}
+
+func (m *MockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	url, err := url.Parse(m.Server.URL + m.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	req.URL = url
+
+	return m.Transport.RoundTrip(req)
+}
+
+func Test_IPs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux := http.NewServeMux()
+	server = httptest.NewServer(mux)
+	defer server.Close()
+
+	defaultTransport := http.DefaultTransport
+	http.DefaultTransport = &MockTransport{
+		Server: server,
+		Path:   "/ips",
+	}
+	defer func() { http.DefaultTransport = defaultTransport }()
+
+	mux.HandleFunc("/ips", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "ipv4_cidrs": ["199.27.128.0/21"],
+    "ipv6_cidrs": ["ffff:ffff::/32"]
+  }
+}`)
+	})
+
+	ipRanges, err := IPs()
+
+	assert.NoError(t, err)
+
+	assert.Len(t, ipRanges.IPv4CIDRs, 1)
+	assert.Equal(t, "199.27.128.0/21", ipRanges.IPv4CIDRs[0])
+	assert.Len(t, ipRanges.IPv6CIDRs, 1)
+	assert.Equal(t, "ffff:ffff::/32", ipRanges.IPv6CIDRs[0])
+}


### PR DESCRIPTION
I believe this fixes #127 (cc @terinjokes).

In my view, this test got left behind after some refactoring work. Looking at the rest of the tests, the `X-Auth-Email` and `X-Auth-Token` asserts are validated [here](https://github.com/cloudflare/cloudflare-go/blob/e24ed152b4c8d947daef772b3505c3d2d3ab01bb/cloudflare_test.go#L45-L46), so this test should only be responsible for asserting that `IPs()` does the right thing, which is a special API call, that [does not require logging in to the Cloudflare API](https://github.com/cloudflare/cloudflare-go/blob/e24ed152b4c8d947daef772b3505c3d2d3ab01bb/ips.go#L25).