### PR TITLE
Make `ZoneIDByName` safer to use for ambiguous zone names

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -15,9 +15,9 @@ type AccountSettings struct {
 
 // Account represents the root object that owns resources.
 type Account struct {
-	ID       string          `json:"id,omitempty"`
-	Name     string          `json:"name,omitempty"`
-	Settings AccountSettings `json:"settings"`
+	ID       string           `json:"id,omitempty"`
+	Name     string           `json:"name,omitempty"`
+	Settings *AccountSettings `json:"settings"`
 }
 
 // AccountResponse represents the response from the accounts endpoint for a

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -12,7 +12,7 @@ import (
 var expectedAccountStruct = Account{
 	ID:   "01a7362d577a6c3019a474fd6f485823",
 	Name: "Cloudflare Demo",
-	Settings: AccountSettings{
+	Settings: &AccountSettings{
 		EnforceTwoFactor: false,
 	},
 }
@@ -132,7 +132,7 @@ func TestUpdateAccount(t *testing.T) {
 	oldAccountDetails := Account{
 		ID:   "01a7362d577a6c3019a474fd6f485823",
 		Name: "Cloudflare Demo - Old",
-		Settings: AccountSettings{
+		Settings: &AccountSettings{
 			EnforceTwoFactor: false,
 		},
 	}
@@ -140,7 +140,7 @@ func TestUpdateAccount(t *testing.T) {
 	newAccountDetails := Account{
 		ID:   "01a7362d577a6c3019a474fd6f485823",
 		Name: "Cloudflare Demo - New",
-		Settings: AccountSettings{
+		Settings: &AccountSettings{
 			EnforceTwoFactor: false,
 		},
 	}

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -90,11 +90,23 @@ func (api *API) ZoneIDByName(zoneName string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "ListZones command failed")
 	}
+
+	if len(res) > 1 && api.OrganizationID == "" {
+		return "", errors.New("ambiguous zone name used without an account ID")
+	}
+
 	for _, zone := range res {
-		if zone.Name == zoneName {
-			return zone.ID, nil
+		if api.OrganizationID != "" {
+			if zone.Name == zoneName && api.OrganizationID == zone.Account.ID {
+				return zone.ID, nil
+			}
+		} else {
+			if zone.Name == zoneName {
+				return zone.ID, nil
+			}
 		}
 	}
+
 	return "", errors.New("Zone could not be found")
 }
 

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -201,3 +201,279 @@ func TestClient_RetryReturnsPersistentErrorResponse(t *testing.T) {
 	_, err := client.ListLoadBalancerPools()
 	assert.Error(t, err)
 }
+
+func TestZoneIDByNameWithNonUniqueZonesWithoutOrgID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "023e105f4ecef8ad9ca31a8372d0c353",
+					"name": "example.com",
+					"development_mode": 7200,
+					"original_name_servers": [
+						"ns1.originaldnshost.com",
+						"ns2.originaldnshost.com"
+					],
+					"original_registrar": "GoDaddy",
+					"original_dnshost": "NameCheap",
+					"created_on": "2014-01-01T05:20:00.12345Z",
+					"modified_on": "2014-01-01T05:20:00.12345Z",
+					"owner": {
+						"id": "7c5dae5552338874e5053f2534d2767a",
+						"email": "user@example.com",
+						"owner_type": "user"
+					},
+					"account": {
+						"id": "01a7362d577a6c3019a474fd6f485823",
+						"name": "Demo Account"
+					},
+					"permissions": [
+						"#zone:read",
+						"#zone:edit"
+					],
+					"plan": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"plan_pending": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"status": "active",
+					"paused": false,
+					"type": "full",
+					"name_servers": [
+						"tony.ns.cloudflare.com",
+						"woz.ns.cloudflare.com"
+					]
+				},
+				{
+					"id": "023e105f4ecef8ad9ca31a8372d0c353",
+					"name": "example.com",
+					"development_mode": 7200,
+					"original_name_servers": [
+						"ns1.originaldnshost.com",
+						"ns2.originaldnshost.com"
+					],
+					"original_registrar": "GoDaddy",
+					"original_dnshost": "NameCheap",
+					"created_on": "2014-01-01T05:20:00.12345Z",
+					"modified_on": "2014-01-01T05:20:00.12345Z",
+					"owner": {
+						"id": "7c5dae5552338874e5053f2534d2767a",
+						"email": "user@example.com",
+						"owner_type": "user"
+					},
+					"account": {
+						"id": "01a7362d577a6c3019a474fd6f485823",
+						"name": "Demo Account"
+					},
+					"permissions": [
+						"#zone:read",
+						"#zone:edit"
+					],
+					"plan": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"plan_pending": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"status": "active",
+					"paused": false,
+					"type": "full",
+					"name_servers": [
+						"tony.ns.cloudflare.com",
+						"woz.ns.cloudflare.com"
+					]
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	// `HandleFunc` doesn't handle query parameters so we just need to
+	// handle the `/zones` endpoint instead.
+	mux.HandleFunc("/zones", handler)
+
+	_, err := client.ZoneIDByName("example.com")
+	assert.EqualError(t, err, "ambiguous zone name used without an account ID")
+}
+
+func TestZoneIDByNameWithNonUniqueZonesWithOrgId(t *testing.T) {
+	setup(UsingOrganization("01a7362d577a6c3019a474fd6f485823"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "023e105f4ecef8ad9ca31a8372d0c353",
+					"name": "example.com",
+					"development_mode": 7200,
+					"original_name_servers": [
+						"ns1.originaldnshost.com",
+						"ns2.originaldnshost.com"
+					],
+					"original_registrar": "GoDaddy",
+					"original_dnshost": "NameCheap",
+					"created_on": "2014-01-01T05:20:00.12345Z",
+					"modified_on": "2014-01-01T05:20:00.12345Z",
+					"owner": {
+						"id": "7c5dae5552338874e5053f2534d2767a",
+						"email": "user@example.com",
+						"owner_type": "user"
+					},
+					"account": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Another Demo Account"
+					},
+					"permissions": [
+						"#zone:read",
+						"#zone:edit"
+					],
+					"plan": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"plan_pending": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"status": "active",
+					"paused": false,
+					"type": "full",
+					"name_servers": [
+						"tony.ns.cloudflare.com",
+						"woz.ns.cloudflare.com"
+					]
+				},
+				{
+					"id": "7c5dae5552338874e5053f2534d2767a",
+					"name": "example.com",
+					"development_mode": 7200,
+					"original_name_servers": [
+						"ns1.originaldnshost.com",
+						"ns2.originaldnshost.com"
+					],
+					"original_registrar": "GoDaddy",
+					"original_dnshost": "NameCheap",
+					"created_on": "2014-01-01T05:20:00.12345Z",
+					"modified_on": "2014-01-01T05:20:00.12345Z",
+					"owner": {
+						"id": "7c5dae5552338874e5053f2534d2767a",
+						"email": "user@example.com",
+						"owner_type": "user"
+					},
+					"account": {
+						"id": "01a7362d577a6c3019a474fd6f485823",
+						"name": "Demo Account"
+					},
+					"permissions": [
+						"#zone:read",
+						"#zone:edit"
+					],
+					"plan": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"plan_pending": {
+						"id": "e592fd9519420ba7405e1307bff33214",
+						"name": "Pro Plan",
+						"price": 20,
+						"currency": "USD",
+						"frequency": "monthly",
+						"legacy_id": "pro",
+						"is_subscribed": true,
+						"can_subscribe": true
+					},
+					"status": "active",
+					"paused": false,
+					"type": "full",
+					"name_servers": [
+						"tony.ns.cloudflare.com",
+						"woz.ns.cloudflare.com"
+					]
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	// `HandleFunc` doesn't handle query parameters so we just need to
+	// handle the `/zones` endpoint instead.
+	mux.HandleFunc("/zones", handler)
+
+	actual, err := client.ZoneIDByName("example.com")
+	if assert.NoError(t, err) {
+		assert.Equal(t, actual, "7c5dae5552338874e5053f2534d2767a")
+	}
+}

--- a/zone.go
+++ b/zone.go
@@ -44,6 +44,7 @@ type Zone struct {
 	Betas       []string `json:"betas"`
 	DeactReason string   `json:"deactivation_reason"`
 	Meta        ZoneMeta `json:"meta"`
+	Account     Account  `json:"account"`
 }
 
 // ZoneMeta describes metadata about a zone.


### PR DESCRIPTION
Updates the `ZoneIDByName` function to be more intuitive (and safe) in
the event that multiple zones are returned by the API. It does this by
ensuring that if we have a response that includes more than a single
zone, an account ID *must be* defined to distinguish which account we
are intending to operate on. This enforcement then feeds into the
following step where the filtering not only matches on `zone.Name` but
the account ID provided as well. Lookups where the zone is unique will
continue to operate as normal.

Included in this change is updating `Account.Settings` to be a pointer
within the struct to enable the `Zone` struct to omit it should it not
be defined.

Fixes #234
Fixes #235