### PR TITLE
[cmd/flarectl] Handle errors from `CreateZone`

### DIFF
--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -33,7 +33,12 @@ func zoneCreate(c *cli.Context) {
 	if orgID != "" {
 		org.ID = orgID
 	}
-	api.CreateZone(zone, jumpstart, org)
+
+	_, err := api.CreateZone(zone, jumpstart, org)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s", err))
+		return
+	}
 }
 
 func zoneCheck(c *cli.Context) {


### PR DESCRIPTION
Should the `CreateZone` calls fail, it should provide some feedback to
the user as to why. This implements a fix whereby it returns the HTTP
response to stderr which includes the error message.

Fixes #241