### PR TITLE
Implement CreateOrganizationInvite 

### DIFF
--- a/organizations.go
+++ b/organizations.go
@@ -159,6 +159,39 @@ func (api *API) OrganizationInvites(organizationID string) ([]OrganizationInvite
 	return r.Result, r.ResultInfo, nil
 }
 
+type createOrganizationInviteParams struct {
+	Email string `json:"invited_member_email"`
+	Roles []OrganizationRole `json:"roles"`
+	AutoAccept bool `json:"auto_accept,omitempty"`
+}
+
+// CreateOrganizationInvite returns list of invites for specified organization of
+// the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organization-invites
+func (api *API) CreateOrganizationInvite(organizationID, email string, roles []string, autoAccept bool) ([]OrganizationInvite, ResultInfo, error) {
+	params := createOrganizationInviteParams{
+		Email: email,
+		AutoAccept: autoAccept,
+	}
+	for _, role := range roles {
+		params.Roles = append(params.Roles, OrganizationRole{ID: role})
+	}
+	var r organizationInvitesResponse
+	uri := "/organizations/" + organizationID + "/invites"
+	res, err := api.makeRequest("POST", uri, params)
+	if err != nil {
+		return []OrganizationInvite{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []OrganizationInvite{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}
+
 // organizationRolesResponse represents the response from the Organization roles endpoint.
 type organizationRolesResponse struct {
 	Response

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -340,6 +340,87 @@ func TestOrganizations_OrganizationInvites(t *testing.T) {
 	assert.Equal(t, paginator, wantPagination)
 }
 
+func TestOrganizations_CreateOrganizationInvites(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/organizations/01a7362d577a6c3019a474fd6f485823/invites", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method, "Expected method 'POST', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "id": "4f5f0c14a2a41d5063dd301b2f829f04",
+      "invited_member_id": "5a7805061c76ada191ed06f989cc3dac",
+      "invited_member_email": "user@example.com",
+      "organization_id": "5a7805061c76ada191ed06f989cc3dac",
+      "organization_name": "Cloudflare, Inc.",
+      "roles": [
+        {
+          "id": "3536bcfad5faccb999b47003c79917fb",
+          "name": "Organization Admin",
+          "description": "Administrative access to the entire Organization",
+          "permissions": [
+            "#zones:read"
+          ]
+        }
+      ],
+      "invited_by": "user@example.com",
+      "invited_on": "2014-01-01T05:20:00Z",
+      "expires_on": "2014-01-01T05:20:00Z",
+      "status": "accepted"
+    }
+  ],
+  "result_info": {
+    "page": 1,
+    "per_page": 20,
+    "count": 1,
+    "total_count": 2000
+  }
+}`)
+	})
+
+	members, paginator, err := client.CreateOrganizationInvite("01a7362d577a6c3019a474fd6f485823", "user@example.com", []string{"3536bcfad5faccb999b47003c79917fb"}, true)
+
+	invitedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00Z")
+
+	want := []OrganizationInvite{{
+		ID:                 "4f5f0c14a2a41d5063dd301b2f829f04",
+		InvitedMemberID:    "5a7805061c76ada191ed06f989cc3dac",
+		InvitedMemberEmail: "user@example.com",
+		OrganizationID:     "5a7805061c76ada191ed06f989cc3dac",
+		OrganizationName:   "Cloudflare, Inc.",
+		Roles: []OrganizationRole{{
+			ID:          "3536bcfad5faccb999b47003c79917fb",
+			Name:        "Organization Admin",
+			Description: "Administrative access to the entire Organization",
+			Permissions: []string{
+				"#zones:read",
+			}}},
+		InvitedBy: "user@example.com",
+		InvitedOn: &invitedOn,
+		ExpiresOn: &expiresOn,
+		Status:    "accepted",
+	}}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, members, want)
+	}
+
+	wantPagination := ResultInfo{
+		Page:    1,
+		PerPage: 20,
+		Count:   1,
+		Total:   2000,
+	}
+	assert.Equal(t, paginator, wantPagination)
+}
+
 func TestOrganizations_OrganizationRoles(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This adds support for the `CreateOrganizationInvite` endpoint.

Fixes #247 