### PR TITLE
Add support for using custom ports with monitors

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -46,6 +46,7 @@ type LoadBalancerMonitor struct {
 	Timeout         int                 `json:"timeout"`
 	Retries         int                 `json:"retries"`
 	Interval        int                 `json:"interval"`
+	Port            uint16              `json:"port,omitempty"`
 	ExpectedBody    string              `json:"expected_body"`
 	ExpectedCodes   string              `json:"expected_codes"`
 	FollowRedirects bool                `json:"follow_redirects"`


### PR DESCRIPTION
This PR add support for creating monitors testing against customer ports which is a requirement for making basic layer 4 TCP connection monitors