### PR TITLE
Add JSON tags for ResultInfo in ZonesResponse and AvailableZoneRate...

### DIFF
--- a/zone.go
+++ b/zone.go
@@ -89,8 +89,8 @@ type ZoneResponse struct {
 // ZonesResponse represents the response from the Zone endpoint containing an array of zones.
 type ZonesResponse struct {
 	Response
-	Result []Zone `json:"result"`
-	ResultInfo
+	Result     []Zone `json:"result"`
+	ResultInfo `json:"result_info"`
 }
 
 // ZoneIDResponse represents the response from the Zone endpoint, containing only a zone ID.
@@ -102,8 +102,8 @@ type ZoneIDResponse struct {
 // AvailableZoneRatePlansResponse represents the response from the Available Rate Plans endpoint.
 type AvailableZoneRatePlansResponse struct {
 	Response
-	Result []ZoneRatePlan `json:"result"`
-	ResultInfo
+	Result     []ZoneRatePlan `json:"result"`
+	ResultInfo `json:"result_info"`
 }
 
 // ZoneRatePlanResponse represents the response from the Plan Details endpoint.


### PR DESCRIPTION
Pagination doesn't work on zones as I always get `0` on all the Println below:

```
popts := cloudflare.PaginationOptions{
	PerPage: 1000,
}
zoneRes, err := cf.ListZonesContext(context.Background(), cloudflare.ReqOption(cloudflare.WithPagination(popts)))
if err != nil {
	panic(err)
}

log.Println(zoneRes.Total)
log.Println(zoneRes.TotalPages)
log.Println(zoneRes.ResultInfo.Count)
log.Println(zoneRes.ResultInfo.Total)
log.Println(zoneRes.ResultInfo.Page)
log.Println(zoneRes.ResultInfo.TotalPages)

log.Fatalln(len(zoneRes.Result))
```

I saw the http response was correct here ( https://github.com/cloudflare/cloudflare-go/blob/master/zone.go#L351 ) but json.Unmarshal was not setting correct values. After applying the tags, it worked.