### PR TITLE
Add session_affinity_ttl option to the libs.

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -54,18 +54,19 @@ type LoadBalancerMonitor struct {
 
 // LoadBalancer represents a load balancer's properties.
 type LoadBalancer struct {
-	ID           string              `json:"id,omitempty"`
-	CreatedOn    *time.Time          `json:"created_on,omitempty"`
-	ModifiedOn   *time.Time          `json:"modified_on,omitempty"`
-	Description  string              `json:"description"`
-	Name         string              `json:"name"`
-	TTL          int                 `json:"ttl,omitempty"`
-	FallbackPool string              `json:"fallback_pool"`
-	DefaultPools []string            `json:"default_pools"`
-	RegionPools  map[string][]string `json:"region_pools"`
-	PopPools     map[string][]string `json:"pop_pools"`
-	Proxied      bool                `json:"proxied"`
-	Persistence  string              `json:"session_affinity,omitempty"`
+	ID             string              `json:"id,omitempty"`
+	CreatedOn      *time.Time          `json:"created_on,omitempty"`
+	ModifiedOn     *time.Time          `json:"modified_on,omitempty"`
+	Description    string              `json:"description"`
+	Name           string              `json:"name"`
+	TTL            int                 `json:"ttl,omitempty"`
+	FallbackPool   string              `json:"fallback_pool"`
+	DefaultPools   []string            `json:"default_pools"`
+	RegionPools    map[string][]string `json:"region_pools"`
+	PopPools       map[string][]string `json:"pop_pools"`
+	Proxied        bool                `json:"proxied"`
+	Persistence    string              `json:"session_affinity,omitempty"`
+	PersistenceTTL int                 `json:"session_affinity_ttl,omitempty"`
 
 	// SteeringPolicy controls pool selection logic.
 	// "off" select pools in DefaultPools order

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -814,7 +814,8 @@ func TestCreateLoadBalancer(t *testing.T) {
                 ]
               },
               "proxied": true,
-              "session_affinity": "cookie"
+              "session_affinity": "cookie",
+              "session_affinity_ttl": 5000
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -857,7 +858,8 @@ func TestCreateLoadBalancer(t *testing.T) {
                   ]
                 },
                 "proxied": true,
-                "session_affinity": "cookie"
+                "session_affinity": "cookie",
+                "session_affinity_ttl": 5000
             }
         }`)
 	}
@@ -900,8 +902,9 @@ func TestCreateLoadBalancer(t *testing.T) {
 				"00920f38ce07c2e2f4df50b1f61d4194",
 			},
 		},
-		Proxied:     true,
-		Persistence: "cookie",
+		Proxied:        true,
+		Persistence:    "cookie",
+		PersistenceTTL: 5000,
 	}
 	request := LoadBalancer{
 		Description:  "Load Balancer for www.example.com",
@@ -935,8 +938,9 @@ func TestCreateLoadBalancer(t *testing.T) {
 				"00920f38ce07c2e2f4df50b1f61d4194",
 			},
 		},
-		Proxied:     true,
-		Persistence: "cookie",
+		Proxied:        true,
+		Persistence:    "cookie",
+		PersistenceTTL: 5000,
 	}
 
 	actual, err := client.CreateLoadBalancer("199d98642c564d2e855e9661899b7252", request)


### PR DESCRIPTION
## Description

This change enables using PersistenceTTL to specify the time in seconds the cookie is going to stay alive. This will provide the user the flexibility to set the cookie expiry time if the choose to.

## Has your change been tested?

Yes. Unit test added. 


## Types of changes

What sort of change does your code introduce/modify?

- [X] New feature (non-breaking change which adds functionality)

