### PR TITLE
Add origin header match support for rate limits

### DIFF
--- a/rate_limiting.go
+++ b/rate_limiting.go
@@ -36,8 +36,17 @@ type RateLimitRequestMatcher struct {
 
 // RateLimitResponseMatcher contains the matching rules pertaining to responses
 type RateLimitResponseMatcher struct {
-	Statuses      []int `json:"status,omitempty"`
-	OriginTraffic *bool `json:"origin_traffic,omitempty"` // api defaults to true so we need an explicit empty value
+	Statuses      []int                            `json:"status,omitempty"`
+	OriginTraffic *bool                            `json:"origin_traffic,omitempty"` // api defaults to true so we need an explicit empty value
+	Headers       []RateLimitResponseMatcherHeader `json:"headers,omitempty"`
+}
+
+// RateLimitResponseMatcherHeader contains the structure of the origin
+// HTTP headers used in request matcher checks.
+type RateLimitResponseMatcherHeader struct {
+	Name  string `json:"name"`
+	Op    string `json:"op"`
+	Value string `json:"value"`
 }
 
 // RateLimitKeyValue is k-v formatted as expected in the rate limit description


### PR DESCRIPTION
Rate limiting has the ability to be applied if the origin response
includes a HTTP header matching a specific value. This adds support for
using that functionality within the library (and later, the Terraform
provider.)

Needed for terraform-providers/terraform-provider-cloudflare#196 to
proceed.