### PR TITLE
Add Minify in PageRuleActions

### DIFF
--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -147,7 +147,11 @@ func pageRules(c *cli.Context) {
 			case float64:
 				s = fmt.Sprintf("%s: %.f", cloudflare.PageRuleActions[a.ID], v)
 			case map[string]interface{}:
-				s = fmt.Sprintf("%s: %.f - %s", cloudflare.PageRuleActions[a.ID], v["status_code"], v["url"])
+				if a.ID == "minify" {
+					s = fmt.Sprintf("%s: [js:%s html:%s css:%s]", cloudflare.PageRuleActions[a.ID], v["js"], v["html"], v["css"])
+				} else {
+					s = fmt.Sprintf("%s: %.f - %s", cloudflare.PageRuleActions[a.ID], v["status_code"], v["url"])
+				}
 			case nil:
 				s = fmt.Sprintf("%s", cloudflare.PageRuleActions[a.ID])
 			default:

--- a/page_rules.go
+++ b/page_rules.go
@@ -43,6 +43,7 @@ Valid IDs are:
   forwarding_url
   host_header_override
   ip_geolocation
+  minify
   mirage
   opportunistic_encryption
   origin_error_page_pass_thru
@@ -85,6 +86,7 @@ var PageRuleActions = map[string]string{
 	"forwarding_url":              "Forwarding URL",              // Value of type map[string]interface
 	"host_header_override":        "Host Header Override",        // Value of type string
 	"ip_geolocation":              "IP Geolocation Header",       // Value of type string
+	"minify":                      "Minify",                      // Value of type map[string]interface
 	"mirage":                      "Mirage",                      // Value of type string
 	"opportunistic_encryption":    "Opportunistic Encryption",    // Value of type string
 	"origin_error_page_pass_thru": "Origin Error Page Pass-thru", // Value of type string


### PR DESCRIPTION
Add Auto-Minify in PageRuleActions

Need this action for create Auto-Minify in PageRules by terraform provider (terraform-providers/terraform-provider-cloudflare#120)

Also made the flarectl output more readable on pagerules with minify.
Before:
```
$ ~/go/bin/flarectl p l --zone example.org
Pri ID                               Status   URL
  2 ad668eaaa0de1ea66dc26939491cced0 active   https://example.org/*/test/_static_/*
    : %!f(<nil>) - %!s(<nil>)
  1 b1ea70598683166ebf41b256ab9368b9 active   https://example.org/test/*.js
    : %!f(<nil>) - %!s(<nil>)
```
After:
```
$ ~/go/bin/flarectl p l --zone example.org
Pri ID                               Status   URL
  2 ad668eaaa0de1ea66dc26939491cced0 active   https://example.org/*/test/_static_/*
    Minify: [js:on html:off css:on]
  1 b1ea70598683166ebf41b256ab9368b9 active   https://example.org/test/*.js
    Minify: [js:on html:off css:off]
```

I'm not sure that everything is done correctly. Waiting for check