### PR TITLE
flarectl: Add support for organization scopes

### DIFF
--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -24,10 +24,6 @@ func formatDNSRecord(record cloudflare.DNSRecord) []string {
 }
 
 func dnsCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "name", "type", "content"); err != nil {
 		return
 	}
@@ -65,10 +61,6 @@ func dnsCreate(c *cli.Context) {
 }
 
 func dnsCreateOrUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "name", "type", "content"); err != nil {
 		fmt.Println(err)
 		return
@@ -136,10 +128,6 @@ func dnsCreateOrUpdate(c *cli.Context) {
 }
 
 func dnsUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		fmt.Println(err)
 		return
@@ -172,10 +160,6 @@ func dnsUpdate(c *cli.Context) {
 }
 
 func dnsDelete(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		fmt.Println(err)
 		return

--- a/cmd/flarectl/firewall.go
+++ b/cmd/flarectl/firewall.go
@@ -22,11 +22,6 @@ func formatAccessRule(rule cloudflare.AccessRule) []string {
 }
 
 func firewallAccessRules(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	organizationID, zoneID, err := getScope(c)
 	if err != nil {
 		return
@@ -88,10 +83,6 @@ func firewallAccessRules(c *cli.Context) {
 }
 
 func firewallAccessRuleCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "mode", "value"); err != nil {
 		fmt.Println(err)
 		return
@@ -145,10 +136,6 @@ func firewallAccessRuleCreate(c *cli.Context) {
 }
 
 func firewallAccessRuleUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "id"); err != nil {
 		fmt.Println(err)
 		return
@@ -200,10 +187,6 @@ func firewallAccessRuleUpdate(c *cli.Context) {
 }
 
 func firewallAccessRuleCreateOrUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "mode", "value"); err != nil {
 		fmt.Println(err)
 		return
@@ -272,10 +255,6 @@ func firewallAccessRuleCreateOrUpdate(c *cli.Context) {
 }
 
 func firewallAccessRuleDelete(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "id"); err != nil {
 		fmt.Println(err)
 		return

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -14,6 +14,14 @@ func main() {
 	app.Name = "flarectl"
 	app.Usage = "Cloudflare CLI"
 	app.Version = "2017.10.0"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "org-id",
+			Usage:  "Optional organization ID",
+			Value:  "",
+			EnvVar: "CF_ORG_ID",
+		},
+	}
 	app.Commands = []cli.Command{
 		{
 			Name:    "ips",
@@ -36,6 +44,7 @@ func main() {
 			Name:    "user",
 			Aliases: []string{"u"},
 			Usage:   "User information",
+			Before:  initializeAPI,
 			Subcommands: []cli.Command{
 				{
 					Name:    "info",
@@ -56,6 +65,7 @@ func main() {
 			Name:    "zone",
 			Aliases: []string{"z"},
 			Usage:   "Zone information",
+			Before:  initializeAPI,
 			Subcommands: []cli.Command{
 				{
 					Name:    "list",
@@ -182,6 +192,7 @@ func main() {
 			Name:    "dns",
 			Aliases: []string{"d"},
 			Usage:   "DNS records",
+			Before:  initializeAPI,
 			Subcommands: []cli.Command{
 				{
 					Name:    "list",
@@ -328,6 +339,7 @@ func main() {
 			Name:    "user-agents",
 			Aliases: []string{"ua"},
 			Usage:   "User-Agent blocking",
+			Before:  initializeAPI,
 			Subcommands: []cli.Command{
 				{
 					Name:    "list",
@@ -427,6 +439,7 @@ func main() {
 			Name:    "pagerules",
 			Aliases: []string{"p"},
 			Usage:   "Page Rules",
+			Before:  initializeAPI,
 			Subcommands: []cli.Command{
 				{
 					Name:    "list",
@@ -447,6 +460,7 @@ func main() {
 			Name:    "railgun",
 			Aliases: []string{"r"},
 			Usage:   "Railgun information",
+			Before:  initializeAPI,
 			Action:  railgun,
 		},
 
@@ -454,6 +468,7 @@ func main() {
 			Name:    "firewall",
 			Aliases: []string{"f"},
 			Usage:   "Firewall",
+			Before:  initializeAPI,
 			Subcommands: []cli.Command{
 				{
 					Name:    "rules",

--- a/cmd/flarectl/user_agent.go
+++ b/cmd/flarectl/user_agent.go
@@ -20,11 +20,6 @@ func formatUserAgentRule(rule cloudflare.UserAgentRule) []string {
 }
 
 func userAgentCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "mode", "value"); err != nil {
 		fmt.Println(err)
 		return
@@ -60,11 +55,6 @@ func userAgentCreate(c *cli.Context) {
 }
 
 func userAgentUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "id", "mode", "value"); err != nil {
 		return
 	}
@@ -99,11 +89,6 @@ func userAgentUpdate(c *cli.Context) {
 }
 
 func userAgentDelete(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		return
 	}
@@ -128,11 +113,6 @@ func userAgentDelete(c *cli.Context) {
 }
 
 func userAgentList(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "page"); err != nil {
 		return
 	}

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -19,10 +19,6 @@ func zoneRailgun(*cli.Context) {
 }
 
 func zoneCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone"); err != nil {
 		return
 	}
@@ -42,10 +38,6 @@ func zoneCreate(c *cli.Context) {
 }
 
 func zoneCheck(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone"); err != nil {
 		return
 	}
@@ -66,10 +58,6 @@ func zoneCheck(c *cli.Context) {
 }
 
 func zoneList(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	zones, err := api.ListZones()
 	if err != nil {
 		fmt.Println(err)
@@ -88,10 +76,6 @@ func zoneList(c *cli.Context) {
 }
 
 func zoneInfo(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	var zone string
 	if len(c.Args()) > 0 {
 		zone = c.Args()[0]
@@ -134,12 +118,6 @@ func zoneSettings(*cli.Context) {
 }
 
 func zoneCachePurge(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		cli.ShowSubcommandHelp(c)
-		return
-	}
-
 	if err := checkFlags(c, "zone"); err != nil {
 		cli.ShowSubcommandHelp(c)
 		return
@@ -194,10 +172,6 @@ func zoneCachePurge(c *cli.Context) {
 }
 
 func zoneRecords(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	var zone string
 	if len(c.Args()) > 0 {
 		zone = c.Args()[0]


### PR DESCRIPTION
## Description

This merge requests adds a global flag `--orgid` used when users want to change to an organization scope. 

I'm working on some `loadbalancer` and `pool` subcommands where users are required to change scope. I will open a pull request when ready.

Also: Cleaning the code up a bit - this way we don't have to push around `checkEnv` function calls everywhere

## Has your change been tested?

I have tested that `--orgid` is used - `flarectl ips` still works as expected even when not providing any credentials and all the other sub commands are working as before when given credentials

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (move code and functions around in a way that does not break functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
