### PR TITLE
Make rate limiting `correlate` optional

### DIFF
--- a/rate_limiting.go
+++ b/rate_limiting.go
@@ -18,7 +18,7 @@ type RateLimit struct {
 	Threshold   int                     `json:"threshold"`
 	Period      int                     `json:"period"`
 	Action      RateLimitAction         `json:"action"`
-	Correlate   RateLimitCorrelate      `json:"correlate"`
+	Correlate   *RateLimitCorrelate     `json:"correlate,omitempty"`
 }
 
 // RateLimitTrafficMatcher contains the rules that will be used to apply a rate limit to traffic

--- a/rate_limiting_example_test.go
+++ b/rate_limiting_example_test.go
@@ -20,7 +20,7 @@ var exampleNewRateLimit = cloudflare.RateLimit{
 		Mode:    "ban",
 		Timeout: 60,
 	},
-	Correlate: cloudflare.RateLimitCorrelate{
+	Correlate: &cloudflare.RateLimitCorrelate{
 		By: "nat",
 	},
 }

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -65,7 +65,7 @@ var expectedRateLimitStruct = RateLimit{
 		Mode:    "ban",
 		Timeout: 60,
 	},
-	Correlate: RateLimitCorrelate{
+	Correlate: &RateLimitCorrelate{
 		By: "nat",
 	},
 }
@@ -89,7 +89,7 @@ var expectedRateLimitStructUpdated = RateLimit{
 		Mode:    "ban",
 		Timeout: 60,
 	},
-	Correlate: RateLimitCorrelate{
+	Correlate: &RateLimitCorrelate{
 		By: "nat",
 	},
 }
@@ -260,7 +260,7 @@ func TestCreateRateLimit(t *testing.T) {
 			Mode:    "ban",
 			Timeout: 60,
 		},
-		Correlate: RateLimitCorrelate{
+		Correlate: &RateLimitCorrelate{
 			By: "nat",
 		},
 	}


### PR DESCRIPTION
While looking into an issue in the Terraform provider, I've found that
the `correlate` values for rate limiting are always being sent
regardless of whether the value is set or not. This isn't really a big
deal as I'm assuming the API endpoint just disregard it but for the
Terraform provider, it does make the state management more difficult and
messy than what it needs to be due to the nested types.

Instead of always sending the value, I've updated the struct to allow
`nil` and to omit when the values are empty resulting in a fix for the
issues downstream.