### PR TITLE
Added ProbeZone to LoadBalancerMonitor

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -51,6 +51,7 @@ type LoadBalancerMonitor struct {
 	ExpectedCodes   string              `json:"expected_codes"`
 	FollowRedirects bool                `json:"follow_redirects"`
 	AllowInsecure   bool                `json:"allow_insecure"`
+	ProbeZone       string              `json:"probe_zone"`
 }
 
 // LoadBalancer represents a load balancer's properties.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -406,7 +406,8 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
               "expected_body": "alive",
               "expected_codes": "2xx",
               "follow_redirects": true,
-              "allow_insecure": true
+              "allow_insecure": true,
+              "probe_zone": ""
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -435,7 +436,8 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
                 "expected_body": "alive",
                 "expected_codes": "2xx",
                 "follow_redirects": true,
-                "allow_insecure": true
+                "allow_insecure": true,
+                "probe_zone": ""
             }
         }`)
 	}
@@ -596,7 +598,8 @@ func TestLoadBalancerMonitorDetails(t *testing.T) {
                 "expected_body": "alive",
                 "expected_codes": "2xx",
                 "follow_redirects": true,
-                "allow_insecure": true
+                "allow_insecure": true,
+                "probe_zone": ""
             }
         }`)
 	}
@@ -687,7 +690,8 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "expected_body": "kicking",
                 "expected_codes": "200",
                 "follow_redirects": true,
-                "allow_insecure": true
+                "allow_insecure": true,
+                "probe_zone": ""
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -716,7 +720,8 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "expected_body": "kicking",
                 "expected_codes": "200",
                 "follow_redirects": true,
-                "allow_insecure": true
+                "allow_insecure": true,
+                "probe_zone": ""
             }
         }`)
 	}


### PR DESCRIPTION
This adds ProbeZone to LoadBalancerMonitor a new field for the loadbalancing monitor API.