### PR TITLE
Add support for Cloudflare Registrar

### DIFF
--- a/registrar.go
+++ b/registrar.go
@@ -53,6 +53,15 @@ type RegistrantContact struct {
 	Fax          string `json:"fax"`
 }
 
+// RegistrarDomainConfiguration is the structure for making updates to
+// and existing domain.
+type RegistrarDomainConfiguration struct {
+	NameServers []string `json:"name_servers"`
+	Privacy     bool     `json:"privacy"`
+	Locked      bool     `json:"locked"`
+	AutoRenew   bool     `json:"auto_renew"`
+}
+
 // RegistrarDomainDetailResponse is the structure of the detailed
 // response from the API for a single domain.
 type RegistrarDomainDetailResponse struct {
@@ -142,6 +151,25 @@ func (api *API) CancelRegistrarDomainTransfer(accountID, domainName string) ([]R
 	err = json.Unmarshal(res, &r)
 	if err != nil {
 		return []RegistrarDomain{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// UpdateRegistrarDomain updates an existing Registrar Domain configuration.
+//
+// API reference: https://api.cloudflare.com/#registrar-domains-update-domain
+func (api *API) UpdateRegistrarDomain(accountID, domainName string, domainConfiguration RegistrarDomainConfiguration) (RegistrarDomain, error) {
+	uri := fmt.Sprintf("/accounts/%s/registrar/domains/%s", accountID, domainName)
+
+	res, err := api.makeRequest("PUT", uri, domainConfiguration)
+	if err != nil {
+		return RegistrarDomain{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r RegistrarDomainDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return RegistrarDomain{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/registrar.go
+++ b/registrar.go
@@ -126,3 +126,22 @@ func (api *API) TransferRegistrarDomain(accountID, domainName string) ([]Registr
 	}
 	return r.Result, nil
 }
+
+// CancelRegistrarDomainTransfer cancels a pending domain transfer.
+//
+// API reference: https://api.cloudflare.com/#registrar-domains-cancel-transfer
+func (api *API) CancelRegistrarDomainTransfer(accountID, domainName string) ([]RegistrarDomain, error) {
+	uri := fmt.Sprintf("/accounts/%s/registrar/domains/%s/cancel_transfer", accountID, domainName)
+
+	res, err := api.makeRequest("POST", uri, nil)
+	if err != nil {
+		return []RegistrarDomain{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r RegistrarDomainsDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []RegistrarDomain{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/registrar.go
+++ b/registrar.go
@@ -86,3 +86,24 @@ func (api *API) RegistrarDomain(accountID, domainName string) (RegistrarDomain, 
 	}
 	return r.Result, nil
 }
+
+// RegistrarDomains returns all registrar domains based on the account
+// ID.
+//
+// API reference: https://api.cloudflare.com/#registrar-domains-list-domains
+func (api *API) RegistrarDomains(accountID string) ([]RegistrarDomain, error) {
+	uri := "/accounts/" + accountID + "/registrar/domains"
+
+	res, err := api.makeRequest("POST", uri, nil)
+	if err != nil {
+		return []RegistrarDomain{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r RegistrarDomainsDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []RegistrarDomain{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+

--- a/registrar.go
+++ b/registrar.go
@@ -1,0 +1,88 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// RegistrarDomain is the structure of the API response for a new
+// Cloudflare Registrar domain.
+type RegistrarDomain struct {
+	ID                string              `json:"id"`
+	Available         bool                `json:"available"`
+	SupportedTLD      bool                `json:"supported_tld"`
+	CanRegister       bool                `json:"can_register"`
+	TransferIn        RegistrarTransferIn `json:"transfer_in"`
+	CurrentRegistrar  string              `json:"current_registrar"`
+	ExpiresAt         time.Time           `json:"expires_at"`
+	RegistryStatuses  string              `json:"registry_statuses"`
+	Locked            bool                `json:"locked"`
+	CreatedAt         time.Time           `json:"created_at"`
+	UpdatedAt         time.Time           `json:"updated_at"`
+	RegistrantContact RegistrantContact   `json:"registrant_contact"`
+}
+
+// RegistrarTransferIn contains the structure for a domain transfer in
+// request.
+type RegistrarTransferIn struct {
+	UnlockDomain      string `json:"unlock_domain"`
+	DisablePrivacy    string `json:"disable_privacy"`
+	EnterAuthCode     string `json:"enter_auth_code"`
+	ApproveTransfer   string `json:"approve_transfer"`
+	AcceptFoa         string `json:"accept_foa"`
+	CanCancelTransfer bool   `json:"can_cancel_transfer"`
+}
+
+// RegistrantContact is the contact details for the domain registration.
+type RegistrantContact struct {
+	ID           string `json:"id"`
+	FirstName    string `json:"first_name"`
+	LastName     string `json:"last_name"`
+	Organization string `json:"organization"`
+	Address      string `json:"address"`
+	Address2     string `json:"address2"`
+	City         string `json:"city"`
+	State        string `json:"state"`
+	Zip          string `json:"zip"`
+	Country      string `json:"country"`
+	Phone        string `json:"phone"`
+	Email        string `json:"email"`
+	Fax          string `json:"fax"`
+}
+
+// RegistrarDomainDetailResponse is the structure of the detailed
+// response from the API for a single domain.
+type RegistrarDomainDetailResponse struct {
+	Response
+	Result RegistrarDomain `json:"result"`
+}
+
+// RegistrarDomainsDetailResponse is the structure of the detailed
+// response from the API.
+type RegistrarDomainsDetailResponse struct {
+	Response
+	Result []RegistrarDomain `json:"result"`
+}
+
+// RegistrarDomain returns a single domain based on the account ID and
+// domain name.
+//
+// API reference: https://api.cloudflare.com/#registrar-domains-get-domain
+func (api *API) RegistrarDomain(accountID, domainName string) (RegistrarDomain, error) {
+	uri := fmt.Sprintf("/accounts/%s/registrar/domains/%s", accountID, domainName)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return RegistrarDomain{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r RegistrarDomainDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return RegistrarDomain{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/registrar.go
+++ b/registrar.go
@@ -107,3 +107,22 @@ func (api *API) RegistrarDomains(accountID string) ([]RegistrarDomain, error) {
 	return r.Result, nil
 }
 
+// TransferRegistrarDomain initiates the transfer from another registrar
+// to Cloudflare Registrar.
+//
+// API reference: https://api.cloudflare.com/#registrar-domains-transfer-domain
+func (api *API) TransferRegistrarDomain(accountID, domainName string) ([]RegistrarDomain, error) {
+	uri := fmt.Sprintf("/accounts/%s/registrar/domains/%s/transfer", accountID, domainName)
+
+	res, err := api.makeRequest("POST", uri, nil)
+	if err != nil {
+		return []RegistrarDomain{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r RegistrarDomainsDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []RegistrarDomain{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/registrar_example_test.go
+++ b/registrar_example_test.go
@@ -60,3 +60,14 @@ func ExampleAPI_RegistrarDomain() {
 
 	fmt.Printf("%+v\n", domain)
 }
+
+func ExampleAPI_RegistrarDomains() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	domains, err := api.RegistrarDomains("01a7362d577a6c3019a474fd6f485823")
+
+	fmt.Printf("%+v\n", domains)
+}

--- a/registrar_example_test.go
+++ b/registrar_example_test.go
@@ -82,3 +82,14 @@ func ExampleAPI_TransferRegistrarDomain() {
 
 	fmt.Printf("%+v\n", domain)
 }
+
+func ExampleAPI_CancelRegistrarDomainTransfer() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	domains, err := api.CancelRegistrarDomainTransfer("01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+
+	fmt.Printf("%+v\n", domains)
+}

--- a/registrar_example_test.go
+++ b/registrar_example_test.go
@@ -93,3 +93,21 @@ func ExampleAPI_CancelRegistrarDomainTransfer() {
 
 	fmt.Printf("%+v\n", domains)
 }
+
+func ExampleAPI_UpdateRegistrarDomain() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	domain, err := api.UpdateRegistrarDomain(
+		"01a7362d577a6c3019a474fd6f485823",
+		"cloudflare.com",
+		cloudflare.RegistrarDomainConfiguration{
+			NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
+			Locked:      false,
+		},
+	)
+
+	fmt.Printf("%+v\n", domain)
+}

--- a/registrar_example_test.go
+++ b/registrar_example_test.go
@@ -71,3 +71,14 @@ func ExampleAPI_RegistrarDomains() {
 
 	fmt.Printf("%+v\n", domains)
 }
+
+func ExampleAPI_TransferRegistrarDomain() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	domain, err := api.TransferRegistrarDomain("01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+
+	fmt.Printf("%+v\n", domain)
+}

--- a/registrar_example_test.go
+++ b/registrar_example_test.go
@@ -1,0 +1,62 @@
+package cloudflare_test
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+)
+
+var (
+	createdAndModifiedTimestamp, _ = time.Parse(time.RFC3339, "2018-08-28T17:26:26Z")
+	expiresAtTimestamp, _          = time.Parse(time.RFC3339, "2019-08-28T23:59:59Z")
+	expectedRegistrarTransferIn    = cloudflare.RegistrarTransferIn{
+		UnlockDomain:      "ok",
+		DisablePrivacy:    "ok",
+		EnterAuthCode:     "needed",
+		ApproveTransfer:   "unknown",
+		AcceptFoa:         "needed",
+		CanCancelTransfer: true,
+	}
+	expectedRegistrarContact = cloudflare.RegistrantContact{
+		ID:           "ea95132c15732412d22c1476fa83f27a",
+		FirstName:    "John",
+		LastName:     "Appleseed",
+		Organization: "Cloudflare, Inc.",
+		Address:      "123 Sesame St.",
+		Address2:     "Suite 430",
+		City:         "Austin",
+		State:        "TX",
+		Zip:          "12345",
+		Country:      "US",
+		Phone:        "+1 123-123-1234",
+		Email:        "user@example.com",
+		Fax:          "123-867-5309",
+	}
+	expectedRegistrarDomain = cloudflare.RegistrarDomain{
+		ID:                "ea95132c15732412d22c1476fa83f27a",
+		Available:         false,
+		SupportedTLD:      true,
+		CanRegister:       false,
+		TransferIn:        expectedRegistrarTransferIn,
+		CurrentRegistrar:  "Cloudflare",
+		ExpiresAt:         expiresAtTimestamp,
+		RegistryStatuses:  "ok,serverTransferProhibited",
+		Locked:            false,
+		CreatedAt:         createdAndModifiedTimestamp,
+		UpdatedAt:         createdAndModifiedTimestamp,
+		RegistrantContact: expectedRegistrarContact,
+	}
+)
+
+func ExampleAPI_RegistrarDomain() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	domain, err := api.RegistrarDomain("01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+
+	fmt.Printf("%+v\n", domain)
+}

--- a/registrar_test.go
+++ b/registrar_test.go
@@ -349,3 +349,69 @@ func TestCancelRegistrarDomainTransfer(t *testing.T) {
 		assert.Equal(t, []RegistrarDomain{expectedRegistrarDomain}, actual)
 	}
 }
+
+func TestUpdateRegistrarDomain(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "ea95132c15732412d22c1476fa83f27a",
+				"available": false,
+				"supported_tld": true,
+				"can_register": false,
+				"transfer_in": {
+					"unlock_domain": "ok",
+					"disable_privacy": "ok",
+					"enter_auth_code": "needed",
+					"approve_transfer": "unknown",
+					"accept_foa": "needed",
+					"can_cancel_transfer": true
+				},
+				"current_registrar": "Cloudflare",
+				"expires_at": "2019-08-28T23:59:59Z",
+				"registry_statuses": "ok,serverTransferProhibited",
+				"locked": false,
+				"created_at": "2018-08-28T17:26:26Z",
+				"updated_at": "2018-08-28T17:26:26Z",
+				"registrant_contact": {
+					"id": "ea95132c15732412d22c1476fa83f27a",
+					"first_name": "John",
+					"last_name": "Appleseed",
+					"organization": "Cloudflare, Inc.",
+					"address": "123 Sesame St.",
+					"address2": "Suite 430",
+					"city": "Austin",
+					"state": "TX",
+					"zip": "12345",
+					"country": "US",
+					"phone": "+1 123-123-1234",
+					"email": "user@example.com",
+					"fax": "123-867-5309"
+				}
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/registrar/domains/cloudflare.com", handler)
+
+	actual, err := client.UpdateRegistrarDomain(
+		"01a7362d577a6c3019a474fd6f485823",
+		"cloudflare.com",
+		RegistrarDomainConfiguration{
+			NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
+			Locked:      false,
+		},
+	)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedRegistrarDomain, actual)
+	}
+}

--- a/registrar_test.go
+++ b/registrar_test.go
@@ -148,3 +148,70 @@ func TestRegistrarDomain(t *testing.T) {
 		assert.Equal(t, expectedRegistrarDomain, actual)
 	}
 }
+
+func TestRegistrarDomains(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "ea95132c15732412d22c1476fa83f27a",
+					"available": false,
+					"supported_tld": true,
+					"can_register": false,
+					"transfer_in": {
+						"unlock_domain": "ok",
+						"disable_privacy": "ok",
+						"enter_auth_code": "needed",
+						"approve_transfer": "unknown",
+						"accept_foa": "needed",
+						"can_cancel_transfer": true
+					},
+					"current_registrar": "Cloudflare",
+					"expires_at": "2019-08-28T23:59:59Z",
+					"registry_statuses": "ok,serverTransferProhibited",
+					"locked": false,
+					"created_at": "2018-08-28T17:26:26Z",
+					"updated_at": "2018-08-28T17:26:26Z",
+					"registrant_contact": {
+						"id": "ea95132c15732412d22c1476fa83f27a",
+						"first_name": "John",
+						"last_name": "Appleseed",
+						"organization": "Cloudflare, Inc.",
+						"address": "123 Sesame St.",
+						"address2": "Suite 430",
+						"city": "Austin",
+						"state": "TX",
+						"zip": "12345",
+						"country": "US",
+						"phone": "+1 123-123-1234",
+						"email": "user@example.com",
+						"fax": "123-867-5309"
+					}
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/registrar/domains", handler)
+
+	actual, err := client.RegistrarDomains("01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, []RegistrarDomain{expectedRegistrarDomain}, actual)
+	}
+}

--- a/registrar_test.go
+++ b/registrar_test.go
@@ -215,3 +215,70 @@ func TestRegistrarDomains(t *testing.T) {
 		assert.Equal(t, []RegistrarDomain{expectedRegistrarDomain}, actual)
 	}
 }
+
+func TestTransferRegistrarDomain(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "ea95132c15732412d22c1476fa83f27a",
+					"available": false,
+					"supported_tld": true,
+					"can_register": false,
+					"transfer_in": {
+						"unlock_domain": "ok",
+						"disable_privacy": "ok",
+						"enter_auth_code": "needed",
+						"approve_transfer": "unknown",
+						"accept_foa": "needed",
+						"can_cancel_transfer": true
+					},
+					"current_registrar": "Cloudflare",
+					"expires_at": "2019-08-28T23:59:59Z",
+					"registry_statuses": "ok,serverTransferProhibited",
+					"locked": false,
+					"created_at": "2018-08-28T17:26:26Z",
+					"updated_at": "2018-08-28T17:26:26Z",
+					"registrant_contact": {
+						"id": "ea95132c15732412d22c1476fa83f27a",
+						"first_name": "John",
+						"last_name": "Appleseed",
+						"organization": "Cloudflare, Inc.",
+						"address": "123 Sesame St.",
+						"address2": "Suite 430",
+						"city": "Austin",
+						"state": "TX",
+						"zip": "12345",
+						"country": "US",
+						"phone": "+1 123-123-1234",
+						"email": "user@example.com",
+						"fax": "123-867-5309"
+					}
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/registrar/domains/cloudflare.com/transfer", handler)
+
+	actual, err := client.TransferRegistrarDomain("01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, []RegistrarDomain{expectedRegistrarDomain}, actual)
+	}
+}

--- a/registrar_test.go
+++ b/registrar_test.go
@@ -1,0 +1,150 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	registrarDomainPayload = `{
+		"id": "ea95132c15732412d22c1476fa83f27a",
+		"available": false,
+		"supported_tld": true,
+		"can_register": false,
+		"transfer_in": {
+			"unlock_domain": "ok",
+			"disable_privacy": "ok",
+			"enter_auth_code": "needed",
+			"approve_transfer": "unknown",
+			"accept_foa": "needed",
+			"can_cancel_transfer": true
+		},
+		"current_registrar": "Cloudflare",
+		"expires_at": "2019-08-28T23:59:59Z",
+		"registry_statuses": "ok,serverTransferProhibited",
+		"locked": false,
+		"created_at": "2018-08-28T17:26:26Z",
+		"updated_at": "2018-08-28T17:26:26Z",
+		"registrant_contact": {
+			"id": "ea95132c15732412d22c1476fa83f27a",
+			"first_name": "John",
+			"last_name": "Appleseed",
+			"organization": "Cloudflare, Inc.",
+			"address": "123 Sesame St.",
+			"address2": "Suite 430",
+			"city": "Austin",
+			"state": "TX",
+			"zip": "12345",
+			"country": "US",
+			"phone": "+1 123-123-1234",
+			"email": "user@example.com",
+			"fax": "123-867-5309"
+		}
+	}
+`
+)
+
+var (
+	createdAndModifiedTimestamp, _ = time.Parse(time.RFC3339, "2018-08-28T17:26:26Z")
+	expiresAtTimestamp, _          = time.Parse(time.RFC3339, "2019-08-28T23:59:59Z")
+	expectedRegistrarTransferIn    = RegistrarTransferIn{
+		UnlockDomain:      "ok",
+		DisablePrivacy:    "ok",
+		EnterAuthCode:     "needed",
+		ApproveTransfer:   "unknown",
+		AcceptFoa:         "needed",
+		CanCancelTransfer: true,
+	}
+	expectedRegistrarContact = RegistrantContact{
+		ID:           "ea95132c15732412d22c1476fa83f27a",
+		FirstName:    "John",
+		LastName:     "Appleseed",
+		Organization: "Cloudflare, Inc.",
+		Address:      "123 Sesame St.",
+		Address2:     "Suite 430",
+		City:         "Austin",
+		State:        "TX",
+		Zip:          "12345",
+		Country:      "US",
+		Phone:        "+1 123-123-1234",
+		Email:        "user@example.com",
+		Fax:          "123-867-5309",
+	}
+	expectedRegistrarDomain = RegistrarDomain{
+		ID:                "ea95132c15732412d22c1476fa83f27a",
+		Available:         false,
+		SupportedTLD:      true,
+		CanRegister:       false,
+		TransferIn:        expectedRegistrarTransferIn,
+		CurrentRegistrar:  "Cloudflare",
+		ExpiresAt:         expiresAtTimestamp,
+		RegistryStatuses:  "ok,serverTransferProhibited",
+		Locked:            false,
+		CreatedAt:         createdAndModifiedTimestamp,
+		UpdatedAt:         createdAndModifiedTimestamp,
+		RegistrantContact: expectedRegistrarContact,
+	}
+)
+
+func TestRegistrarDomain(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "ea95132c15732412d22c1476fa83f27a",
+				"available": false,
+				"supported_tld": true,
+				"can_register": false,
+				"transfer_in": {
+					"unlock_domain": "ok",
+					"disable_privacy": "ok",
+					"enter_auth_code": "needed",
+					"approve_transfer": "unknown",
+					"accept_foa": "needed",
+					"can_cancel_transfer": true
+				},
+				"current_registrar": "Cloudflare",
+				"expires_at": "2019-08-28T23:59:59Z",
+				"registry_statuses": "ok,serverTransferProhibited",
+				"locked": false,
+				"created_at": "2018-08-28T17:26:26Z",
+				"updated_at": "2018-08-28T17:26:26Z",
+				"registrant_contact": {
+					"id": "ea95132c15732412d22c1476fa83f27a",
+					"first_name": "John",
+					"last_name": "Appleseed",
+					"organization": "Cloudflare, Inc.",
+					"address": "123 Sesame St.",
+					"address2": "Suite 430",
+					"city": "Austin",
+					"state": "TX",
+					"zip": "12345",
+					"country": "US",
+					"phone": "+1 123-123-1234",
+					"email": "user@example.com",
+					"fax": "123-867-5309"
+				}
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/registrar/domains/cloudflare.com", handler)
+
+	actual, err := client.RegistrarDomain("01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedRegistrarDomain, actual)
+	}
+}

--- a/registrar_test.go
+++ b/registrar_test.go
@@ -282,3 +282,70 @@ func TestTransferRegistrarDomain(t *testing.T) {
 		assert.Equal(t, []RegistrarDomain{expectedRegistrarDomain}, actual)
 	}
 }
+
+func TestCancelRegistrarDomainTransfer(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "ea95132c15732412d22c1476fa83f27a",
+					"available": false,
+					"supported_tld": true,
+					"can_register": false,
+					"transfer_in": {
+						"unlock_domain": "ok",
+						"disable_privacy": "ok",
+						"enter_auth_code": "needed",
+						"approve_transfer": "unknown",
+						"accept_foa": "needed",
+						"can_cancel_transfer": true
+					},
+					"current_registrar": "Cloudflare",
+					"expires_at": "2019-08-28T23:59:59Z",
+					"registry_statuses": "ok,serverTransferProhibited",
+					"locked": false,
+					"created_at": "2018-08-28T17:26:26Z",
+					"updated_at": "2018-08-28T17:26:26Z",
+					"registrant_contact": {
+						"id": "ea95132c15732412d22c1476fa83f27a",
+						"first_name": "John",
+						"last_name": "Appleseed",
+						"organization": "Cloudflare, Inc.",
+						"address": "123 Sesame St.",
+						"address2": "Suite 430",
+						"city": "Austin",
+						"state": "TX",
+						"zip": "12345",
+						"country": "US",
+						"phone": "+1 123-123-1234",
+						"email": "user@example.com",
+						"fax": "123-867-5309"
+					}
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/registrar/domains/cloudflare.com/cancel_transfer", handler)
+
+	actual, err := client.CancelRegistrarDomainTransfer("01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, []RegistrarDomain{expectedRegistrarDomain}, actual)
+	}
+}


### PR DESCRIPTION
This introduces support for Cloudflare Registrar into `cloudflare-go`.

API documentation:

- List domains: https://api.cloudflare.com/#registrar-domains-list-domains
- Get a domain: https://api.cloudflare.com/#registrar-domains-get-domain
- Update a domain: https://api.cloudflare.com/#registrar-domains-update-domain
- Transfer domain: https://api.cloudflare.com/#registrar-domains-transfer-domain
- Cancel a transfer: https://api.cloudflare.com/#registrar-domains-cancel-transfer