### PR TITLE
zone: Paginate `ListZones` for all zones

### DIFF
--- a/zone.go
+++ b/zone.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -342,9 +343,6 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 			}
 		}
 	} else {
-		// TODO: Paginate here. We only grab the first page of results.
-		// Could do this concurrently after the first request by creating a
-		// sync.WaitGroup or just a channel + workers.
 		res, err = api.makeRequest("GET", "/zones", nil)
 		if err != nil {
 			return []Zone{}, errors.Wrap(err, errMakeRequestError)
@@ -353,7 +351,40 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 		if err != nil {
 			return []Zone{}, errors.Wrap(err, errUnmarshalError)
 		}
-		zones = r.Result
+
+		totalPageCount := r.TotalPages
+		var wg sync.WaitGroup
+		wg.Add(totalPageCount)
+		errc := make(chan error)
+
+		for i := 1; i <= totalPageCount; i++ {
+			go func(pageNumber int) error {
+				res, err = api.makeRequest("GET", fmt.Sprintf("/zones?page=%d", pageNumber), nil)
+				if err != nil {
+					errc <- err
+				}
+
+				err = json.Unmarshal(res, &r)
+				if err != nil {
+					errc <- err
+				}
+
+				for _, zone := range r.Result {
+					zones = append(zones, zone)
+				}
+
+				select {
+				case err := <-errc:
+					return err
+				default:
+					wg.Done()
+				}
+
+				return nil
+			}(i)
+		}
+
+		wg.Wait()
 	}
 
 	return zones, nil

--- a/zone.go
+++ b/zone.go
@@ -343,7 +343,7 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 			}
 		}
 	} else {
-		res, err = api.makeRequest("GET", "/zones", nil)
+		res, err = api.makeRequest("GET", "/zones?per_page=50", nil)
 		if err != nil {
 			return []Zone{}, errors.Wrap(err, errMakeRequestError)
 		}
@@ -359,7 +359,7 @@ func (api *API) ListZones(z ...string) ([]Zone, error) {
 
 		for i := 1; i <= totalPageCount; i++ {
 			go func(pageNumber int) error {
-				res, err = api.makeRequest("GET", fmt.Sprintf("/zones?page=%d", pageNumber), nil)
+				res, err = api.makeRequest("GET", fmt.Sprintf("/zones?per_page=50&page=%d", pageNumber), nil)
 				if err != nil {
 					errc <- err
 				}

--- a/zone_example_test.go
+++ b/zone_example_test.go
@@ -13,7 +13,7 @@ func ExampleAPI_ListZones_all() {
 		log.Fatal(err)
 	}
 
-	// Fetch a slice of all zones available to this account.
+	// Fetch all zones available to this user.
 	zones, err := api.ListZones()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
The `ListZones` function has two distinct code paths. The first is for
fetching zones explicitly. You do this by passing in the zones you wish
to return.

```go
ListZones("example.org", "example.net")
```

This will return two `Zone` structs for `example.org` and `example.net`.

The other code path is returning all the zones the user has access to.
Previously, this would only return the first page of results (generally
20 zones). Many customers wouldn't have noticed this was the case but
some larger customers have hundreds or even thousands and would need to
perform multiple requests within their client to get return all pages.

This change addresses the latter by paginating through all pages. It
does this using a `sync.WaitGroup` and sending off concurrent requests
based on the number of `total_pages` returned in the API response.
Channels were considered here but introduced too much complexity and
gun-pointing-at-foot scenarios where it really wasn't needed. The only
use of channels here is to keep track of any errors that pop up during
the request parsing cycle.