### PR TITLE
argo: Add smart routing and tiered caching support

### DIFF
--- a/argo.go
+++ b/argo.go
@@ -1,0 +1,120 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var validSettingValues = []string{"on", "off"}
+
+// ArgoFeatureSetting is the structure of the API object for the
+// argo smart routing and tiered caching settings.
+type ArgoFeatureSetting struct {
+	Editable   bool      `json:"editable,omitempty"`
+	ID         string    `json:"id,omitempty"`
+	ModifiedOn time.Time `json:"modified_on,omitempty"`
+	Value      string    `json:"value"`
+}
+
+// ArgoDetailsResponse is the API response for the argo smart routing
+// and tiered caching response.
+type ArgoDetailsResponse struct {
+	Result ArgoFeatureSetting `json:"result"`
+	Response
+}
+
+// ArgoSmartRouting returns the current settings for smart routing.
+//
+// API reference: https://api.cloudflare.com/#argo-smart-routing-get-argo-smart-routing-setting
+func (api *API) ArgoSmartRouting(zoneID string) (ArgoFeatureSetting, error) {
+	uri := "/zones/" + zoneID + "/argo/smart_routing"
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoDetailsResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return argoDetailsResponse.Result, nil
+}
+
+// UpdateArgoSmartRouting updates the setting for smart routing.
+//
+// API reference: https://api.cloudflare.com/#argo-smart-routing-patch-argo-smart-routing-setting
+func (api *API) UpdateArgoSmartRouting(zoneID, settingValue string) (ArgoFeatureSetting, error) {
+	if !contains(validSettingValues, settingValue) {
+		return ArgoFeatureSetting{}, errors.New(fmt.Sprintf("invalid setting value '%s'. must be 'on' or 'off'", settingValue))
+	}
+
+	uri := "/zones/" + zoneID + "/argo/smart_routing"
+
+	res, err := api.makeRequest("PATCH", uri, ArgoFeatureSetting{Value: settingValue})
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoDetailsResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return argoDetailsResponse.Result, nil
+}
+
+// ArgoTieredCaching returns the current settings for tiered caching.
+//
+// API reference: TBA
+func (api *API) ArgoTieredCaching(zoneID string) (ArgoFeatureSetting, error) {
+	uri := "/zones/" + zoneID + "/argo/tiered_caching"
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoDetailsResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return argoDetailsResponse.Result, nil
+}
+
+// UpdateArgoTieredCaching updates the setting for tiered caching.
+//
+// API reference: TBA
+func (api *API) UpdateArgoTieredCaching(zoneID, settingValue string) (ArgoFeatureSetting, error) {
+	if !contains(validSettingValues, settingValue) {
+		return ArgoFeatureSetting{}, errors.New(fmt.Sprintf("invalid setting value '%s'. must be 'on' or 'off'", settingValue))
+	}
+
+	uri := "/zones/" + zoneID + "/argo/tiered_caching"
+
+	res, err := api.makeRequest("PATCH", uri, ArgoFeatureSetting{Value: settingValue})
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoDetailsResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return ArgoFeatureSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return argoDetailsResponse.Result, nil
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/argo_example_test.go
+++ b/argo_example_test.go
@@ -1,0 +1,64 @@
+package cloudflare_test
+
+import (
+	"fmt"
+	"log"
+
+	cloudflare "github.com/cloudflare/cloudflare-go"
+)
+
+func ExampleAPI_ArgoSmartRouting() {
+	api, err := cloudflare.New("deadbeef", "test@example.org")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	smartRoutingSettings, err := api.ArgoSmartRouting("01a7362d577a6c3019a474fd6f485823")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("smart routing is %s", smartRoutingSettings.Value)
+}
+
+func ExampleAPI_ArgoTieredCaching() {
+	api, err := cloudflare.New("deadbeef", "test@example.org")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tieredCachingSettings, err := api.ArgoTieredCaching("01a7362d577a6c3019a474fd6f485823")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("tiered caching is %s", tieredCachingSettings.Value)
+}
+
+func ExampleAPI_UpdateArgoSmartRouting() {
+	api, err := cloudflare.New("deadbeef", "test@example.org")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	smartRoutingSettings, err := api.UpdateArgoSmartRouting("01a7362d577a6c3019a474fd6f485823", "on")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("smart routing is %s", smartRoutingSettings.Value)
+}
+
+func ExampleAPI_UpdateArgoTieredCaching() {
+	api, err := cloudflare.New("deadbeef", "test@example.org")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tieredCachingSettings, err := api.UpdateArgoTieredCaching("01a7362d577a6c3019a474fd6f485823", "on")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("tiered caching is %s", tieredCachingSettings.Value)
+}

--- a/argo_test.go
+++ b/argo_test.go
@@ -1,0 +1,178 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var argoTimestamp, _ = time.Parse(time.RFC3339Nano, "2019-02-20T22:37:07.107449Z")
+
+func TestArgoSmartRouting(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "smart_routing",
+				"value": "on",
+				"editable": true,
+				"modified_on": "2019-02-20T22:37:07.107449Z"
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/argo/smart_routing", handler)
+	want := ArgoFeatureSetting{
+		ID:         "smart_routing",
+		Value:      "on",
+		Editable:   true,
+		ModifiedOn: argoTimestamp,
+	}
+
+	actual, err := client.ArgoSmartRouting("01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateArgoSmartRouting(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PATCH", "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "smart_routing",
+				"value": "off",
+				"editable": true,
+				"modified_on": "2019-02-20T22:37:07.107449Z"
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/argo/smart_routing", handler)
+	want := ArgoFeatureSetting{
+		ID:         "smart_routing",
+		Value:      "off",
+		Editable:   true,
+		ModifiedOn: argoTimestamp,
+	}
+
+	actual, err := client.UpdateArgoSmartRouting("01a7362d577a6c3019a474fd6f485823", "off")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateArgoSmartRoutingWithInvalidValue(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.UpdateArgoSmartRouting("01a7362d577a6c3019a474fd6f485823", "notreal")
+
+	if assert.Error(t, err) {
+		assert.Equal(t, "invalid setting value 'notreal'. must be 'on' or 'off'", err.Error())
+	}
+}
+
+func TestArgoTieredCaching(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "tiered_caching",
+				"value": "on",
+				"editable": true,
+				"modified_on": "2019-02-20T22:37:07.107449Z"
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/argo/tiered_caching", handler)
+	want := ArgoFeatureSetting{
+		ID:         "tiered_caching",
+		Value:      "on",
+		Editable:   true,
+		ModifiedOn: argoTimestamp,
+	}
+
+	actual, err := client.ArgoTieredCaching("01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateArgoTieredCaching(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PATCH", "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "tiered_caching",
+				"value": "off",
+				"editable": true,
+				"modified_on": "2019-02-20T22:37:07.107449Z"
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/argo/tiered_caching", handler)
+	want := ArgoFeatureSetting{
+		ID:         "tiered_caching",
+		Value:      "off",
+		Editable:   true,
+		ModifiedOn: argoTimestamp,
+	}
+
+	actual, err := client.UpdateArgoTieredCaching("01a7362d577a6c3019a474fd6f485823", "off")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateArgoTieredCachingWithInvalidValue(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.UpdateArgoTieredCaching("01a7362d577a6c3019a474fd6f485823", "notreal")
+
+	if assert.Error(t, err) {
+		assert.Equal(t, "invalid setting value 'notreal'. must be 'on' or 'off'", err.Error())
+	}
+}


### PR DESCRIPTION
Updates the library to support getting and setting Argo smart routing
and tiered caching features. The public API documentation is missing the
payload for the Smart Routing and all documentation for Tiered Caching
however it is apparently [under way](https://github.com/terraform-providers/terraform-provider-cloudflare/issues/219#issuecomment-479632883).

This is a feature request from
terraform-providers/terraform-provider-cloudflare#219 to be able to use
this functionality within the providfer.

cc @martijngonlag