### PR TITLE
Issue 290 update logpush job data

### DIFF
--- a/logpush.go
+++ b/logpush.go
@@ -135,7 +135,7 @@ func (api *API) LogpushJob(zoneID string, jobID int) (LogpushJob, error) {
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
 func (api *API) UpdateLogpushJob(zoneID string, jobID int, job LogpushJob) error {
 	uri := "/zones/" + zoneID + "/logpush/jobs/" + strconv.Itoa(jobID)
-	res, err := api.makeRequest("PUT", uri, nil)
+	res, err := api.makeRequest("PUT", uri, job)
 	if err != nil {
 		return errors.Wrap(err, errMakeRequestError)
 	}

--- a/logpush_example_test.go
+++ b/logpush_example_test.go
@@ -14,6 +14,13 @@ var exampleNewLogpushJob = cloudflare.LogpushJob{
 	DestinationConf: "s3://mybucket/logs?region=us-west-2",
 }
 
+var exampleUpdatedLogpushJob = cloudflare.LogpushJob{
+	Enabled: true, 
+	Name: "updated.com", 
+	LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp",
+	DestinationConf: "gs://mybucket/logs",
+}
+
 func ExampleAPI_CreateLogpushJob() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
@@ -31,6 +38,23 @@ func ExampleAPI_CreateLogpushJob() {
 	}
 
 	fmt.Printf("%+v\n", job)
+}
+
+func ExampleAPI_UpdateLogpushJob() {
+	api, err := cloudflare.New(apiKey, user)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	zoneID, err := api.ZoneIDByName(domain)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = api.UpdateLogpushJob(zoneID, 1, exampleUpdatedLogpushJob)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func ExampleAPI_LogpushJobs() {


### PR DESCRIPTION
Passes the missing job object to the Cloudflare API via makeRequest. 

## Description

The job body was missing as the third parameter to the API client's makeRequest method.

## Has your change been tested?

This was tested locally and resolved the issues I experienced.

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.