### PR TITLE
Add OwnershipChallenge token field to LogpushJob struct

### DIFF
--- a/logpush.go
+++ b/logpush.go
@@ -15,7 +15,7 @@ type LogpushJob struct {
 	Name               string     `json:"name"`
 	LogpullOptions     string     `json:"logpull_options"`
 	DestinationConf    string     `json:"destination_conf"`
-	OwnershipChallenge string     `json:"ownership_challenge"`
+	OwnershipChallenge string     `json:"ownership_challenge,omitempty"`
 	LastComplete       *time.Time `json:"last_complete,omitempty"`
 	LastError          *time.Time `json:"last_error,omitempty"`
 	ErrorMessage       string     `json:"error_message,omitempty"`

--- a/logpush.go
+++ b/logpush.go
@@ -10,14 +10,15 @@ import (
 
 // LogpushJob describes a Logpush job.
 type LogpushJob struct {
-	ID              int        `json:"id,omitempty"`
-	Enabled         bool       `json:"enabled"`
-	Name            string     `json:"name"`
-	LogpullOptions  string     `json:"logpull_options"`
-	DestinationConf string     `json:"destination_conf"`
-	LastComplete    *time.Time `json:"last_complete,omitempty"`
-	LastError       *time.Time `json:"last_error,omitempty"`
-	ErrorMessage    string     `json:"error_message,omitempty"`
+	ID                 int        `json:"id,omitempty"`
+	Enabled            bool       `json:"enabled"`
+	Name               string     `json:"name"`
+	LogpullOptions     string     `json:"logpull_options"`
+	DestinationConf    string     `json:"destination_conf"`
+	OwnershipChallenge string     `json:"ownership_challenge"`
+	LastComplete       *time.Time `json:"last_complete,omitempty"`
+	LastError          *time.Time `json:"last_error,omitempty"`
+	ErrorMessage       string     `json:"error_message,omitempty"`
 }
 
 // LogpushJobsResponse is the API response, containing an array of Logpush Jobs.


### PR DESCRIPTION
To facilitate forthcoming support for Cloudflare logpush jobs in the Cloudflare Terraform provider, this change adds an ```OwnershipChallenge``` token field to the LogpushJob struct. 

LogpushJob create and update tasks require that this token be passed in the body of the API request.

## Has your change been tested?

This was tested locally and works alongside the forthcoming Terraform ```cloudflare_logpush_job``` resource.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.