### PR TITLE
URL Escape the URI

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -267,6 +267,7 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, u
 // *http.Response, or an error if one occurred. The caller is responsible for
 // closing the response body.
 func (api *API) request(ctx context.Context, method, uri string, reqBody io.Reader, authType int, headers http.Header) (*http.Response, error) {
+	uri = url.PathEscape(uri)
 	req, err := http.NewRequest(method, api.BaseURL+uri, reqBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request creation failed")


### PR DESCRIPTION
Currently, the path is used for submitting data that may contain special characters. For example, if you try to set up bulk redirects in Workers with KV per https://developers.cloudflare.com/workers/recipes/bulk-redirects/, the key '/pathtoreplace' is stored in KV as 'pathtoreplace'. Currently, the caller has to URL encode the submission to the api.WriteWorkersKV() call to ensure the slashes get through.

I can't think of a situation where we wouldn't want to URL encode a path, since it's built with a simple Sprintf() call in the higher level functions - adding an encode would the right thing instead of passively allowing data loss.

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Description

Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].

## Has your change been tested?

Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
