### PR TITLE
URL Encode Key values

### DIFF
--- a/workers_kv.go
+++ b/workers_kv.go
@@ -125,6 +125,7 @@ func (api *API) UpdateWorkersKVNamespace(ctx context.Context, namespaceID string
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair
 func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, value []byte) (Response, error) {
+	key = url.PathEscape(key)
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, key)
 	res, err := api.makeRequestWithAuthTypeAndHeaders(
 		ctx, http.MethodPut, uri, value, api.authType, http.Header{"Content-Type": []string{"application/octet-stream"}},
@@ -145,6 +146,7 @@ func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, val
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair
 func (api API) ReadWorkersKV(ctx context.Context, namespaceID, key string) ([]byte, error) {
+	key = url.PathEscape(key)
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, key)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
@@ -157,6 +159,7 @@ func (api API) ReadWorkersKV(ctx context.Context, namespaceID, key string) ([]by
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair
 func (api API) DeleteWorkersKV(ctx context.Context, namespaceID, key string) (Response, error) {
+	key = url.PathEscape(key)
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, key)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
Currently, the path is used for submitting data that may contain special characters. For example, if you try to set up bulk redirects in Workers with KV per https://developers.cloudflare.com/workers/recipes/bulk-redirects/, the key '/pathtoreplace' is stored in KV as 'pathtoreplace'. Currently, the caller has to URL encode the submission to the api.WriteWorkersKV() call to ensure the slashes get through.

I can't think of a situation where we wouldn't want to URL encode a key as soon as the user submits it - adding an encode would do the right thing instead of passively allowing data loss.