### PR TITLE
[BREAKING] Workers KV refactor, add bulk write and key expiry API

### DIFF
--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -24,10 +24,6 @@ func formatDNSRecord(record cloudflare.DNSRecord) []string {
 }
 
 func dnsCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "name", "type", "content"); err != nil {
 		return
 	}
@@ -65,10 +61,6 @@ func dnsCreate(c *cli.Context) {
 }
 
 func dnsCreateOrUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "name", "type", "content"); err != nil {
 		fmt.Println(err)
 		return
@@ -141,10 +133,6 @@ func dnsCreateOrUpdate(c *cli.Context) {
 }
 
 func dnsUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		fmt.Println(err)
 		return
@@ -177,10 +165,6 @@ func dnsUpdate(c *cli.Context) {
 }
 
 func dnsDelete(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		fmt.Println(err)
 		return

--- a/cmd/flarectl/firewall.go
+++ b/cmd/flarectl/firewall.go
@@ -22,11 +22,6 @@ func formatAccessRule(rule cloudflare.AccessRule) []string {
 }
 
 func firewallAccessRules(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	organizationID, zoneID, err := getScope(c)
 	if err != nil {
 		return
@@ -88,10 +83,6 @@ func firewallAccessRules(c *cli.Context) {
 }
 
 func firewallAccessRuleCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "mode", "value"); err != nil {
 		fmt.Println(err)
 		return
@@ -145,10 +136,6 @@ func firewallAccessRuleCreate(c *cli.Context) {
 }
 
 func firewallAccessRuleUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "id"); err != nil {
 		fmt.Println(err)
 		return
@@ -200,10 +187,6 @@ func firewallAccessRuleUpdate(c *cli.Context) {
 }
 
 func firewallAccessRuleCreateOrUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "mode", "value"); err != nil {
 		fmt.Println(err)
 		return
@@ -272,10 +255,6 @@ func firewallAccessRuleCreateOrUpdate(c *cli.Context) {
 }
 
 func firewallAccessRuleDelete(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "id"); err != nil {
 		fmt.Println(err)
 		return

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -392,10 +392,143 @@ func main() {
 					Aliases: []string{"l"},
 					Action:  pageRules,
 					Usage:   "List Page Rules for a zone",
+				},
+			},
+		},
+
+		{
+			Name:    "key-value",
+			Aliases: []string{"kv"},
+			Usage:   "Workers KV",
+			Subcommands: []cli.Command{
+				{
+					Name:    "write",
+					Aliases: []string{"w"},
+					Action:  kvWrite,
+					Usage:   "Write a key-value pair to a namespace",
 					Flags: []cli.Flag{
 						cli.StringFlag{
-							Name:  "zone",
-							Usage: "zone name",
+							Name:  "namespace, n",
+							Usage: "name or ID of the namespace",
+						},
+						cli.StringFlag{
+							Name:  "key, k",
+							Usage: "key name of the pair",
+						},
+						cli.StringFlag{
+							Name:  "value, v",
+							Usage: "value of the pair",
+						},
+						cli.IntFlag{
+							Name:  "expiration, e",
+							Usage: "expiration of the pair",
+						},
+						cli.DurationFlag{
+							Name:  "ttl, t",
+							Usage: "expiration ttl of the pair",
+						},
+					},
+				},
+				{
+					Name:    "upload",
+					Aliases: []string{"u"},
+					Action:  kvUpload,
+					Usage:   "Upload file(s) to a namespace",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "namespace, n",
+							Usage: "name or ID of the namespace",
+						},
+						cli.StringFlag{
+							Name:  "key, k",
+							Usage: "format string to make keys from their path",
+							Value: "%s",
+						},
+						cli.StringFlag{
+							Name:  "filter, f",
+							Usage: "regex expression to filter for paths",
+							Value: ".*",
+						},
+						cli.StringFlag{
+							Name:  "path, p",
+							Usage: "path of the file or directory to upload",
+						},
+						cli.BoolFlag{
+							Name:  "recursive, r",
+							Usage: "whether to search for files recursively",
+						},
+						cli.IntFlag{
+							Name:  "expiration, e",
+							Usage: "expiration of each file",
+						},
+						cli.DurationFlag{
+							Name:  "ttl, t",
+							Usage: "expiration ttl of each file",
+						},
+						cli.BoolFlag{
+							Name:  "unsafe, u",
+							Usage: "whether to NOT check for max upload limits",
+						},
+					},
+				},
+				{
+					Name:    "read",
+					Aliases: []string{"r"},
+					Action:  kvRead,
+					Usage:   "Read key-value pair(s) from a namespace",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "namespace, n",
+							Usage: "name or ID of the namespace",
+						},
+						cli.StringSliceFlag{
+							Name:  "key, k",
+							Usage: "key name of the pair(s)",
+						},
+						cli.BoolFlag{
+							Name:  "raw, r",
+							Usage: "whether to print the raw value",
+						},
+					},
+				},
+				{
+					Name:    "delete",
+					Aliases: []string{"d"},
+					Action:  kvDelete,
+					Usage:   "Delete key-value pair(s) from a namespace",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "namespace, n",
+							Usage: "name or ID of the namespace",
+						},
+						cli.StringSliceFlag{
+							Name:  "key, k",
+							Usage: "key name of the pair(s)",
+						},
+					},
+				}, {
+					Name:    "list",
+					Aliases: []string{"l"},
+					Action:  kvList,
+					Usage:   "List key-value pairs in a namespace",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "namespace, n",
+							Usage: "name or ID of the namespace",
+						},
+						cli.StringFlag{
+							Name:  "cursor, c",
+							Usage: "cursor from the previous list operation",
+							Value: "",
+						},
+						cli.IntFlag{
+							Name:  "limit, l",
+							Usage: "maximum number of pairs to list",
+							Value: 20,
+						},
+						cli.BoolFlag{
+							Name:  "values, v",
+							Usage: "whether to also fetch values",
 						},
 					},
 				},

--- a/cmd/flarectl/user_agent.go
+++ b/cmd/flarectl/user_agent.go
@@ -20,11 +20,6 @@ func formatUserAgentRule(rule cloudflare.UserAgentRule) []string {
 }
 
 func userAgentCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "mode", "value"); err != nil {
 		fmt.Println(err)
 		return
@@ -60,11 +55,6 @@ func userAgentCreate(c *cli.Context) {
 }
 
 func userAgentUpdate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "id", "mode", "value"); err != nil {
 		return
 	}
@@ -99,11 +89,6 @@ func userAgentUpdate(c *cli.Context) {
 }
 
 func userAgentDelete(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "id"); err != nil {
 		return
 	}
@@ -128,11 +113,6 @@ func userAgentDelete(c *cli.Context) {
 }
 
 func userAgentList(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	if err := checkFlags(c, "zone", "page"); err != nil {
 		return
 	}

--- a/cmd/flarectl/workers_kv.go
+++ b/cmd/flarectl/workers_kv.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/codegangsta/cli"
+)
+
+var kvMaxCharView = 100 // Maximum chars of a value to preview
+
+func kvPair(ns string, pair *cloudflare.WorkersKVPair) []string {
+	expires := "Never"
+	if pair.Expiration > 0 {
+		expires = strconv.FormatUint(uint64(pair.Expiration), 10)
+	}
+	value := string(pair.Value)
+	if len(value) > kvMaxCharView {
+		value = value[0:kvMaxCharView] + "..."
+	}
+	return []string{
+		ns,
+		pair.Name,
+		expires,
+		value,
+		strconv.FormatInt(int64(len(pair.Value)), 10),
+	}
+}
+
+func kvNamespace(c *cli.Context) string {
+	if err := checkFlags(c, "namespace"); err != nil {
+		return ""
+	}
+
+	split := strings.SplitN(c.String("namespace"), ":", 2)
+	prefix := split[0]
+	if len(split) < 2 || !(prefix == "name" || prefix == "id") {
+		fmt.Println("error: namespace must be in format id:<namespace id> or name:<namespace title>")
+		return ""
+	}
+	title := split[1]
+	if prefix == "id" {
+		return title
+	}
+
+	list, err := api.ListWorkersKVNamespaces(context.Background())
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	for i := 0; i < len(list.Result); i++ {
+		ns := list.Result[i]
+		if ns.Title == title {
+			return ns.ID
+		}
+	}
+
+	res, err := api.CreateWorkersKVNamespace(context.Background(),
+		&cloudflare.WorkersKVNamespaceRequest{Title: title})
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+
+	return res.Result.ID
+}
+
+func kvRead(c *cli.Context) {
+	if err := checkFlags(c, "key"); err != nil {
+		return
+	}
+	keys := c.StringSlice("key")
+
+	ns := kvNamespace(c)
+	if ns == "" {
+		return
+	}
+
+	raw := c.Bool("raw")
+	if raw && len(keys) > 1 {
+		fmt.Println("error: cannot combine --raw with multiple keys")
+		return
+	}
+
+	output := [][]string{}
+	for _, key := range keys {
+		pair, err := api.ReadWorkersKVPair(context.Background(), ns, key)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+
+		if raw {
+			fmt.Print(string(pair.Value))
+			return
+		}
+		output = append(output, kvPair(ns, &pair))
+	}
+
+	writeTable(output, "Namespace ID", "Key", "Expiration", "Value", "Bytes")
+}
+
+func kvWrite(c *cli.Context) {
+	ns := kvNamespace(c)
+	if ns == "" {
+		return
+	}
+
+	if err := checkFlags(c, "key", "value"); err != nil {
+		return
+	}
+
+	pair := &cloudflare.WorkersKVPair{
+		Name:          c.String("key"),
+		Value:         c.String("value"),
+		Expiration:    uint(c.Int("expiration")),
+		ExpirationTTL: uint(c.Duration("ttl").Seconds()),
+	}
+	_, err := api.WriteWorkersKVPair(context.Background(), ns, pair)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	kvRead(c)
+}
+
+func kvDelete(c *cli.Context) {
+	if err := checkFlags(c, "key"); err != nil {
+		return
+	}
+	key := c.String("key")
+
+	ns := kvNamespace(c)
+	if ns == "" {
+		return
+	}
+
+	_, err := api.DeleteWorkersKVPair(context.Background(), ns, key)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}
+
+func kvList(c *cli.Context) {
+	ns := kvNamespace(c)
+	if ns == "" {
+		return
+	}
+	page := cloudflare.WorkersKVKeyPagination{
+		Cursor: c.String("cursor"),
+		Count:  uint(c.Int("limit")),
+	}
+	res, err := api.ListWorkersKVKeys(context.Background(), ns, &page)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	output := [][]string{
+		[]string{
+			ns,
+			strconv.FormatUint(uint64(res.ResultInfo.Count), 10),
+			res.ResultInfo.Cursor,
+		},
+	}
+	writeTable(output, "Namespace ID", "Count", "Cursor")
+
+	values := c.Bool("values")
+	output = [][]string{}
+	for _, key := range res.Result {
+		if values {
+			pair, err := api.ReadWorkersKVPair(context.Background(), ns, key.Name)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
+			output = append(output, kvPair(ns, &pair)[1:5])
+		} else {
+			pair := cloudflare.WorkersKVPair{Name: key.Name, Expiration: key.Expiration}
+			output = append(output, kvPair(ns, &pair)[1:3])
+		}
+	}
+
+	if values {
+		writeTable(output, "Key", "Expiration", "Value", "Bytes")
+	} else {
+		writeTable(output, "Key", "Expiration")
+	}
+}
+
+// Technically the official limits are larger than this,
+// however the payload size becomes larger due to string encoding.
+//
+// With discretion, use --unsafe to get around these limits.
+
+var kvMaxRequestSize int64 = 2.097e+7 // 20MB approximately
+var kvMaxValueSize int64 = 1.049e+6   // 1MB per value
+var kvMaxKeyAmount int64 = 1e4        // 10k keys
+
+func kvUpload(c *cli.Context) {
+	ns := kvNamespace(c)
+	if err := checkFlags(c, "path"); err != nil || ns == "" {
+		return
+	}
+
+	unsafe := c.Bool("unsafe")
+	root := c.String("path")
+	os.Chdir(root)
+
+	var statOk int64     // Number of uploaded files
+	var statIgnore int64 // Number of ignored files
+	var statSize int64   // Total bytes so far in this batch
+	var statTotal int64  // Total bytes in all batches
+	var statBatch int64  // Number of batches
+
+	pairs := []*cloudflare.WorkersKVPair{}
+	var path string
+	err := filepath.Walk(root, func(pth string, info os.FileInfo, err error) error {
+		path = pth
+		if err != nil {
+			return err
+		}
+
+		match, _ := regexp.MatchString(c.String("filter"), path)
+		if info.IsDir() {
+			if root != path && !c.Bool("recursive") {
+				return filepath.SkipDir
+			}
+		} else if match {
+			key := c.String("key")
+			if strings.Count(key, "%s") != 0 {
+				key = fmt.Sprintf(c.String("key"), strings.Replace(path, root, "", 1))
+			}
+
+			var size = int64(info.Size())
+			if !unsafe && size > kvMaxValueSize {
+				statIgnore++
+				return nil
+			}
+
+			if !unsafe && (int64(len(pairs)) >= kvMaxKeyAmount || statSize >= kvMaxRequestSize) {
+				_, err := api.WriteWorkersKVPairBulk(context.Background(), ns, pairs)
+				if err != nil {
+					return err
+				}
+
+				pairs = []*cloudflare.WorkersKVPair{}
+				statBatch++
+				statTotal += statSize
+				statSize = 0
+			}
+
+			data, err := ioutil.ReadFile(path)
+			size = int64(len(data))
+			if err != nil {
+				fmt.Println(err)
+				return nil
+			}
+
+			pairs = append(pairs, &cloudflare.WorkersKVPair{
+				Name:          key,
+				Value:         string(data),
+				Expiration:    uint(c.Int("expiration")),
+				ExpirationTTL: uint(c.Duration("ttl").Seconds()),
+			})
+			statSize += size + int64(len(key))
+			statOk++
+		}
+
+		return nil
+	})
+	if err != nil {
+		fmt.Printf("upload error @ %s:\n", path)
+		fmt.Println(err)
+		return
+	}
+
+	if len(pairs) > 0 {
+		_, err = api.WriteWorkersKVPairBulk(context.Background(), ns, pairs)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		statBatch++
+		statTotal += statSize
+	}
+
+	output := [][]string{{
+		strconv.FormatInt(statOk, 10),
+		strconv.FormatInt(statIgnore, 10),
+		strconv.FormatInt(statTotal, 10),
+		strconv.FormatInt(statBatch, 10),
+	}}
+	writeTable(output, "Ok", "Ignored", "Bytes", "Requests")
+}

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -19,10 +19,6 @@ func zoneRailgun(*cli.Context) {
 }
 
 func zoneCreate(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone"); err != nil {
 		return
 	}
@@ -47,10 +43,6 @@ func zoneCreate(c *cli.Context) {
 }
 
 func zoneCheck(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	if err := checkFlags(c, "zone"); err != nil {
 		return
 	}
@@ -71,10 +63,6 @@ func zoneCheck(c *cli.Context) {
 }
 
 func zoneList(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	zones, err := api.ListZones()
 	if err != nil {
 		fmt.Println(err)
@@ -93,10 +81,6 @@ func zoneList(c *cli.Context) {
 }
 
 func zoneInfo(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	var zone string
 	if len(c.Args()) > 0 {
 		zone = c.Args()[0]
@@ -139,12 +123,6 @@ func zoneSettings(*cli.Context) {
 }
 
 func zoneCachePurge(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		cli.ShowSubcommandHelp(c)
-		return
-	}
-
 	if err := checkFlags(c, "zone"); err != nil {
 		cli.ShowSubcommandHelp(c)
 		return
@@ -199,10 +177,6 @@ func zoneCachePurge(c *cli.Context) {
 }
 
 func zoneRecords(c *cli.Context) {
-	if err := checkEnv(); err != nil {
-		fmt.Println(err)
-		return
-	}
 	var zone string
 	if len(c.Args()) > 0 {
 		zone = c.Args()[0]

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -5,46 +5,65 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/pkg/errors"
 )
 
-// WorkersKVNamespaceRequest provides parameters for creating and updating storage namespaces
-type WorkersKVNamespaceRequest struct {
-	Title string `json:"title"`
-}
-
-// WorkersKVNamespaceResponse is the response received when creating storage namespaces
-type WorkersKVNamespaceResponse struct {
-	Response
-	Result WorkersKVNamespace `json:"result"`
-}
-
-// WorkersKVNamespace contains the unique identifier and title of a storage namespace
+// WorkersKVNamespace contains the unique identifier and title of a kv namespace.
 type WorkersKVNamespace struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
 }
 
-// ListWorkersKVNamespacesResponse contains a slice of storage namespaces associated with an
-// account, pagination information, and an embedded response struct
-type ListWorkersKVNamespacesResponse struct {
+// WorkersKVNamespaceRequest provides parameters for creating and updating kv namespaces.
+type WorkersKVNamespaceRequest struct {
+	Title string `json:"title"`
+}
+
+// WorkersKVNamespaceResponse is the response received when creating or updating kv namespaces.
+type WorkersKVNamespaceResponse struct {
+	Response
+	Result WorkersKVNamespace `json:"result"`
+}
+
+// WorkersKVNamespaceListResponse contains a slice of kv namespaces associated with an
+// account, pagination information, and an embedded response struct.
+type WorkersKVNamespaceListResponse struct {
 	Response
 	Result     []WorkersKVNamespace `json:"result"`
 	ResultInfo `json:"result_info"`
 }
 
-// StorageKey is a key name used to identify a storage value
-type StorageKey struct {
-	Name string `json:"name"`
+// ListWorkersKVNamespacesResponse is deprecated, use WorkersKVNamespaceListResponse instead.
+type ListWorkersKVNamespacesResponse = WorkersKVNamespaceListResponse
+
+// WorkersKVKey contains the name and expiration of a kv key.
+type WorkersKVKey struct {
+	Name       string `json:"name"`
+	Expiration uint   `json:"expiration,omitempty"`
 }
 
-// ListStorageKeysResponse contains a slice of keys belonging to a storage namespace,
-// pagination information, and an embedded response struct
-type ListStorageKeysResponse struct {
+// WorkersKVPair contains all key, value, and expiration of a kv pair.
+type WorkersKVPair struct {
+	Name          string `json:"key"`
+	Value         string `json:"value"`
+	Expiration    uint   `json:"expiration,omitempty"`
+	ExpirationTTL uint   `json:"expiration_ttl,omitempty"`
+}
+
+// WorkersKVKeyListResponse is the response received when listing kv keys in a namespace.
+type WorkersKVKeyListResponse struct {
 	Response
-	Result     []StorageKey `json:"result"`
-	ResultInfo `json:"result_info"`
+	Result     []WorkersKVKey         `json:"result"`
+	ResultInfo WorkersKVKeyPagination `json:"result_info"`
+}
+
+// WorkersKVKeyPagination contains metadata about listing kv keys in a namespace.
+type WorkersKVKeyPagination struct {
+	Count  uint   `json:"count"`
+	Cursor string `json:"cursor"`
 }
 
 // CreateWorkersKVNamespace creates a namespace under the given title.
@@ -67,17 +86,17 @@ func (api *API) CreateWorkersKVNamespace(ctx context.Context, req *WorkersKVName
 	return result, err
 }
 
-// ListWorkersKVNamespaces lists storage namespaces
+// ListWorkersKVNamespaces lists kv namespaces.
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-list-namespaces
-func (api *API) ListWorkersKVNamespaces(ctx context.Context) (ListWorkersKVNamespacesResponse, error) {
+func (api *API) ListWorkersKVNamespaces(ctx context.Context) (WorkersKVNamespaceListResponse, error) {
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces", api.OrganizationID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
-		return ListWorkersKVNamespacesResponse{}, errors.Wrap(err, errMakeRequestError)
+		return WorkersKVNamespaceListResponse{}, errors.Wrap(err, errMakeRequestError)
 	}
 
-	result := ListWorkersKVNamespacesResponse{}
+	result := WorkersKVNamespaceListResponse{}
 	if err := json.Unmarshal(res, &result); err != nil {
 		return result, errors.Wrap(err, errUnmarshalError)
 	}
@@ -85,7 +104,7 @@ func (api *API) ListWorkersKVNamespaces(ctx context.Context) (ListWorkersKVNames
 	return result, err
 }
 
-// DeleteWorkersKVNamespace deletes the namespace corresponding to the given ID
+// DeleteWorkersKVNamespace deletes the namespace corresponding to the given ID.
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-remove-a-namespace
 func (api *API) DeleteWorkersKVNamespace(ctx context.Context, namespaceID string) (Response, error) {
@@ -103,7 +122,7 @@ func (api *API) DeleteWorkersKVNamespace(ctx context.Context, namespaceID string
 	return result, err
 }
 
-// UpdateWorkersKVNamespace modifies a namespace's title
+// UpdateWorkersKVNamespace modifies a namespace's title.
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-rename-a-namespace
 func (api *API) UpdateWorkersKVNamespace(ctx context.Context, namespaceID string, req *WorkersKVNamespaceRequest) (Response, error) {
@@ -121,14 +140,23 @@ func (api *API) UpdateWorkersKVNamespace(ctx context.Context, namespaceID string
 	return result, err
 }
 
-// WriteWorkersKV writes a value identified by a key.
+// WriteWorkersKVPair writes a value identified by a key.
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair
-func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, value []byte) (Response, error) {
-	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, key)
+func (api *API) WriteWorkersKVPair(ctx context.Context, namespaceID string, pair *WorkersKVPair) (Response, error) {
+	params := url.Values{}
+	expires := pair.Expiration
+	if expires > 0 {
+		params.Set("expiration", strconv.Itoa(int(expires)))
+	}
+	expires = pair.ExpirationTTL
+	if expires > 0 {
+		params.Set("expiration_ttl", strconv.Itoa(int(expires)))
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s?"+params.Encode(), api.OrganizationID, namespaceID, url.PathEscape(pair.Name))
 	res, err := api.makeRequestWithAuthTypeAndHeaders(
-		ctx, http.MethodPut, uri, value, api.authType, http.Header{"Content-Type": []string{"application/octet-stream"}},
-	)
+		ctx, http.MethodPut, uri, pair.Value, api.authType, http.Header{"Content-Type": []string{"application/octet-stream"}})
 	if err != nil {
 		return Response{}, errors.Wrap(err, errMakeRequestError)
 	}
@@ -141,23 +169,63 @@ func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, val
 	return result, err
 }
 
-// ReadWorkersKV returns the value associated with the given key in the given namespace
+// WriteWorkersKV writes a value identified by a key.
 //
-// API reference: https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair
-func (api API) ReadWorkersKV(ctx context.Context, namespaceID, key string) ([]byte, error) {
-	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, key)
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, errMakeRequestError)
-	}
-	return res, nil
+// Deprecated: Use WriteWorkersKVPair instead.
+func (api API) WriteWorkersKV(ctx context.Context, namespaceID, key string, value []byte) (Response, error) {
+	return api.WriteWorkersKVPair(ctx, namespaceID, &WorkersKVPair{Name: key, Value: string(value)})
 }
 
-// DeleteWorkersKV deletes a key and value for a provided storage namespace
+// WriteWorkersKVPairBulk writes multiple key-value pairs.
+//
+// API reference: https://api.cloudflare.com/#workers-kv-namespace-write-key-value-pair
+func (api *API) WriteWorkersKVPairBulk(ctx context.Context, namespaceID string, pairs []*WorkersKVPair) (Response, error) {
+	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk", api.OrganizationID, namespaceID)
+	res, err := api.makeRequestWithAuthTypeAndHeaders(
+		ctx, http.MethodPut, uri, pairs, api.authType, http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return Response{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := Response{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return result, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result, err
+}
+
+// ReadWorkersKVPair returns the kv pair associated with the given key in the given namespace.
+//
+// API reference: https://api.cloudflare.com/#workers-kv-namespace-read-key-value-pair
+func (api *API) ReadWorkersKVPair(ctx context.Context, namespaceID, key string) (WorkersKVPair, error) {
+	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, url.PathEscape(key))
+	res, headers, err := api.makeRequestWithAuthTypeAndHeadersTuple(ctx, http.MethodGet, uri, nil, api.authType, http.Header{"Content-Type": []string{"application/octet-stream"}})
+	if err != nil {
+		return WorkersKVPair{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	expiration, _ := strconv.ParseUint(headers.Get("Expiration"), 10, 64)
+	return WorkersKVPair{
+		Name:       key,
+		Value:      string(res),
+		Expiration: uint(expiration),
+	}, nil
+}
+
+// ReadWorkersKV returns the kv pair associated with the given key in the given namespace.
+//
+// Deprecated: Use ReadWorkersKVPair instead.
+func (api API) ReadWorkersKV(ctx context.Context, namespaceID, key string) ([]byte, error) {
+	pair, err := api.ReadWorkersKVPair(ctx, namespaceID, key)
+	return []byte(pair.Value), err
+}
+
+// DeleteWorkersKVPair deletes the kv pair associated with the given key in the given namespace.
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-delete-key-value-pair
-func (api API) DeleteWorkersKV(ctx context.Context, namespaceID, key string) (Response, error) {
-	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, key)
+func (api *API) DeleteWorkersKVPair(ctx context.Context, namespaceID, key string) (Response, error) {
+	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.OrganizationID, namespaceID, url.PathEscape(key))
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {
 		return Response{}, errors.Wrap(err, errMakeRequestError)
@@ -170,17 +238,34 @@ func (api API) DeleteWorkersKV(ctx context.Context, namespaceID, key string) (Re
 	return result, err
 }
 
-// ListWorkersKVs lists a namespace's keys
+// DeleteWorkersKV deletes the kv pair associated with the given key in the given namespace.
+//
+// Deprecated: Use DeleteWorkersKVPair instead.
+func (api API) DeleteWorkersKV(ctx context.Context, namespaceID, key string) (Response, error) {
+	return api.DeleteWorkersKVPair(ctx, namespaceID, key)
+}
+
+// ListWorkersKVKeys lists the keys in the given namespace.
 //
 // API Reference: https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys
-func (api API) ListWorkersKVs(ctx context.Context, namespaceID string) (ListStorageKeysResponse, error) {
-	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/keys", api.OrganizationID, namespaceID)
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return ListStorageKeysResponse{}, errors.Wrap(err, errMakeRequestError)
+func (api *API) ListWorkersKVKeys(ctx context.Context, namespaceID string, request *WorkersKVKeyPagination) (WorkersKVKeyListResponse, error) {
+	params := url.Values{}
+	limit := request.Count
+	if limit > 0 {
+		params.Set("limit", strconv.Itoa(int(limit)))
+	}
+	cursor := request.Cursor
+	if cursor != "" {
+		params.Set("cursor", cursor)
 	}
 
-	result := ListStorageKeysResponse{}
+	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/keys?"+params.Encode(), api.OrganizationID, namespaceID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return WorkersKVKeyListResponse{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := WorkersKVKeyListResponse{}
 	if err := json.Unmarshal(res, &result); err != nil {
 		return result, errors.Wrap(err, errUnmarshalError)
 	}

--- a/workers_kv_example_test.go
+++ b/workers_kv_example_test.go
@@ -70,16 +70,16 @@ func ExampleAPI_UpdateWorkersKVNamespace() {
 	fmt.Println(resp)
 }
 
-func ExampleAPI_WriteWorkersKV() {
+func ExampleAPI_WriteWorkersKVPair() {
 	api, err := cloudflare.New(apiKey, user, cloudflare.UsingOrganization(org))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	payload := []byte("test payload")
-	key := "test_key"
+	payload := "test payload"
+	key := "/test_key"
 
-	resp, err := api.WriteWorkersKV(context.Background(), namespace, key, payload)
+	resp, err := api.WriteWorkersKVPair(context.Background(), namespace, &cloudflare.WorkersKVPair{Name: key, Value: payload})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -87,29 +87,32 @@ func ExampleAPI_WriteWorkersKV() {
 	fmt.Println(resp)
 }
 
-func ExampleAPI_ReadWorkersKV() {
+func ExampleAPI_WriteWorkersKVPairBulk() {
 	api, err := cloudflare.New(apiKey, user, cloudflare.UsingOrganization(org))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	key := "test_key"
-	resp, err := api.ReadWorkersKV(context.Background(), namespace, key)
+	pairs := []*cloudflare.WorkersKVPair{
+		{Name: "key-1", Value: "value-1"},
+		{Name: "key-2", Value: "value-2"}}
+
+	resp, err := api.WriteWorkersKVPairBulk(context.Background(), namespace, pairs)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("%s\n", resp)
+	fmt.Println(resp)
 }
 
-func ExampleAPI_DeleteWorkersKV() {
+func ExampleAPI_ReadWorkersKVPair() {
 	api, err := cloudflare.New(apiKey, user, cloudflare.UsingOrganization(org))
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	key := "test_key"
-	resp, err := api.DeleteWorkersKV(context.Background(), namespace, key)
+	resp, err := api.ReadWorkersKVPair(context.Background(), namespace, key)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -117,13 +120,28 @@ func ExampleAPI_DeleteWorkersKV() {
 	fmt.Printf("%+v\n", resp)
 }
 
-func ExampleAPI_ListWorkersKVs() {
+func ExampleAPI_DeleteWorkersKVPair() {
 	api, err := cloudflare.New(apiKey, user, cloudflare.UsingOrganization(org))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	resp, err := api.ListWorkersKVs(context.Background(), namespace)
+	key := "test_key"
+	resp, err := api.DeleteWorkersKVPair(context.Background(), namespace, key)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", resp)
+}
+
+func ExampleAPI_ListWorkersKVKeys() {
+	api, err := cloudflare.New(apiKey, user, cloudflare.UsingOrganization(org))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := api.ListWorkersKVKeys(context.Background(), namespace, &cloudflare.WorkersKVKeyPagination{Count: 1000})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description
In trying to implement expiring keys and looking at the PR (#309) for bulk endpoints, I quickly realized the Workers KV module needs some refactoring. If we plan on having features like access control in the future, we'll want to do this sooner than later. Since KV is still recently GA and we (storage team) know how many people are using KV, the API disruption should be minimal.

### New
* Added `WorkersKVPair` to unify parameters for read/write and singleton/bulk APIs
* Add new bulk write API
  * `WriteWorkersKVPairBulk(ns, key, []*struct)`

### Backwards-Compatible
* Expose `http.Header` to `makeRequest` method
* Ensure consistent nomenclature to `WorkersKV<Type><Action>`
  * Pure struct renames, with backwards compatible aliases
    * `ListWorkersKVNamespacesResponse` -> `WorkersKVNamespaceListResponse`
    * `StorageKey` -> `WorkersKVKey`
  * Method renames and parameter changes, old methods now deprecated
     * `WriteWorkersKV(ns, key, value)` -> `WriteWorkersKVPair(ns, *struct)`
    * `ReadWorkersKV(ns, key) -> value` -> `ReadWorkersKVPair(ns, key) -> struct`

### Breaking
* Redo key listing API
   * Previous API was coded and mocked incorrectly, there was no cursor implementation
   * Because of this, it shows no one was using it, so we can make this a breaking change
     * Added struct `WorkersKVKeyListRequest`
     * Added struct `WorkersKVKeyListResponse`
     * Added struct `WorkersKVKeyPagination`
     * Added method `ListWorkersKVKeys(ns, *request) -> response`

### Misc
* Test suite fully updated
* All changes tested with production Workers KV
* If merged, add @Michael9127 as co-author for his bulk work
