### PR TITLE
CUSTOM_ORIGIN_SERVER Adding custom_origin_server to CustomHostname st…

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -31,10 +31,11 @@ type CustomMetadata map[string]interface{}
 
 // CustomHostname represents a custom hostname in a zone.
 type CustomHostname struct {
-	ID             string            `json:"id,omitempty"`
-	Hostname       string            `json:"hostname,omitempty"`
-	SSL            CustomHostnameSSL `json:"ssl,omitempty"`
-	CustomMetadata CustomMetadata    `json:"custom_metadata,omitempty"`
+	ID                 string            `json:"id,omitempty"`
+	Hostname           string            `json:"hostname,omitempty"`
+	CustomOriginServer string            `json:"custom_origin_server,omitempty"`
+	SSL                CustomHostnameSSL `json:"ssl,omitempty"`
+	CustomMetadata     CustomMetadata    `json:"custom_metadata,omitempty"`
 }
 
 // CustomHostnameResponse represents a response from the Custom Hostnames endpoints.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -82,7 +82,63 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 		assert.Equal(t, want, response)
 	}
 }
+func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
+	setup()
+	defer teardown()
 
+	mux.HandleFunc("/zones/foo/custom_hostnames", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method, "Expected method 'POST', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `
+{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": {
+    "id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+	"hostname": "app.example.com",
+	"custom_origin_server": "example.app.com",
+    "ssl": {
+      "status": "pending_validation",
+      "method": "cname",
+      "type": "dv",
+      "cname_target": "dcv.digicert.com",
+      "cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+      "settings": {
+        "http2": "on"
+      }
+    }
+  }
+}`)
+	})
+
+	response, err := client.CreateCustomHostname("foo", CustomHostname{Hostname: "app.example.com", CustomOriginServer: "example.app.com", SSL: CustomHostnameSSL{Method: "cname", Type: "dv"}})
+
+	want := &CustomHostnameResponse{
+		Result: CustomHostname{
+			ID:       "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+			Hostname: "app.example.com",
+			CustomOriginServer: "example.app.com",
+			SSL: CustomHostnameSSL{
+				Type:        "dv",
+				Method:      "cname",
+				Status:      "pending_validation",
+				CnameTarget: "dcv.digicert.com",
+				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				Settings: CustomHostnameSSLSettings{
+					HTTP2: "on",
+				},
+			},
+		},
+		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, response)
+	}
+}
 func TestCustomHostname_CustomHostnames(t *testing.T) {
 	setup()
 	defer teardown()

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -82,6 +82,7 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 		assert.Equal(t, want, response)
 	}
 }
+
 func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 	setup()
 	defer teardown()

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -140,6 +140,7 @@ func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 		assert.Equal(t, want, response)
 	}
 }
+
 func TestCustomHostname_CustomHostnames(t *testing.T) {
 	setup()
 	defer teardown()

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -94,24 +94,24 @@ func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, `
 {
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
-	"hostname": "app.example.com",
-	"custom_origin_server": "example.app.com",
-    "ssl": {
-      "status": "pending_validation",
-      "method": "cname",
-      "type": "dv",
-      "cname_target": "dcv.digicert.com",
-      "cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
-      "settings": {
-        "http2": "on"
-      }
-    }
-  }
+	"success": true,
+	"errors": [],
+	"messages": [],
+	"result": {
+		"id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+		"hostname": "app.example.com",
+		"custom_origin_server": "example.app.com",
+		"ssl": {
+			"status": "pending_validation",
+			"method": "cname",
+			"type": "dv",
+			"cname_target": "dcv.digicert.com",
+			"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+			"settings": {
+			"http2": "on"
+			}
+		}
+  	}
 }`)
 	})
 
@@ -150,29 +150,29 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-"success": true,
-"result": [
-    {
-      "id": "custom_host_1",
-      "hostname": "custom.host.one",
+	"success": true,
+	"result": [
+		{
+			"id": "custom_host_1",
+			"hostname": "custom.host.one",
 			"ssl": {
-        "type": "dv",
-        "method": "cname",
-        "status": "pending_validation",
-        "cname_target": "dcv.digicert.com",
-        "cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com"
-      },
-      "custom_metadata": {
+				"type": "dv",
+				"method": "cname",
+				"status": "pending_validation",
+				"cname_target": "dcv.digicert.com",
+				"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com"
+			},
+			"custom_metadata": {
 				"a_random_field": "random field value"
-      }
-    }
-],
-"result_info": {
-	  "page": 1,
-    "per_page": 20,
-    "count": 5,
-    "total_count": 5
-}
+			}
+		}
+	],
+	"result_info": {
+		"page": 1,
+		"per_page": 20,
+		"count": 5,
+		"total_count": 5
+	}
 }`)
 	})
 


### PR DESCRIPTION
…ruct



## Description

I added an optional custom_origin_server property to the CustomHostname struct so the cloudflare-go client can be used to create this special custom hostname.

## Has your change been tested?

I added a new test for the optional property. `go test` ran successfully.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

??? If https://godoc.org/github.com/cloudflare/cloudflare-go#CustomHostname is auto-generated, then it should show up. If not, instructions would be helpful.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
