### PR TITLE
get and edit WAF rule groups

### DIFF
--- a/waf.go
+++ b/waf.go
@@ -56,6 +56,13 @@ type WAFGroupsResponse struct {
 	ResultInfo ResultInfo `json:"result_info"`
 }
 
+// WAFGroupResponse represents the response from the WAF group endpoint.
+type WAFGroupResponse struct {
+	Response
+	Result     WAFGroup   `json:"result"`
+	ResultInfo ResultInfo `json:"result_info"`
+}
+
 // WAFRule represents a WAF rule.
 type WAFRule struct {
 	ID          string `json:"id"`
@@ -183,6 +190,25 @@ func (api *API) ListWAFGroups(zoneID, packageID string) ([]WAFGroup, error) {
 		groups = append(groups, r.Result[gi])
 	}
 	return groups, nil
+}
+
+// WAFGroup returns a WAF rule group from the given WAF package.
+//
+// API Reference: https://api.cloudflare.com/#waf-rule-groups-rule-group-details
+func (api *API) WAFGroup(zoneID, packageID, groupID string) (WAFGroup, error) {
+	uri := "/zones/" + zoneID + "/firewall/waf/packages/" + packageID + "/groups/" + groupID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return WAFGroup{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r WAFGroupResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return WAFGroup{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
 }
 
 // ListWAFRules returns a slice of the WAF rules for the given WAF package.

--- a/waf.go
+++ b/waf.go
@@ -211,6 +211,25 @@ func (api *API) WAFGroup(zoneID, packageID, groupID string) (WAFGroup, error) {
 	return r.Result, nil
 }
 
+// UpdateWAFGroup lets you update the mode of a WAF Group.
+//
+// API Reference: https://api.cloudflare.com/#waf-rule-groups-edit-rule-group
+func (api *API) UpdateWAFGroup(zoneID, packageID, groupID, mode string) (WAFGroup, error) {
+	opts := WAFRuleOptions{Mode: mode}
+	uri := "/zones/" + zoneID + "/firewall/waf/packages/" + packageID + "/groups/" + groupID
+	res, err := api.makeRequest("PATCH", uri, opts)
+	if err != nil {
+		return WAFGroup{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r WAFGroupResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return WAFGroup{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
 // ListWAFRules returns a slice of the WAF rules for the given WAF package.
 //
 // API Reference: https://api.cloudflare.com/#waf-rules-list-rules

--- a/waf_test.go
+++ b/waf_test.go
@@ -289,6 +289,64 @@ func TestWAFGroup(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestUpdateWAFGroup(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testZoneID := "abcd123"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "Expected method 'PATCH', got %s", r.Method)
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		defer r.Body.Close()
+
+		assert.Equal(t, `{"mode":"on"}`, string(body), "Expected body '{\"mode\":\"on\"}', got %s", string(body))
+
+		w.Header().Set("content-type", "application/json")
+		// JSON data from: https://api.cloudflare.com/#waf-rule-groups-edit-rule-group
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "de677e5818985db1285d0e80225f06e5",
+				"name": "Project Honey Pot",
+				"description": "Group designed to protect against IP addresses that are a threat and typically used to launch DDoS attacks",
+				"rules_count": 10,
+				"modified_rules_count": 2,
+				"package_id": "a25a9a7e9c00afc1fb2e0245519d725b",
+				"mode": "on",
+				"allowed_modes": [
+					"on",
+					"off"
+				]
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/groups/de677e5818985db1285d0e80225f06e5", handler)
+
+	want := WAFGroup{
+		ID:                 "de677e5818985db1285d0e80225f06e5",
+		Name:               "Project Honey Pot",
+		Description:        "Group designed to protect against IP addresses that are a threat and typically used to launch DDoS attacks",
+		RulesCount:         10,
+		ModifiedRulesCount: 2,
+		PackageID:          "a25a9a7e9c00afc1fb2e0245519d725b",
+		Mode:               "on",
+		AllowedModes:       []string{"on", "off"},
+	}
+
+	d, err := client.UpdateWAFGroup(testZoneID, "a25a9a7e9c00afc1fb2e0245519d725b", "de677e5818985db1285d0e80225f06e5", "on")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, d)
+	}
+}
+
 func TestListWAFRules(t *testing.T) {
 	setup()
 	defer teardown()

--- a/waf_test.go
+++ b/waf_test.go
@@ -235,6 +235,60 @@ func TestListWAFGroups(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestWAFGroup(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testZoneID := "abcd123"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		// JSON data from: https://api.cloudflare.com/#waf-rule-groups-rule-group-details
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "de677e5818985db1285d0e80225f06e5",
+				"name": "Project Honey Pot",
+				"description": "Group designed to protect against IP addresses that are a threat and typically used to launch DDoS attacks",
+				"rules_count": 10,
+				"modified_rules_count": 2,
+				"package_id": "a25a9a7e9c00afc1fb2e0245519d725b",
+				"mode": "on",
+				"allowed_modes": [
+					"on",
+					"off"
+				]
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/firewall/waf/packages/a25a9a7e9c00afc1fb2e0245519d725b/groups/de677e5818985db1285d0e80225f06e5", handler)
+
+	want := WAFGroup{
+		ID:                 "de677e5818985db1285d0e80225f06e5",
+		Name:               "Project Honey Pot",
+		Description:        "Group designed to protect against IP addresses that are a threat and typically used to launch DDoS attacks",
+		RulesCount:         10,
+		ModifiedRulesCount: 2,
+		PackageID:          "a25a9a7e9c00afc1fb2e0245519d725b",
+		Mode:               "on",
+		AllowedModes:       []string{"on", "off"},
+	}
+
+	d, err := client.WAFGroup(testZoneID, "a25a9a7e9c00afc1fb2e0245519d725b", "de677e5818985db1285d0e80225f06e5")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, d)
+	}
+
+	_, err = client.WAFGroup(testZoneID, "a25a9a7e9c00afc1fb2e0245519d725b", "123")
+	assert.Error(t, err)
+}
+
 func TestListWAFRules(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
This PR adds entry-points to get and edit WAF rule groups as per https://api.cloudflare.com/#waf-rule-groups-rule-group-details and https://api.cloudflare.com/#waf-rule-groups-edit-rule-group 

This adds the missing pieces and closes #321

/cc @patryk @jacobbednarz 

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
