### PR TITLE
Add universal ssl verification details.

### DIFF
--- a/universal_ssl.go
+++ b/universal_ssl.go
@@ -16,6 +16,28 @@ type universalSSLSettingResponse struct {
 	Result UniversalSSLSetting `json:"result"`
 }
 
+// UniversalSSLVerificationDetails represents a universal ssl verifcation's properties.
+type UniversalSSLVerificationDetails struct {
+	CertificateStatus  string                       `json:"certificate_status"`
+	VerificationType   string                       `json:"verification_type"`
+	ValidationMethod   string                       `json:"validation_method"`
+	CertPackUUID       string                       `json:"cert_pack_uuid"`
+	VerificationStatus bool                         `json:"verification_status"`
+	BrandCheck         bool                         `json:"brand_check"`
+	VerificationInfo   UniversalSSLVerificationInfo `json:"verification_info"`
+}
+
+// UniversalSSLVerificationInfo represents DCV record.
+type UniversalSSLVerificationInfo struct {
+	RecordName   string `json:"record_name"`
+	RecordTarget string `json:"record_target"`
+}
+
+type universalSSLVerificationResponse struct {
+	Response
+	Result []UniversalSSLVerificationDetails `json:"result"`
+}
+
 // UniversalSSLSettingDetails returns the details for a universal ssl setting
 //
 // API reference: https://api.cloudflare.com/#universal-ssl-settings-for-a-zone-universal-ssl-settings-details
@@ -47,4 +69,20 @@ func (api *API) EditUniversalSSLSetting(zoneID string, setting UniversalSSLSetti
 	}
 	return r.Result, nil
 
+}
+
+// UniversalSSLVerificationDetails returns the details for a universal ssl verifcation
+//
+// API reference: https://api.cloudflare.com/#ssl-verification-ssl-verification-details
+func (api *API) UniversalSSLVerificationDetails(zoneID string) ([]UniversalSSLVerificationDetails, error) {
+	uri := "/zones/" + zoneID + "/ssl/verification"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []UniversalSSLVerificationDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r universalSSLVerificationResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return []UniversalSSLVerificationDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
 }

--- a/universal_ssl_test.go
+++ b/universal_ssl_test.go
@@ -78,3 +78,51 @@ func TestEditUniversalSSLSetting(t *testing.T) {
 		assert.Equal(t, want, got)
 	}
 }
+
+func TestUniversalSSLVerificationDetails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	testZoneID := "abcd123"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [{
+				"certificate_status": "active",
+				"verification_type": "cname",
+				"verification_status": true,
+				"verification_info": {
+					"record_name": "b3b90cfedd89a3e487d3e383c56c4267.example.com",
+					"record_target": "6979be7e4cfc9e5c603e31df7efac9cc60fee82d.comodoca.com"
+				},
+				"brand_check": false,
+				"validation_method": "txt",
+				"cert_pack_uuid": "a77f8bd7-3b47-46b4-a6f1-75cf98109948"
+			}]
+		}`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/verification", handler)
+
+	want := []UniversalSSLVerificationDetails{
+		{
+			CertificateStatus:  "active",
+			VerificationType:   "cname",
+			ValidationMethod:   "txt",
+			CertPackUUID:       "a77f8bd7-3b47-46b4-a6f1-75cf98109948",
+			VerificationStatus: true,
+			BrandCheck:         false,
+			VerificationInfo: UniversalSSLVerificationInfo{
+				RecordName:   "b3b90cfedd89a3e487d3e383c56c4267.example.com",
+				RecordTarget: "6979be7e4cfc9e5c603e31df7efac9cc60fee82d.comodoca.com",
+			},
+		},
+	}
+
+	got, err := client.UniversalSSLVerificationDetails(testZoneID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}


### PR DESCRIPTION
## Description

We have several projects using CNAME setup and we need to automate DCV communication to our customers (CNAMEs for SSL). I've just added a method to fetch them.

## Has your change been tested?

yes

## What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
