### PR TITLE
Support setting fallback origin on a zone

### DIFF
--- a/zone.go
+++ b/zone.go
@@ -270,9 +270,8 @@ type newZone struct {
 
 // FallbackOrigin describes a fallback origin
 type FallbackOrigin struct {
-	Value    string `json:"value"`
-	ID       string `json:"id,omitempty"`
-	Editable bool   `json:"editable,omitempty"`
+	Value string `json:"value"`
+	ID    string `json:"id,omitempty"`
 }
 
 // FallbackOriginResponse represents the response from the fallback_origin endpoint
@@ -704,6 +703,7 @@ func (api *API) ZoneSSLSettings(zoneID string) (ZoneSSLSetting, error) {
 
 // FallbackOrigin returns information about the fallback origin for the specified zone.
 //
+// API reference: https://developers.cloudflare.com/ssl/ssl-for-saas/api-calls/#fallback-origin-configuration
 func (api *API) FallbackOrigin(zoneID string) (FallbackOrigin, error) {
 	uri := "/zones/" + zoneID + "/fallback_origin"
 	res, err := api.makeRequest("GET", uri, nil)
@@ -722,6 +722,7 @@ func (api *API) FallbackOrigin(zoneID string) (FallbackOrigin, error) {
 
 // UpdateFallbackOrigin updates the fallback origin for a given zone.
 //
+// API reference: https://developers.cloudflare.com/ssl/ssl-for-saas/api-calls/#4-example-patch-to-change-fallback-origin
 func (api *API) UpdateFallbackOrigin(zoneID string, fbo FallbackOrigin) (*FallbackOriginResponse, error) {
 	uri := "/zones/" + zoneID + "/fallback_origin"
 	res, err := api.makeRequest("PATCH", uri, fbo)

--- a/zone.go
+++ b/zone.go
@@ -268,6 +268,19 @@ type newZone struct {
 	Account *Account `json:"organization,omitempty"`
 }
 
+// FallbackOrigin describes a fallback origin
+type FallbackOrigin struct {
+	Value    string `json:"value"`
+	ID       string `json:"id,omitempty"`
+	Editable bool   `json:"editable,omitempty"`
+}
+
+// FallbackOriginResponse represents the response from the fallback_origin endpoint
+type FallbackOriginResponse struct {
+	Response
+	Result FallbackOrigin `json:"result"`
+}
+
 // CreateZone creates a zone on an account.
 //
 // Setting jumpstart to true will attempt to automatically scan for existing
@@ -687,4 +700,40 @@ func (api *API) ZoneSSLSettings(zoneID string) (ZoneSSLSetting, error) {
 		return ZoneSSLSetting{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
+}
+
+// FallbackOrigin returns information about the fallback origin for the specified zone.
+//
+func (api *API) FallbackOrigin(zoneID string) (FallbackOrigin, error) {
+	uri := "/zones/" + zoneID + "/fallback_origin"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return FallbackOrigin{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r FallbackOriginResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return FallbackOrigin{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}
+
+// UpdateFallbackOrigin updates the fallback origin for a given zone.
+//
+func (api *API) UpdateFallbackOrigin(zoneID string, fbo FallbackOrigin) (*FallbackOriginResponse, error) {
+	uri := "/zones/" + zoneID + "/fallback_origin"
+	res, err := api.makeRequest("PATCH", uri, fbo)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &FallbackOriginResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
 }

--- a/zone_test.go
+++ b/zone_test.go
@@ -915,9 +915,8 @@ func TestFallbackOrigin_FallbackOrigin(t *testing.T) {
 	fallbackOrigin, err := client.FallbackOrigin("foo")
 
 	want := FallbackOrigin{
-		ID:       "fallback_origin",
-		Value:    "app.example.com",
-		Editable: true,
+		ID:    "fallback_origin",
+		Value: "app.example.com",
 	}
 
 	if assert.NoError(t, err) {
@@ -951,9 +950,8 @@ func TestFallbackOrigin_UpdateFallbackOrigin(t *testing.T) {
 
 	want := &FallbackOriginResponse{
 		Result: FallbackOrigin{
-			ID:       "fallback_origin",
-			Value:    "app.example.com",
-			Editable: true,
+			ID:    "fallback_origin",
+			Value: "app.example.com",
 		},
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
 	}


### PR DESCRIPTION
Supports getting/setting the `fallback_origin` on Cloudflare Zones

## Description

As part of Cloudflare's [SSL for SaaS](https://www.cloudflare.com/ssl-for-saas-providers/) offering, a default origin server (`fallback_origin`) can be configured on any enabled zones.

Ultimately I'd like to be able to set this configuration option via a Terraform resource however I'm unable to do so until the Go client supports this endpoint.

The API endpoint is undocumented in the API docs but details can be found [here](https://developers.cloudflare.com/ssl/ssl-for-saas/api-calls/)


## Has your change been tested?

- Automated tests added
- Manually tested getting the fallback origin for a zone (`api.FallbackOrigin("<ZONEID>")`) & updating the fallback origin for a zone (`api.UpdateFallbackOrigin("<ZONEID>", newOrigin)`)

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
