### PR TITLE
Add support for Access Identity Providers

### DIFF
--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -1,0 +1,331 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// AccessIdentityProvider is the structure of the provider object.
+type AccessIdentityProvider struct {
+	ID     string      `json:"id,omitemtpy"`
+	Name   string      `json:"name"`
+	Type   string      `json:"type"`
+	Config interface{} `json:"config"`
+}
+
+// AzureADConfiguration is the representation of the Azure AD identity
+// provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/azuread/
+type AzureADConfiguration struct {
+	ClientID      string `json:"client_id"`
+	ClientSecret  string `json:"client_secret"`
+	DirectoryID   string `json:"directory_id"`
+	SupportGroups bool   `json:"support_groups"`
+}
+
+// CentrifyConfiguration is the representation of the Centrify identity
+// provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/centrify/
+type CentrifyConfiguration struct {
+	ClientID        string `json:"client_id"`
+	ClientSecret    string `json:"client_secret"`
+	CentrifyAccount string `json:"centrify_account"`
+	CentrifyAppID   string `json:"centrify_app_id"`
+}
+
+// CentrifySAMLConfiguration is the representation of the Centrify
+// identity provider using SAML.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/saml-centrify/
+type CentrifySAMLConfiguration struct {
+	IssuerURL          string   `json:"issuer_url"`
+	SsoTargetURL       string   `json:"sso_target_url"`
+	Attributes         []string `json:"attributes"`
+	EmailAttributeName string   `json:"email_attribute_name"`
+	SignRequest        bool     `json:"sign_request"`
+	IdpPublicCert      string   `json:"idp_public_cert"`
+}
+
+// FacebookConfiguration is the representation of the Facebook identity
+// provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/facebook-login/
+type FacebookConfiguration struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// GSuiteConfiguration is the representation of the GSuite identity
+// provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/gsuite/
+type GSuiteConfiguration struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	AppsDomain   string `json:"apps_domain"`
+}
+
+// GenericOIDCConfiguration is the representation of the generic OpenID
+// Connect (OIDC) connector.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/generic-oidc/
+type GenericOIDCConfiguration struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	AuthURL      string `json:"auth_url"`
+	TokenURL     string `json:"token_url"`
+	CertsURL     string `json:"certs_url"`
+}
+
+// GitHubConfiguration is the representation of the GitHub identity
+// provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/github/
+type GitHubConfiguration struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// GoogleConfiguration is the representation of the Google identity
+// provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/google/
+type GoogleConfiguration struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// JumpCloudSAMLConfiguration is the representation of the Jump Cloud
+// identity provider using SAML.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/jumpcloud-saml/
+type JumpCloudSAMLConfiguration struct {
+	IssuerURL          string   `json:"issuer_url"`
+	SsoTargetURL       string   `json:"sso_target_url"`
+	Attributes         []string `json:"attributes"`
+	EmailAttributeName string   `json:"email_attribute_name"`
+	SignRequest        bool     `json:"sign_request"`
+	IdpPublicCert      string   `json:"idp_public_cert"`
+}
+
+// OktaConfiguration is the representation of the Okta identity provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/okta/
+type OktaConfiguration struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	OktaAccount  string `json:"okta_account"`
+}
+
+// OktaSAMLConfiguration is the representation of the Okta identity
+// provider using SAML.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/saml-okta/
+type OktaSAMLConfiguration struct {
+	IssuerURL          string   `json:"issuer_url"`
+	SsoTargetURL       string   `json:"sso_target_url"`
+	Attributes         []string `json:"attributes"`
+	EmailAttributeName string   `json:"email_attribute_name"`
+	SignRequest        bool     `json:"sign_request"`
+	IdpPublicCert      string   `json:"idp_public_cert"`
+}
+
+// OneTimePinCnfiguration is the representation of the default One Time
+// Pin identity provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/one-time-pin/
+type OneTimePinCnfiguration struct{}
+
+// OneLoginOIDCConfiguration is the representation of the OneLogin
+// OpenID connector as an identity provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/onelogin-oidc/
+type OneLoginOIDCConfiguration struct {
+	ClientID        string `json:"client_id"`
+	ClientSecret    string `json:"client_secret"`
+	OneloginAccount string `json:"onelogin_account"`
+}
+
+// OneLoginSAMLConfiguration is the representation of the OneLogin
+// identity provider using SAML.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/onelogin-saml/
+type OneLoginSAMLConfiguration struct {
+	IssuerURL          string   `json:"issuer_url"`
+	SsoTargetURL       string   `json:"sso_target_url"`
+	Attributes         []string `json:"attributes"`
+	EmailAttributeName string   `json:"email_attribute_name"`
+	SignRequest        bool     `json:"sign_request"`
+	IdpPublicCert      string   `json:"idp_public_cert"`
+}
+
+// PingSAMLConfiguration is the representation of the Ping identity
+// provider using SAML.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/ping-saml/
+type PingSAMLConfiguration struct {
+	IssuerURL          string   `json:"issuer_url"`
+	SsoTargetURL       string   `json:"sso_target_url"`
+	Attributes         []string `json:"attributes"`
+	EmailAttributeName string   `json:"email_attribute_name"`
+	SignRequest        bool     `json:"sign_request"`
+	IdpPublicCert      string   `json:"idp_public_cert"`
+}
+
+// YandexConfiguration is the representation of the Yandex identity provider.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/yandex/
+type YandexConfiguration struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// ADSAMLConfiguration is the representation of the Active Directory
+// identity provider using SAML.
+//
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/adfs/
+type ADSAMLConfiguration struct {
+	IssuerURL          string   `json:"issuer_url"`
+	SsoTargetURL       string   `json:"sso_target_url"`
+	Attributes         []string `json:"attributes"`
+	EmailAttributeName string   `json:"email_attribute_name"`
+	SignRequest        bool     `json:"sign_request"`
+	IdpPublicCert      string   `json:"idp_public_cert"`
+}
+
+// AccessIdentityProvidersListResponse is the API response for multiple
+// Access Identity Providers.
+type AccessIdentityProvidersListResponse struct {
+	Success  bool                     `json:"success"`
+	Errors   []string                 `json:"errors"`
+	Messages []string                 `json:"messages"`
+	Result   []AccessIdentityProvider `json:"result"`
+}
+
+// AccessIdentityProviderListResponse is the API response for a single
+// Access Identity Provider.
+type AccessIdentityProviderListResponse struct {
+	Success  bool                   `json:"success"`
+	Errors   []string               `json:"errors"`
+	Messages []string               `json:"messages"`
+	Result   AccessIdentityProvider `json:"result"`
+}
+
+// AccessIdentityProviders returns all Access Identity Providers for an
+// account.
+//
+// API reference: https://api.cloudflare.com/#access-identity-providers-list-access-identity-providers
+func (api *API) AccessIdentityProviders(accountID string) ([]AccessIdentityProvider, error) {
+	uri := "/accounts/" + accountID + "/access/identity_providers"
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []AccessIdentityProvider{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessIdentityProviderResponse AccessIdentityProvidersListResponse
+	err = json.Unmarshal(res, &accessIdentityProviderResponse)
+	if err != nil {
+		return []AccessIdentityProvider{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessIdentityProviderResponse.Result, nil
+}
+
+// AccessIdentityProviderDetails returns a single Access Identity
+// Provider for an account.
+//
+// API reference: https://api.cloudflare.com/#access-identity-providers-access-identity-providers-details
+func (api *API) AccessIdentityProviderDetails(accountID, identityProviderID string) (AccessIdentityProvider, error) {
+	uri := fmt.Sprintf(
+		"/accounts/%s/access/identity_providers/%s",
+		accountID,
+		identityProviderID,
+	)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessIdentityProviderResponse AccessIdentityProviderListResponse
+	err = json.Unmarshal(res, &accessIdentityProviderResponse)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessIdentityProviderResponse.Result, nil
+}
+
+// CreateAccessIdentityProvider creates a new Access Identity Provider.
+//
+// API reference: https://api.cloudflare.com/#access-identity-providers-create-access-identity-provider
+func (api *API) CreateAccessIdentityProvider(accountID string, identityProviderConfiguration AccessIdentityProvider) (AccessIdentityProvider, error) {
+	uri := "/accounts/" + accountID + "/access/identity_providers"
+
+	res, err := api.makeRequest("POST", uri, identityProviderConfiguration)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessIdentityProviderResponse AccessIdentityProviderListResponse
+	err = json.Unmarshal(res, &accessIdentityProviderResponse)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessIdentityProviderResponse.Result, nil
+}
+
+// UpdateAccessIdentityProvider updates an existing Access Identity
+// Provider.
+//
+// API reference: https://api.cloudflare.com/#access-identity-providers-create-access-identity-provider
+func (api *API) UpdateAccessIdentityProvider(accountID, identityProviderUUID string, identityProviderConfiguration AccessIdentityProvider) (AccessIdentityProvider, error) {
+	uri := fmt.Sprintf(
+		"/accounts/%s/access/identity_providers/%s",
+		accountID,
+		identityProviderUUID,
+	)
+
+	res, err := api.makeRequest("PUT", uri, identityProviderConfiguration)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessIdentityProviderResponse AccessIdentityProviderListResponse
+	err = json.Unmarshal(res, &accessIdentityProviderResponse)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessIdentityProviderResponse.Result, nil
+}
+
+// DeleteAccessIdentityProvider deletes an Access Identity Provider.
+//
+// API reference: https://api.cloudflare.com/#access-identity-providers-create-access-identity-provider
+func (api *API) DeleteAccessIdentityProvider(accountID, identityProviderUUID string) (AccessIdentityProvider, error) {
+	uri := fmt.Sprintf(
+		"/accounts/%s/access/identity_providers/%s",
+		accountID,
+		identityProviderUUID,
+	)
+
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessIdentityProviderResponse AccessIdentityProviderListResponse
+	err = json.Unmarshal(res, &accessIdentityProviderResponse)
+	if err != nil {
+		return AccessIdentityProvider{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessIdentityProviderResponse.Result, nil
+}

--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -15,33 +15,33 @@ type AccessIdentityProvider struct {
 	Config interface{} `json:"config"`
 }
 
-// AzureADConfiguration is the representation of the Azure AD identity
+// AccessAzureADConfiguration is the representation of the Azure AD identity
 // provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/azuread/
-type AzureADConfiguration struct {
+type AccessAzureADConfiguration struct {
 	ClientID      string `json:"client_id"`
 	ClientSecret  string `json:"client_secret"`
 	DirectoryID   string `json:"directory_id"`
 	SupportGroups bool   `json:"support_groups"`
 }
 
-// CentrifyConfiguration is the representation of the Centrify identity
+// AccessCentrifyConfiguration is the representation of the Centrify identity
 // provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/centrify/
-type CentrifyConfiguration struct {
+type AccessCentrifyConfiguration struct {
 	ClientID        string `json:"client_id"`
 	ClientSecret    string `json:"client_secret"`
 	CentrifyAccount string `json:"centrify_account"`
 	CentrifyAppID   string `json:"centrify_app_id"`
 }
 
-// CentrifySAMLConfiguration is the representation of the Centrify
+// AccessCentrifySAMLConfiguration is the representation of the Centrify
 // identity provider using SAML.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/saml-centrify/
-type CentrifySAMLConfiguration struct {
+type AccessCentrifySAMLConfiguration struct {
 	IssuerURL          string   `json:"issuer_url"`
 	SsoTargetURL       string   `json:"sso_target_url"`
 	Attributes         []string `json:"attributes"`
@@ -50,30 +50,30 @@ type CentrifySAMLConfiguration struct {
 	IdpPublicCert      string   `json:"idp_public_cert"`
 }
 
-// FacebookConfiguration is the representation of the Facebook identity
+// AccessFacebookConfiguration is the representation of the Facebook identity
 // provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/facebook-login/
-type FacebookConfiguration struct {
+type AccessFacebookConfiguration struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 }
 
-// GSuiteConfiguration is the representation of the GSuite identity
+// AccessGSuiteConfiguration is the representation of the GSuite identity
 // provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/gsuite/
-type GSuiteConfiguration struct {
+type AccessGSuiteConfiguration struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	AppsDomain   string `json:"apps_domain"`
 }
 
-// GenericOIDCConfiguration is the representation of the generic OpenID
+// AccessGenericOIDCConfiguration is the representation of the generic OpenID
 // Connect (OIDC) connector.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/generic-oidc/
-type GenericOIDCConfiguration struct {
+type AccessGenericOIDCConfiguration struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	AuthURL      string `json:"auth_url"`
@@ -81,29 +81,29 @@ type GenericOIDCConfiguration struct {
 	CertsURL     string `json:"certs_url"`
 }
 
-// GitHubConfiguration is the representation of the GitHub identity
+// AccessGitHubConfiguration is the representation of the GitHub identity
 // provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/github/
-type GitHubConfiguration struct {
+type AccessGitHubConfiguration struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 }
 
-// GoogleConfiguration is the representation of the Google identity
+// AccessGoogleConfiguration is the representation of the Google identity
 // provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/google/
-type GoogleConfiguration struct {
+type AccessGoogleConfiguration struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 }
 
-// JumpCloudSAMLConfiguration is the representation of the Jump Cloud
+// AccessJumpCloudSAMLConfiguration is the representation of the Jump Cloud
 // identity provider using SAML.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/jumpcloud-saml/
-type JumpCloudSAMLConfiguration struct {
+type AccessJumpCloudSAMLConfiguration struct {
 	IssuerURL          string   `json:"issuer_url"`
 	SsoTargetURL       string   `json:"sso_target_url"`
 	Attributes         []string `json:"attributes"`
@@ -112,20 +112,20 @@ type JumpCloudSAMLConfiguration struct {
 	IdpPublicCert      string   `json:"idp_public_cert"`
 }
 
-// OktaConfiguration is the representation of the Okta identity provider.
+// AccessOktaConfiguration is the representation of the Okta identity provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/okta/
-type OktaConfiguration struct {
+type AccessOktaConfiguration struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	OktaAccount  string `json:"okta_account"`
 }
 
-// OktaSAMLConfiguration is the representation of the Okta identity
+// AccessOktaSAMLConfiguration is the representation of the Okta identity
 // provider using SAML.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/saml-okta/
-type OktaSAMLConfiguration struct {
+type AccessOktaSAMLConfiguration struct {
 	IssuerURL          string   `json:"issuer_url"`
 	SsoTargetURL       string   `json:"sso_target_url"`
 	Attributes         []string `json:"attributes"`
@@ -134,27 +134,27 @@ type OktaSAMLConfiguration struct {
 	IdpPublicCert      string   `json:"idp_public_cert"`
 }
 
-// OneTimePinCnfiguration is the representation of the default One Time
+// AccessOneTimePinConfiguration is the representation of the default One Time
 // Pin identity provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/one-time-pin/
-type OneTimePinCnfiguration struct{}
+type AccessOneTimePinConfiguration struct{}
 
-// OneLoginOIDCConfiguration is the representation of the OneLogin
+// AccessOneLoginOIDCConfiguration is the representation of the OneLogin
 // OpenID connector as an identity provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/onelogin-oidc/
-type OneLoginOIDCConfiguration struct {
+type AccessOneLoginOIDCConfiguration struct {
 	ClientID        string `json:"client_id"`
 	ClientSecret    string `json:"client_secret"`
 	OneloginAccount string `json:"onelogin_account"`
 }
 
-// OneLoginSAMLConfiguration is the representation of the OneLogin
+// AccessOneLoginSAMLConfiguration is the representation of the OneLogin
 // identity provider using SAML.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/onelogin-saml/
-type OneLoginSAMLConfiguration struct {
+type AccessOneLoginSAMLConfiguration struct {
 	IssuerURL          string   `json:"issuer_url"`
 	SsoTargetURL       string   `json:"sso_target_url"`
 	Attributes         []string `json:"attributes"`
@@ -163,11 +163,11 @@ type OneLoginSAMLConfiguration struct {
 	IdpPublicCert      string   `json:"idp_public_cert"`
 }
 
-// PingSAMLConfiguration is the representation of the Ping identity
+// AccessPingSAMLConfiguration is the representation of the Ping identity
 // provider using SAML.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/ping-saml/
-type PingSAMLConfiguration struct {
+type AccessPingSAMLConfiguration struct {
 	IssuerURL          string   `json:"issuer_url"`
 	SsoTargetURL       string   `json:"sso_target_url"`
 	Attributes         []string `json:"attributes"`
@@ -176,19 +176,19 @@ type PingSAMLConfiguration struct {
 	IdpPublicCert      string   `json:"idp_public_cert"`
 }
 
-// YandexConfiguration is the representation of the Yandex identity provider.
+// AccessYandexConfiguration is the representation of the Yandex identity provider.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/yandex/
-type YandexConfiguration struct {
+type AccessYandexConfiguration struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 }
 
-// ADSAMLConfiguration is the representation of the Active Directory
+// AccessADSAMLConfiguration is the representation of the Active Directory
 // identity provider using SAML.
 //
 // API reference: https://developers.cloudflare.com/access/configuring-identity-providers/adfs/
-type ADSAMLConfiguration struct {
+type AccessADSAMLConfiguration struct {
 	IssuerURL          string   `json:"issuer_url"`
 	SsoTargetURL       string   `json:"sso_target_url"`
 	Attributes         []string `json:"attributes"`

--- a/access_identity_provider_test.go
+++ b/access_identity_provider_test.go
@@ -1,0 +1,243 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccessIdentityProviders(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+					"name": "Widget Corps OTP",
+					"type": "github",
+					"config": {
+						"client_id": "example_id",
+						"client_secret": "a-secret-key"
+					}
+				}
+			]
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers", handler)
+
+	want := []AccessIdentityProvider{AccessIdentityProvider{
+		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name: "Widget Corps OTP",
+		Type: "github",
+		Config: map[string]interface{}{
+			"client_id":     "example_id",
+			"client_secret": "a-secret-key",
+		},
+	}}
+
+	actual, err := client.AccessIdentityProviders("01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestAccessIdentityProviderDetails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name": "Widget Corps OTP",
+				"type": "github",
+				"config": {
+					"client_id": "example_id",
+					"client_secret": "a-secret-key"
+				}
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc841", handler)
+
+	want := AccessIdentityProvider{
+		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name: "Widget Corps OTP",
+		Type: "github",
+		Config: map[string]interface{}{
+			"client_id":     "example_id",
+			"client_secret": "a-secret-key",
+		},
+	}
+
+	actual, err := client.AccessIdentityProviderDetails("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc841")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateAccessIdentityProvider(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name": "Widget Corps OTP",
+				"type": "github",
+				"config": {
+					"client_id": "example_id",
+					"client_secret": "a-secret-key"
+				}
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers", handler)
+
+	newIdentityProvider := AccessIdentityProvider{
+		Name: "Widget Corps OTP",
+		Type: "github",
+		Config: GitHubConfiguration{
+			ClientID:     "example_id",
+			ClientSecret: "a-secret-key",
+		},
+	}
+
+	want := AccessIdentityProvider{
+		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name: "Widget Corps OTP",
+		Type: "github",
+		Config: map[string]interface{}{
+			"client_id":     "example_id",
+			"client_secret": "a-secret-key",
+		},
+	}
+
+	actual, err := client.CreateAccessIdentityProvider("01a7362d577a6c3019a474fd6f485823", newIdentityProvider)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+func TestUpdateAccessIdentityProvider(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name": "Widget Corps OTP",
+				"type": "github",
+				"config": {
+					"client_id": "example_id",
+					"client_secret": "a-secret-key"
+				}
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	updatedIdentityProvider := AccessIdentityProvider{
+		Name: "Widget Corps OTP",
+		Type: "github",
+		Config: GitHubConfiguration{
+			ClientID:     "example_id",
+			ClientSecret: "a-secret-key",
+		},
+	}
+
+	want := AccessIdentityProvider{
+		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name: "Widget Corps OTP",
+		Type: "github",
+		Config: map[string]interface{}{
+			"client_id":     "example_id",
+			"client_secret": "a-secret-key",
+		},
+	}
+
+	actual, err := client.UpdateAccessIdentityProvider("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415", updatedIdentityProvider)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeleteAccessIdentityProvider(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name": "Widget Corps OTP",
+				"type": "github",
+				"config": {
+					"client_id": "example_id",
+					"client_secret": "a-secret-key"
+				}
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	want := AccessIdentityProvider{
+		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name: "Widget Corps OTP",
+		Type: "github",
+		Config: map[string]interface{}{
+			"client_id":     "example_id",
+			"client_secret": "a-secret-key",
+		},
+	}
+
+	actual, err := client.DeleteAccessIdentityProvider("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}

--- a/access_identity_provider_test.go
+++ b/access_identity_provider_test.go
@@ -125,7 +125,7 @@ func TestCreateAccessIdentityProvider(t *testing.T) {
 	newIdentityProvider := AccessIdentityProvider{
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: GitHubConfiguration{
+		Config: AccessGitHubConfiguration{
 			ClientID:     "example_id",
 			ClientSecret: "a-secret-key",
 		},
@@ -176,7 +176,7 @@ func TestUpdateAccessIdentityProvider(t *testing.T) {
 	updatedIdentityProvider := AccessIdentityProvider{
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: GitHubConfiguration{
+		Config: AccessGitHubConfiguration{
 			ClientID:     "example_id",
 			ClientSecret: "a-secret-key",
 		},


### PR DESCRIPTION
Updates the library to have full support for Access Identity Providers.

API reference: https://api.cloudflare.com/#access-identity-providers-properties
Identity provider reference: https://developers.cloudflare.com/access/configuring-identity-providers/