### PR TITLE
Adding custom hostname commands to cli

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -133,6 +133,81 @@ func main() {
 					},
 				},
 				{
+					Name:    "customhostname",
+					Aliases: []string{"ch"},
+					Usage:   "Custom hostname information",
+					Subcommands: []cli.Command{
+						{
+							Name:    "list",
+							Aliases: []string{"l"},
+							Action:  zoneCustHostList,
+							Usage:   "List all the custom hostname on an account",
+							Flags: []cli.Flag{
+								cli.StringFlag{
+									Name:  "zone",
+									Usage: "zone name",
+								},
+							},
+						},
+						{
+							Name:    "info",
+							Aliases: []string{"i"},
+							Action:  zoneCustHostInfo,
+							Usage:   "Information on one custom hostname",
+							Flags: []cli.Flag{
+								cli.StringFlag{
+									Name:  "zone",
+									Usage: "zone name",
+								},
+								cli.StringFlag{
+									Name:  "hostname",
+									Usage: "host name",
+								},
+							},
+						},
+						{
+							Name:    "create",
+							Aliases: []string{"c"},
+							Action:  zoneCustHostCreate,
+							Usage:   "Create a custom hostname",
+							Flags: []cli.Flag{
+								cli.StringFlag{
+									Name:  "zone",
+									Usage: "zone name",
+								},
+								cli.StringFlag{
+									Name:  "hostname",
+									Usage: "host name",
+								},
+								cli.StringFlag{
+									Name:  "ssl-method",
+									Usage: "ssl method",
+								},
+								cli.StringFlag{
+									Name:  "ssl-type",
+									Usage: "ssl type",
+								},
+							},
+						},
+						{
+							Name:    "delete",
+							Aliases: []string{"d"},
+							Action:  zoneCustHostDelete,
+							Usage:   "Delete a custom hostname",
+							Flags: []cli.Flag{
+								cli.StringFlag{
+									Name:  "zone",
+									Usage: "zone name",
+								},
+								cli.StringFlag{
+									Name:  "hostname",
+									Usage: "host name",
+								},
+							},
+						},
+					},
+				},
+				{
 					Name:    "info",
 					Aliases: []string{"i"},
 					Action:  zoneInfo,

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -263,3 +263,194 @@ func formatCacheResponse(resp cloudflare.PurgeCacheResponse) []string {
 		resp.Result.ID,
 	}
 }
+
+func zoneCustHostList(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var zone string
+	if c.String("zone") != "" {
+		zone = c.String("zone")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+	zoneID, err := api.ZoneIDByName(zone)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	customhostnamesResult, _, err := api.CustomHostnames(zoneID, 0, cloudflare.CustomHostname{})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var output []table
+	for _, z := range customhostnamesResult {
+		output = append(output, table{
+			"Hostname": z.Hostname,
+			"ID":       z.ID,
+		})
+	}
+	makeTable(output, "Hostname", "ID")
+}
+
+func zoneCustHostInfo(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var zone string
+	if c.String("zone") != "" {
+		zone = c.String("zone")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+	zoneID, err := api.ZoneIDByName(zone)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var hostname string
+	if c.String("hostname") != "" {
+		hostname = c.String("hostname")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+	hostnameID, err := api.CustomHostnameIDByName(zoneID, hostname)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	customname, err := api.CustomHostname(zoneID, hostnameID)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var output []table
+	output = append(output, table{
+		"Hostname":   customname.Hostname,
+		"ID":         customname.ID,
+		"SSL Status": customname.SSL.Status,
+		"SSL Method": customname.SSL.Method,
+		"SSL Type":   customname.SSL.Type,
+	})
+	makeTable(output, "Hostname", "ID", "SSL Status", "SSL Method", "SSL Type")
+}
+
+func zoneCustHostCreate(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var zone string
+	if c.String("zone") != "" {
+		zone = c.String("zone")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+	zoneID, err := api.ZoneIDByName(zone)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var hostname string
+	if c.String("hostname") != "" {
+		hostname = c.String("hostname")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+
+	var sslMethod string
+	if c.String("ssl-method") != "" {
+		sslMethod = c.String("ssl-method")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+
+	var sslType string
+	if c.String("ssl-type") != "" {
+		sslType = c.String("ssl-type")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+
+	newCustHost := cloudflare.CustomHostname{Hostname: hostname, SSL: cloudflare.CustomHostnameSSL{Method: sslMethod, Type: sslType}}
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	res, err := api.CreateCustomHostname(zoneID, newCustHost)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var output []table
+	output = append(output, table{
+		"Created":    fmt.Sprintf("%t", res.Response.Success),
+		"Hostname":   res.Result.Hostname,
+		"ID":         res.Result.ID,
+		"SSL Status": res.Result.SSL.Status,
+		"SSL Method": res.Result.SSL.Method,
+		"SSL Type":   res.Result.SSL.Type,
+	})
+	makeTable(output, "Created", "Hostname", "ID", "SSL Status", "SSL Method", "SSL Type")
+}
+
+func zoneCustHostDelete(c *cli.Context) {
+	if err := checkEnv(); err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var zone string
+	if c.String("zone") != "" {
+		zone = c.String("zone")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+	zoneID, err := api.ZoneIDByName(zone)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var hostname string
+	if c.String("hostname") != "" {
+		hostname = c.String("hostname")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+	hostnameID, err := api.CustomHostnameIDByName(zoneID, hostname)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	_ = api.DeleteCustomHostname(zoneID, hostnameID)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+}

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -64,8 +64,8 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 				Type:        "dv",
 				Method:      "cname",
 				Status:      "pending_validation",
-				CnameTarget: "dcv.digicert.com",
-				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				CNAMETarget: "dcv.digicert.com",
+				CNAMEName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
 			},
 		},
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
@@ -90,7 +90,7 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
     {
       "id": "custom_host_1",
       "hostname": "custom.host.one",
-			"ssl": {
+      "ssl": {
         "type": "dv",
         "method": "cname",
         "status": "pending_validation",
@@ -98,12 +98,12 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
         "cname_name": "810b7d5f01154524b961ba0cd578acc2.app.example.com"
       },
       "custom_metadata": {
-				"a_random_field": "random field value"
+        "a_random_field": "random field value"
       }
     }
 ],
 "result_info": {
-	  "page": 1,
+    "page": 1,
     "per_page": 20,
     "count": 5,
     "total_count": 5
@@ -111,7 +111,7 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 }`)
 	})
 
-	customHostnames, _, err := client.CustomHostnames("foo", 1, CustomHostname{})
+	customHostnames, _, err := client.ListCustomHostnames("foo", 1)
 
 	want := []CustomHostname{
 		{
@@ -121,8 +121,8 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 				Type:        "dv",
 				Method:      "cname",
 				Status:      "pending_validation",
-				CnameTarget: "dcv.digicert.com",
-				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				CNAMETarget: "dcv.digicert.com",
+				CNAMEName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
 			},
 			CustomMetadata: CustomMetadata{"a_random_field": "random field value"},
 		},


### PR DESCRIPTION
 {
      "id": "4590376cf2994d72cee36828ec4eff19",
      "protocol": "tcp/22",
      "dns": {
        "type": "ADDRESS",
        "name": "ssh.cam7.com"
      },
      "origin_direct": [
        "tcp://192.0.2.1:22"
      ],
      "ip_firewall": true,
      "proxy_protocol": false,
      "spp": false,
      "tls": "off",
      "traffic_type": "direct",
      "edge_ips": {
        "type": "static",
        "ips": [
          "198.51.100.10",
          "2001:DB8::1"
        ]
      }
    }