### PR TITLE
Add 'zone delete' command to flarectl

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -93,6 +93,17 @@ func main() {
 						},
 					},
 				},
+                {
+                    Name: "delete",
+                    Action: zoneDelete,
+                    Usage: "Delete a zone",
+                    Flags: []cli.Flag{
+                        cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+                    },
+                },
 				{
 					Name:   "check",
 					Action: zoneCheck,

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -80,6 +80,24 @@ func zoneList(c *cli.Context) {
 	writeTable(output, "ID", "Name", "Plan", "Status")
 }
 
+func zoneDelete(c *cli.Context) {
+    if err := checkFlags(c, "zone"); err != nil {
+		return
+	}
+
+    zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	_, err = api.DeleteZone(zoneID)
+    if err != nil {
+		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s", err))
+		return
+	}
+}
+
 func zoneCreateLockdown(c *cli.Context) {
 	if err := checkFlags(c, "zone", "urls", "targets", "values"); err != nil {
 		return


### PR DESCRIPTION
## Description

This adds a missing 'zone delete' command to flarectl.  When dealing with large numbers of domains, deleting them individually is painful.  This allows it to be done via the CLI.

Fixes #277.

## Has your change been tested?

Tested by using the binary and adding/deleting zones to Cloudflare. Given no other part of flarectl seems to have unit tests, I did not add any.  Leverages parts of the API that are already tested.


## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.