### PR TITLE
add support for modifying spectrum app traffic type

### DIFF
--- a/spectrum.go
+++ b/spectrum.go
@@ -20,6 +20,7 @@ type SpectrumApplication struct {
 	IPFirewall    bool                          `json:"ip_firewall,omitempty"`
 	ProxyProtocol bool                          `json:"proxy_protocol,omitempty"`
 	TLS           string                        `json:"tls,omitempty"`
+	TrafficType   string                        `json:"traffic_type,omitempty"`
 	CreatedOn     *time.Time                    `json:"created_on,omitempty"`
 	ModifiedOn    *time.Time                    `json:"modified_on,omitempty"`
 }


### PR DESCRIPTION
## Description

Add support for modifying spectrum app traffic type.  This change is required for updating the same in the terraform provider.  That PR is here: https://github.com/terraform-providers/terraform-provider-cloudflare/pull/481

## Has your change been tested?

This change was tested by successfully running terraform (via https://github.com/terraform-providers/terraform-provider-cloudflare/pull/481) to apply changes to the application type of a spectrum app.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
