### PR TITLE
Update documentation for PageRule.Status

### DIFF
--- a/page_rules.go
+++ b/page_rules.go
@@ -109,7 +109,7 @@ type PageRule struct {
 	Targets    []PageRuleTarget `json:"targets"`
 	Actions    []PageRuleAction `json:"actions"`
 	Priority   int              `json:"priority"`
-	Status     string           `json:"status"` // can be: active, paused
+	Status     string           `json:"status"` // can be: active, disabled
 	ModifiedOn time.Time        `json:"modified_on,omitempty"`
 	CreatedOn  time.Time        `json:"created_on,omitempty"`
 }

--- a/page_rules.go
+++ b/page_rules.go
@@ -109,7 +109,7 @@ type PageRule struct {
 	Targets    []PageRuleTarget `json:"targets"`
 	Actions    []PageRuleAction `json:"actions"`
 	Priority   int              `json:"priority"`
-	Status     string           `json:"status"` // can be: active, disabled
+	Status     string           `json:"status"`
 	ModifiedOn time.Time        `json:"modified_on,omitempty"`
 	CreatedOn  time.Time        `json:"created_on,omitempty"`
 }


### PR DESCRIPTION
## Description

The documentation for PageRule.Status was describing incorrect values. The API returns "active" and "disabled", and returns an error if we try to set the status to "paused".

## Has your change been tested?

The API rejects "paused"

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
