### PR TITLE
Changed the API endpoint used for Worker route deletion

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -411,7 +411,7 @@ func formatMultipartBody(params *WorkerScriptParams) (string, []byte, error) {
 
 // CreateWorkerRoute creates worker route for a zone
 //
-// API reference: https://api.cloudflare.com/#worker-filters-create-filter
+// API reference: https://api.cloudflare.com/#worker-filters-create-filter, https://api.cloudflare.com/#worker-routes-create-route
 func (api *API) CreateWorkerRoute(zoneID string, route WorkerRoute) (WorkerRouteResponse, error) {
 	// Check whether a script name is defined in order to determine whether
 	// to use the single-script or multi-script endpoint.
@@ -438,11 +438,9 @@ func (api *API) CreateWorkerRoute(zoneID string, route WorkerRoute) (WorkerRoute
 
 // DeleteWorkerRoute deletes worker route for a zone
 //
-// API reference: https://api.cloudflare.com/#worker-filters-delete-filter
+// API reference: https://api.cloudflare.com/#worker-routes-delete-route
 func (api *API) DeleteWorkerRoute(zoneID string, routeID string) (WorkerRouteResponse, error) {
-	// For deleting a route, it doesn't matter whether we use the
-	// single-script or multi-script endpoint
-	uri := "/zones/" + zoneID + "/workers/filters/" + routeID
+	uri := "/zones/" + zoneID + "/workers/routes/" + routeID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
 		return WorkerRouteResponse{}, errors.Wrap(err, errMakeRequestError)
@@ -457,7 +455,7 @@ func (api *API) DeleteWorkerRoute(zoneID string, routeID string) (WorkerRouteRes
 
 // ListWorkerRoutes returns list of worker routes
 //
-// API reference: https://api.cloudflare.com/#worker-filters-list-filters
+// API reference: https://api.cloudflare.com/#worker-filters-list-filters, https://api.cloudflare.com/#worker-routes-list-routes
 func (api *API) ListWorkerRoutes(zoneID string) (WorkerRoutesResponse, error) {
 	pathComponent := "filters"
 	if api.AccountID != "" {
@@ -487,7 +485,7 @@ func (api *API) ListWorkerRoutes(zoneID string) (WorkerRoutesResponse, error) {
 
 // UpdateWorkerRoute updates worker route for a zone.
 //
-// API reference: https://api.cloudflare.com/#worker-filters-update-filter
+// API reference: https://api.cloudflare.com/#worker-filters-update-filter, https://api.cloudflare.com/#worker-routes-update-route
 func (api *API) UpdateWorkerRoute(zoneID string, routeID string, route WorkerRoute) (WorkerRouteResponse, error) {
 	// Check whether a script name is defined in order to determine whether
 	// to use the single-script or multi-script endpoint.

--- a/workers_test.go
+++ b/workers_test.go
@@ -612,7 +612,7 @@ func TestWorkers_DeleteWorkerRoute(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/zones/foo/workers/filters/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
 		fmt.Fprintf(w, deleteWorkerRouteResponseData)
@@ -631,7 +631,7 @@ func TestWorkers_DeleteWorkerRouteEnt(t *testing.T) {
 	setup(UsingAccount("foo"))
 	defer teardown()
 
-	mux.HandleFunc("/zones/foo/workers/filters/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "DELETE", r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
 		fmt.Fprintf(w, deleteWorkerRouteResponseData)


### PR DESCRIPTION
## Description

Changed the API endpoint used for Worker route deletion to use `zones/:zone_id/workers/routes/:route_id` from https://api.cloudflare.com/#worker-routes-delete-route.

I was trying to use `DeleteWorkerRoute()` but kept encountering the following error:

```
HTTP status 501: content "{\"success\":false,\"errors\":[{\"code\":10000,\"message\":\"API Tokens are not supported by this API for now\"}]}\n"
```

I dug into the code and noticed that this library is using a deprecated API endpoint documented here: https://api.cloudflare.com/#worker-filters-deprecated--properties. This pull request updates the `DeleteWorkerRoute()` function to use https://api.cloudflare.com/#worker-routes-delete-route.

I did notice that there is an attempt in the other `*WorkerRoute()` functions to switch endpoints between the deprecated ones and the currently supported based on some conditions. But I couldn't see an easy way to do this with the `DeleteWorkerRoute()` without adding complication which seemed unnecessary considering that the old API should no longer be used.

## Has your change been tested?

I updated the unit tests to use the new route.

## Screenshots (if appropriate):

N/A

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.