### PR TITLE
Increase per_page for DNS records up to 100

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -69,8 +69,8 @@ func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) (*DNSRecordResponse
 func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	// Construct a query string
 	v := url.Values{}
-	// Request as many records as possible per page - API max is 50
-	v.Set("per_page", "50")
+	// Request as many records as possible per page - API max is 100
+	v.Set("per_page", "100")
 	if rr.Name != "" {
 		v.Set("name", rr.Name)
 	}


### PR DESCRIPTION
This PR updates the per_page max value to 100 as per docs here https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records

## Description

Reason: making lesser API requests to REST API to avoid `Throttling: Rate exceeded` error messages when listing very large DNS zones.

## Has your change been tested?

```
$ go test -v
=== RUN   TestAccessApplications
--- PASS: TestAccessApplications (0.00s)
=== RUN   TestAccessApplication
--- PASS: TestAccessApplication (0.00s)
=== RUN   TestCreateAccessApplications
--- PASS: TestCreateAccessApplications (0.00s)
=== RUN   TestUpdateAccessApplication
--- PASS: TestUpdateAccessApplication (0.00s)
=== RUN   TestUpdateAccessApplicationWithMissingID
--- PASS: TestUpdateAccessApplicationWithMissingID (0.00s)
=== RUN   TestDeleteAccessApplication
--- PASS: TestDeleteAccessApplication (0.00s)
=== RUN   TestRevokeAccessApplicationTokens
--- PASS: TestRevokeAccessApplicationTokens (0.00s)
=== RUN   TestAccessGroups
--- PASS: TestAccessGroups (0.00s)
=== RUN   TestAccessGroup
--- PASS: TestAccessGroup (0.00s)
=== RUN   TestCreateAccessGroup
--- PASS: TestCreateAccessGroup (0.00s)
=== RUN   TestUpdateAccessGroup
--- PASS: TestUpdateAccessGroup (0.00s)
=== RUN   TestUpdateAccessGroupWithMissingID
--- PASS: TestUpdateAccessGroupWithMissingID (0.00s)
=== RUN   TestDeleteAccessGroup
--- PASS: TestDeleteAccessGroup (0.00s)
=== RUN   TestAccessIdentityProviders
--- PASS: TestAccessIdentityProviders (0.00s)
=== RUN   TestAccessIdentityProviderDetails
--- PASS: TestAccessIdentityProviderDetails (0.00s)
=== RUN   TestCreateAccessIdentityProvider
--- PASS: TestCreateAccessIdentityProvider (0.00s)
=== RUN   TestUpdateAccessIdentityProvider
--- PASS: TestUpdateAccessIdentityProvider (0.00s)
=== RUN   TestDeleteAccessIdentityProvider
--- PASS: TestDeleteAccessIdentityProvider (0.00s)
=== RUN   TestAccessOrganization
--- PASS: TestAccessOrganization (0.00s)
=== RUN   TestCreateAccessOrganization
--- PASS: TestCreateAccessOrganization (0.00s)
=== RUN   TestUpdateAccessOrganization
--- PASS: TestUpdateAccessOrganization (0.00s)
=== RUN   TestAccessPolicies
--- PASS: TestAccessPolicies (0.00s)
=== RUN   TestAccessPolicy
--- PASS: TestAccessPolicy (0.00s)
=== RUN   TestCreateAccessPolicy
--- PASS: TestCreateAccessPolicy (0.00s)
=== RUN   TestUpdateAccessPolicy
--- PASS: TestUpdateAccessPolicy (0.00s)
=== RUN   TestUpdateAccessPolicyWithMissingID
--- PASS: TestUpdateAccessPolicyWithMissingID (0.00s)
=== RUN   TestDeleteAccessPolicy
--- PASS: TestDeleteAccessPolicy (0.00s)
=== RUN   TestAccessServiceTokens
--- PASS: TestAccessServiceTokens (0.00s)
=== RUN   TestCreateAccessServiceToken
--- PASS: TestCreateAccessServiceToken (0.00s)
=== RUN   TestUpdateAccessServiceToken
--- PASS: TestUpdateAccessServiceToken (0.00s)
=== RUN   TestDeleteAccessServiceToken
--- PASS: TestDeleteAccessServiceToken (0.00s)
=== RUN   TestAccountMembers
--- PASS: TestAccountMembers (0.00s)
=== RUN   TestAccountMembersWithoutAccountID
--- PASS: TestAccountMembersWithoutAccountID (0.00s)
=== RUN   TestCreateAccountMember
--- PASS: TestCreateAccountMember (0.00s)
=== RUN   TestCreateAccountMemberWithoutAccountID
--- PASS: TestCreateAccountMemberWithoutAccountID (0.00s)
=== RUN   TestUpdateAccountMember
--- PASS: TestUpdateAccountMember (0.00s)
=== RUN   TestUpdateAccountMemberWithoutAccountID
--- PASS: TestUpdateAccountMemberWithoutAccountID (0.00s)
=== RUN   TestAccountMember
--- PASS: TestAccountMember (0.00s)
=== RUN   TestAccountMemberWithoutAccountID
--- PASS: TestAccountMemberWithoutAccountID (0.00s)
=== RUN   TestAccountRoles
--- PASS: TestAccountRoles (0.00s)
=== RUN   TestAccountRole
--- PASS: TestAccountRole (0.00s)
=== RUN   TestAccounts
--- PASS: TestAccounts (0.00s)
=== RUN   TestAccount
--- PASS: TestAccount (0.00s)
=== RUN   TestUpdateAccount
--- PASS: TestUpdateAccount (0.00s)
=== RUN   TestArgoSmartRouting
--- PASS: TestArgoSmartRouting (0.00s)
=== RUN   TestUpdateArgoSmartRouting
--- PASS: TestUpdateArgoSmartRouting (0.00s)
=== RUN   TestUpdateArgoSmartRoutingWithInvalidValue
--- PASS: TestUpdateArgoSmartRoutingWithInvalidValue (0.00s)
=== RUN   TestArgoTieredCaching
--- PASS: TestArgoTieredCaching (0.00s)
=== RUN   TestUpdateArgoTieredCaching
--- PASS: TestUpdateArgoTieredCaching (0.00s)
=== RUN   TestUpdateArgoTieredCachingWithInvalidValue
--- PASS: TestUpdateArgoTieredCachingWithInvalidValue (0.00s)
=== RUN   TestAuditLogFilterStringify
--- PASS: TestAuditLogFilterStringify (0.00s)
=== RUN   TestClient_Headers
--- PASS: TestClient_Headers (0.00s)
=== RUN   TestClient_RetryCanSucceedAfterErrors
--- PASS: TestClient_RetryCanSucceedAfterErrors (0.00s)
=== RUN   TestClient_RetryReturnsPersistentErrorResponse
--- PASS: TestClient_RetryReturnsPersistentErrorResponse (0.00s)
=== RUN   TestZoneIDByNameWithNonUniqueZonesWithoutOrgID
--- PASS: TestZoneIDByNameWithNonUniqueZonesWithoutOrgID (0.00s)
=== RUN   TestZoneIDByNameWithNonUniqueZonesWithOrgId
--- PASS: TestZoneIDByNameWithNonUniqueZonesWithOrgId (0.00s)
=== RUN   TestZoneIDByNameWithIDN
--- PASS: TestZoneIDByNameWithIDN (0.00s)
=== RUN   TestCustomHostname_DeleteCustomHostname
--- PASS: TestCustomHostname_DeleteCustomHostname (0.00s)
=== RUN   TestCustomHostname_CreateCustomHostname
--- PASS: TestCustomHostname_CreateCustomHostname (0.00s)
=== RUN   TestCustomHostname_CreateCustomHostname_CustomOrigin
--- PASS: TestCustomHostname_CreateCustomHostname_CustomOrigin (0.00s)
=== RUN   TestCustomHostname_CustomHostnames
--- PASS: TestCustomHostname_CustomHostnames (0.00s)
=== RUN   TestCustomHostname_CustomHostname
--- PASS: TestCustomHostname_CustomHostname (0.00s)
=== RUN   TestCustomPagesWithoutZoneIDOrAccountID
--- PASS: TestCustomPagesWithoutZoneIDOrAccountID (0.00s)
=== RUN   TestCustomPagesWithZoneIDAndAccountID
--- PASS: TestCustomPagesWithZoneIDAndAccountID (0.00s)
=== RUN   TestCustomPagesForZone
--- PASS: TestCustomPagesForZone (0.00s)
=== RUN   TestCustomPagesForAccount
--- PASS: TestCustomPagesForAccount (0.00s)
=== RUN   TestCustomPageForZone
--- PASS: TestCustomPageForZone (0.00s)
=== RUN   TestCustomPageForAccount
--- PASS: TestCustomPageForAccount (0.00s)
=== RUN   TestUpdateCustomPagesForAccount
--- PASS: TestUpdateCustomPagesForAccount (0.00s)
=== RUN   TestUpdateCustomPagesForZone
--- PASS: TestUpdateCustomPagesForZone (0.00s)
=== RUN   TestUpdateCustomPagesToDefault
--- PASS: TestUpdateCustomPagesToDefault (0.00s)
=== RUN   TestFilter
--- PASS: TestFilter (0.00s)
=== RUN   TestFilters
--- PASS: TestFilters (0.00s)
=== RUN   TestCreateSingleFilter
--- PASS: TestCreateSingleFilter (0.00s)
=== RUN   TestCreateMultipleFilters
--- PASS: TestCreateMultipleFilters (0.00s)
=== RUN   TestUpdateSingleFilter
--- PASS: TestUpdateSingleFilter (0.00s)
=== RUN   TestUpdateMultipleFilters
--- PASS: TestUpdateMultipleFilters (0.00s)
=== RUN   TestDeleteFilter
--- PASS: TestDeleteFilter (0.00s)
=== RUN   TestDeleteFilterWithMissingID
--- PASS: TestDeleteFilterWithMissingID (0.00s)
=== RUN   TestFirewallRules
--- PASS: TestFirewallRules (0.00s)
=== RUN   TestFirewallRule
--- PASS: TestFirewallRule (0.00s)
=== RUN   TestCreateSingleFirewallRule
--- PASS: TestCreateSingleFirewallRule (0.00s)
=== RUN   TestCreateMultipleFirewallRules
--- PASS: TestCreateMultipleFirewallRules (0.00s)
=== RUN   TestUpdateFirewallRuleWithMissingID
--- PASS: TestUpdateFirewallRuleWithMissingID (0.00s)
=== RUN   TestUpdateSingleFirewallRule
--- PASS: TestUpdateSingleFirewallRule (0.00s)
=== RUN   TestUpdateMultipleFirewallRules
--- PASS: TestUpdateMultipleFirewallRules (0.00s)
=== RUN   TestDeleteSingleFirewallRule
--- PASS: TestDeleteSingleFirewallRule (0.00s)
=== RUN   TestDeleteFirewallRuleWithMissingID
--- PASS: TestDeleteFirewallRuleWithMissingID (0.00s)
=== RUN   Test_IPs
--- PASS: Test_IPs (0.00s)
=== RUN   TestCreateLoadBalancerPool
--- PASS: TestCreateLoadBalancerPool (0.00s)
=== RUN   TestListLoadBalancerPools
--- PASS: TestListLoadBalancerPools (0.00s)
=== RUN   TestLoadBalancerPoolDetails
--- PASS: TestLoadBalancerPoolDetails (0.00s)
=== RUN   TestDeleteLoadBalancerPool
--- PASS: TestDeleteLoadBalancerPool (0.00s)
=== RUN   TestModifyLoadBalancerPool
--- PASS: TestModifyLoadBalancerPool (0.00s)
=== RUN   TestCreateLoadBalancerMonitor
--- PASS: TestCreateLoadBalancerMonitor (0.00s)
=== RUN   TestListLoadBalancerMonitors
--- PASS: TestListLoadBalancerMonitors (0.00s)
=== RUN   TestLoadBalancerMonitorDetails
--- PASS: TestLoadBalancerMonitorDetails (0.00s)
=== RUN   TestDeleteLoadBalancerMonitor
--- PASS: TestDeleteLoadBalancerMonitor (0.00s)
=== RUN   TestModifyLoadBalancerMonitor
--- PASS: TestModifyLoadBalancerMonitor (0.00s)
=== RUN   TestCreateLoadBalancer
--- PASS: TestCreateLoadBalancer (0.00s)
=== RUN   TestListLoadBalancers
--- PASS: TestListLoadBalancers (0.00s)
=== RUN   TestLoadBalancerDetails
--- PASS: TestLoadBalancerDetails (0.00s)
=== RUN   TestDeleteLoadBalancer
--- PASS: TestDeleteLoadBalancer (0.00s)
=== RUN   TestModifyLoadBalancer
--- PASS: TestModifyLoadBalancer (0.00s)
=== RUN   TestLoadBalancerPoolHealthDetails
--- PASS: TestLoadBalancerPoolHealthDetails (0.00s)
=== RUN   TestLogpushJobs
--- PASS: TestLogpushJobs (0.00s)
=== RUN   TestGetLogpushJob
--- PASS: TestGetLogpushJob (0.00s)
=== RUN   TestCreateLogpushJob
--- PASS: TestCreateLogpushJob (0.00s)
=== RUN   TestUpdateLogpushJob
--- PASS: TestUpdateLogpushJob (0.00s)
=== RUN   TestDeleteLogpushJob
--- PASS: TestDeleteLogpushJob (0.00s)
=== RUN   TestGetLogpushOwnershipChallenge
--- PASS: TestGetLogpushOwnershipChallenge (0.00s)
=== RUN   TestValidateLogpushOwnershipChallenge
=== RUN   TestValidateLogpushOwnershipChallenge/ownership_is_valid
=== RUN   TestValidateLogpushOwnershipChallenge/ownership_is_not_valid
--- PASS: TestValidateLogpushOwnershipChallenge (0.00s)
    --- PASS: TestValidateLogpushOwnershipChallenge/ownership_is_valid (0.00s)
    --- PASS: TestValidateLogpushOwnershipChallenge/ownership_is_not_valid (0.00s)
=== RUN   TestCheckLogpushDestiantionExists
=== RUN   TestCheckLogpushDestiantionExists/destination_exists
=== RUN   TestCheckLogpushDestiantionExists/destination_does_not_exists
--- PASS: TestCheckLogpushDestiantionExists (0.00s)
    --- PASS: TestCheckLogpushDestiantionExists/destination_exists (0.00s)
    --- PASS: TestCheckLogpushDestiantionExists/destination_does_not_exists (0.00s)
=== RUN   TestOriginCA_CreateOriginCertificate
--- PASS: TestOriginCA_CreateOriginCertificate (0.00s)
=== RUN   TestOriginCA_OriginCertificates
--- PASS: TestOriginCA_OriginCertificates (0.00s)
=== RUN   TestOriginCA_OriginCertificate
--- PASS: TestOriginCA_OriginCertificate (0.00s)
=== RUN   TestOriginCA_RevokeCertificate
--- PASS: TestOriginCA_RevokeCertificate (0.00s)
=== RUN   TestListPageRules
--- PASS: TestListPageRules (0.00s)
=== RUN   TestGetPageRule
--- PASS: TestGetPageRule (0.00s)
=== RUN   TestCreatePageRule
--- PASS: TestCreatePageRule (0.00s)
=== RUN   TestDeletePageRule
--- PASS: TestDeletePageRule (0.00s)
=== RUN   TestCreateRailgun
--- PASS: TestCreateRailgun (0.00s)
=== RUN   TestListRailguns
--- PASS: TestListRailguns (0.00s)
=== RUN   TestRailgunDetails
--- PASS: TestRailgunDetails (0.00s)
=== RUN   TestRailgunZones
--- PASS: TestRailgunZones (0.00s)
=== RUN   TestEnableRailgun
--- PASS: TestEnableRailgun (0.00s)
=== RUN   TestDisbleRailgun
--- PASS: TestDisbleRailgun (0.00s)
=== RUN   TestDeleteRailgun
--- PASS: TestDeleteRailgun (0.00s)
=== RUN   TestZoneRailguns
--- PASS: TestZoneRailguns (0.00s)
=== RUN   TestZoneRailgunDetails
--- PASS: TestZoneRailgunDetails (0.00s)
=== RUN   TestTestRailgunConnection
--- PASS: TestTestRailgunConnection (0.00s)
=== RUN   TestConnectRailgun
--- PASS: TestConnectRailgun (0.00s)
=== RUN   TestDisconnectRailgun
--- PASS: TestDisconnectRailgun (0.00s)
=== RUN   TestListRateLimits
--- PASS: TestListRateLimits (0.00s)
=== RUN   TestListRateLimitsWithPageOpts
--- PASS: TestListRateLimitsWithPageOpts (0.00s)
=== RUN   TestListAllRateLimitsDoesPagination
--- PASS: TestListAllRateLimitsDoesPagination (0.00s)
=== RUN   TestGetRateLimit
--- PASS: TestGetRateLimit (0.00s)
=== RUN   TestCreateRateLimit
--- PASS: TestCreateRateLimit (0.00s)
=== RUN   TestCreateRateLimitWithZeroedThreshold
--- PASS: TestCreateRateLimitWithZeroedThreshold (0.00s)
=== RUN   TestUpdateRateLimit
--- PASS: TestUpdateRateLimit (0.00s)
=== RUN   TestDeleteRateLimit
--- PASS: TestDeleteRateLimit (0.00s)
=== RUN   TestRegistrarDomain
--- PASS: TestRegistrarDomain (0.00s)
=== RUN   TestRegistrarDomains
--- PASS: TestRegistrarDomains (0.00s)
=== RUN   TestTransferRegistrarDomain
--- PASS: TestTransferRegistrarDomain (0.00s)
=== RUN   TestCancelRegistrarDomainTransfer
--- PASS: TestCancelRegistrarDomainTransfer (0.00s)
=== RUN   TestUpdateRegistrarDomain
--- PASS: TestUpdateRegistrarDomain (0.00s)
=== RUN   TestSpectrumApplication
--- PASS: TestSpectrumApplication (0.00s)
=== RUN   TestSpectrumApplications
--- PASS: TestSpectrumApplications (0.00s)
=== RUN   TestUpdateSpectrumApplication
--- PASS: TestUpdateSpectrumApplication (0.00s)
=== RUN   TestCreateSpectrumApplication
--- PASS: TestCreateSpectrumApplication (0.00s)
=== RUN   TestCreateSpectrumApplication_OriginDNS
--- PASS: TestCreateSpectrumApplication_OriginDNS (0.00s)
=== RUN   TestDeleteSpectrumApplication
--- PASS: TestDeleteSpectrumApplication (0.00s)
=== RUN   TestCreateSSL
--- PASS: TestCreateSSL (0.00s)
=== RUN   TestListSSL
--- PASS: TestListSSL (0.00s)
=== RUN   TestSSLDetails
--- PASS: TestSSLDetails (0.00s)
=== RUN   TestUpdateSSL
--- PASS: TestUpdateSSL (0.00s)
=== RUN   TestReprioritizeSSL
--- PASS: TestReprioritizeSSL (0.00s)
=== RUN   TestDeleteSSL
--- PASS: TestDeleteSSL (0.00s)
=== RUN   TestUniversalSSLSettingDetails
--- PASS: TestUniversalSSLSettingDetails (0.00s)
=== RUN   TestEditUniversalSSLSetting
--- PASS: TestEditUniversalSSLSetting (0.00s)
=== RUN   TestUniversalSSLVerificationDetails
--- PASS: TestUniversalSSLVerificationDetails (0.00s)
=== RUN   TestUser_UserDetails
--- PASS: TestUser_UserDetails (0.00s)
=== RUN   TestUser_UpdateUser
--- PASS: TestUser_UpdateUser (0.00s)
=== RUN   TestUser_UserBillingProfile
--- PASS: TestUser_UserBillingProfile (0.00s)
=== RUN   TestVirtualDNSUserAnalytics
--- PASS: TestVirtualDNSUserAnalytics (0.00s)
=== RUN   TestListWAFPackages
--- PASS: TestListWAFPackages (0.00s)
=== RUN   TestWAFPackage
--- PASS: TestWAFPackage (0.00s)
=== RUN   TestUpdateWAFPackage
--- PASS: TestUpdateWAFPackage (0.00s)
=== RUN   TestListWAFGroups
--- PASS: TestListWAFGroups (0.00s)
=== RUN   TestWAFGroup
--- PASS: TestWAFGroup (0.00s)
=== RUN   TestUpdateWAFGroup
--- PASS: TestUpdateWAFGroup (0.00s)
=== RUN   TestListWAFRules
--- PASS: TestListWAFRules (0.00s)
=== RUN   TestWAFRule
--- PASS: TestWAFRule (0.00s)
=== RUN   TestUpdateWAFRule
--- PASS: TestUpdateWAFRule (0.00s)
=== RUN   TestWorkersKV_CreateWorkersKVNamespace
--- PASS: TestWorkersKV_CreateWorkersKVNamespace (0.00s)
=== RUN   TestWorkersKV_DeleteWorkersKVNamespace
--- PASS: TestWorkersKV_DeleteWorkersKVNamespace (0.00s)
=== RUN   TestWorkersKV_ListWorkersKVNamespace
--- PASS: TestWorkersKV_ListWorkersKVNamespace (0.00s)
=== RUN   TestWorkersKV_UpdateWorkersKVNamespace
--- PASS: TestWorkersKV_UpdateWorkersKVNamespace (0.00s)
=== RUN   TestWorkersKV_WriteWorkersKV
--- PASS: TestWorkersKV_WriteWorkersKV (0.00s)
=== RUN   TestWorkersKV_WriteWorkersKVBulk
--- PASS: TestWorkersKV_WriteWorkersKVBulk (0.00s)
=== RUN   TestWorkersKV_ReadWorkersKV
--- PASS: TestWorkersKV_ReadWorkersKV (0.00s)
=== RUN   TestWorkersKV_DeleteWorkersKV
--- PASS: TestWorkersKV_DeleteWorkersKV (0.00s)
=== RUN   TestWorkersKV_ListStorageKeys
--- PASS: TestWorkersKV_ListStorageKeys (0.00s)
=== RUN   TestWorkers_DeleteWorker
--- PASS: TestWorkers_DeleteWorker (0.00s)
=== RUN   TestWorkers_DeleteWorkerWithName
--- PASS: TestWorkers_DeleteWorkerWithName (0.00s)
=== RUN   TestWorkers_DeleteWorkerWithNameErrorsWithoutAccountId
--- PASS: TestWorkers_DeleteWorkerWithNameErrorsWithoutAccountId (0.00s)
=== RUN   TestWorkers_DownloadWorker
--- PASS: TestWorkers_DownloadWorker (0.00s)
=== RUN   TestWorkers_DownloadWorkerWithName
--- PASS: TestWorkers_DownloadWorkerWithName (0.00s)
=== RUN   TestWorkers_DownloadWorkerWithNameErrorsWithoutAccountId
--- PASS: TestWorkers_DownloadWorkerWithNameErrorsWithoutAccountId (0.00s)
=== RUN   TestWorkers_ListWorkerScripts
--- PASS: TestWorkers_ListWorkerScripts (0.00s)
=== RUN   TestWorkers_UploadWorker
--- PASS: TestWorkers_UploadWorker (0.00s)
=== RUN   TestWorkers_UploadWorkerWithName
--- PASS: TestWorkers_UploadWorkerWithName (0.00s)
=== RUN   TestWorkers_UploadWorkerSingleScriptWithAccount
--- PASS: TestWorkers_UploadWorkerSingleScriptWithAccount (0.00s)
=== RUN   TestWorkers_UploadWorkerWithNameErrorsWithoutAccountId
--- PASS: TestWorkers_UploadWorkerWithNameErrorsWithoutAccountId (0.00s)
=== RUN   TestWorkers_UploadWorkerWithInheritBinding
--- PASS: TestWorkers_UploadWorkerWithInheritBinding (0.00s)
=== RUN   TestWorkers_UploadWorkerWithKVBinding
--- PASS: TestWorkers_UploadWorkerWithKVBinding (0.00s)
=== RUN   TestWorkers_UploadWorkerWithWasmBinding
--- PASS: TestWorkers_UploadWorkerWithWasmBinding (0.00s)
=== RUN   TestWorkers_CreateWorkerRoute
--- PASS: TestWorkers_CreateWorkerRoute (0.00s)
=== RUN   TestWorkers_CreateWorkerRouteEnt
--- PASS: TestWorkers_CreateWorkerRouteEnt (0.00s)
=== RUN   TestWorkers_CreateWorkerRouteSingleScriptWithAccount
--- PASS: TestWorkers_CreateWorkerRouteSingleScriptWithAccount (0.00s)
=== RUN   TestWorkers_CreateWorkerRouteErrorsWhenMixingSingleAndMultiScriptProperties
--- PASS: TestWorkers_CreateWorkerRouteErrorsWhenMixingSingleAndMultiScriptProperties (0.00s)
=== RUN   TestWorkers_CreateWorkerRouteWithNoScript
--- PASS: TestWorkers_CreateWorkerRouteWithNoScript (0.00s)
=== RUN   TestWorkers_DeleteWorkerRoute
--- PASS: TestWorkers_DeleteWorkerRoute (0.00s)
=== RUN   TestWorkers_DeleteWorkerRouteEnt
--- PASS: TestWorkers_DeleteWorkerRouteEnt (0.00s)
=== RUN   TestWorkers_ListWorkerRoutes
--- PASS: TestWorkers_ListWorkerRoutes (0.00s)
=== RUN   TestWorkers_ListWorkerRoutesEnt
--- PASS: TestWorkers_ListWorkerRoutesEnt (0.00s)
=== RUN   TestWorkers_UpdateWorkerRoute
--- PASS: TestWorkers_UpdateWorkerRoute (0.00s)
=== RUN   TestWorkers_UpdateWorkerRouteEnt
--- PASS: TestWorkers_UpdateWorkerRouteEnt (0.00s)
=== RUN   TestWorkers_UpdateWorkerRouteSingleScriptWithAccount
--- PASS: TestWorkers_UpdateWorkerRouteSingleScriptWithAccount (0.00s)
=== RUN   TestWorkers_ListWorkerBindingsMultiScript
--- PASS: TestWorkers_ListWorkerBindingsMultiScript (0.00s)
=== RUN   TestWorkers_UpdateWorkerRouteErrorsWhenMixingSingleAndMultiScriptProperties
--- PASS: TestWorkers_UpdateWorkerRouteErrorsWhenMixingSingleAndMultiScriptProperties (0.00s)
=== RUN   TestWorkers_UpdateWorkerRouteWithNoScript
--- PASS: TestWorkers_UpdateWorkerRouteWithNoScript (0.00s)
=== RUN   TestZoneAnalyticsDashboard
--- PASS: TestZoneAnalyticsDashboard (0.00s)
=== RUN   TestZoneAnalyticsByColocation
--- PASS: TestZoneAnalyticsByColocation (0.00s)
=== RUN   TestWithPagination
--- PASS: TestWithPagination (0.00s)
=== RUN   TestZoneFilter
--- PASS: TestZoneFilter (0.00s)
=== RUN   TestCreateZoneFullSetup
--- PASS: TestCreateZoneFullSetup (0.00s)
=== RUN   TestCreateZonePartialSetup
--- PASS: TestCreateZonePartialSetup (0.00s)
=== RUN   TestFallbackOrigin_FallbackOrigin
--- PASS: TestFallbackOrigin_FallbackOrigin (0.00s)
=== RUN   TestFallbackOrigin_UpdateFallbackOrigin
--- PASS: TestFallbackOrigin_UpdateFallbackOrigin (0.00s)
=== RUN   Test_normalizeZoneName
=== RUN   Test_normalizeZoneName/unicode_stays_unicode
=== RUN   Test_normalizeZoneName/valid_punycode_is_normalized_to_unicode
=== RUN   Test_normalizeZoneName/valid_punycode_in_second_label
=== RUN   Test_normalizeZoneName/invalid_punycode_is_returned_without_change
--- PASS: Test_normalizeZoneName (0.00s)
    --- PASS: Test_normalizeZoneName/unicode_stays_unicode (0.00s)
    --- PASS: Test_normalizeZoneName/valid_punycode_is_normalized_to_unicode (0.00s)
    --- PASS: Test_normalizeZoneName/valid_punycode_in_second_label (0.00s)
    --- PASS: Test_normalizeZoneName/invalid_punycode_is_returned_without_change (0.00s)
=== RUN   TestZonePartialHasVerificationKey
--- PASS: TestZonePartialHasVerificationKey (0.00s)
=== RUN   ExampleDuration
--- PASS: ExampleDuration (0.00s)
PASS
ok      github.com/cloudflare/cloudflare-go     0.241s
```

## Screenshots (if appropriate):

See above.

## Types of changes

What sort of change does your code introduce/modify?

- [X] Non-Breaking change

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
