### PR TITLE
Add support for JSON output via --json

### DIFF
--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -57,7 +57,7 @@ func dnsCreate(c *cli.Context) {
 		formatDNSRecord(resp.Result),
 	}
 
-	writeTable(output, "ID", "Name", "Type", "Content", "TTL", "Proxiable", "Proxy", "Locked")
+	writeTable(c, output, "ID", "Name", "Type", "Content", "TTL", "Proxiable", "Proxy", "Locked")
 }
 
 func dnsCreateOrUpdate(c *cli.Context) {
@@ -129,7 +129,7 @@ func dnsCreateOrUpdate(c *cli.Context) {
 		formatDNSRecord(resp.Result),
 	}
 
-	writeTable(output, "ID", "Name", "Type", "Content", "TTL", "Proxiable", "Proxy", "Locked")
+	writeTable(c, output, "ID", "Name", "Type", "Content", "TTL", "Proxiable", "Proxy", "Locked")
 }
 
 func dnsUpdate(c *cli.Context) {

--- a/cmd/flarectl/firewall.go
+++ b/cmd/flarectl/firewall.go
@@ -79,7 +79,7 @@ func firewallAccessRules(c *cli.Context) {
 	for _, rule := range rules {
 		output = append(output, formatAccessRule(rule))
 	}
-	writeTable(output, "ID", "Value", "Scope", "Mode", "Notes")
+	writeTable(c, output, "ID", "Value", "Scope", "Mode", "Notes")
 }
 
 func firewallAccessRuleCreate(c *cli.Context) {
@@ -132,7 +132,7 @@ func firewallAccessRuleCreate(c *cli.Context) {
 	for _, rule := range rules {
 		output = append(output, formatAccessRule(rule))
 	}
-	writeTable(output, "ID", "Value", "Scope", "Mode", "Notes")
+	writeTable(c, output, "ID", "Value", "Scope", "Mode", "Notes")
 }
 
 func firewallAccessRuleUpdate(c *cli.Context) {
@@ -182,7 +182,7 @@ func firewallAccessRuleUpdate(c *cli.Context) {
 	for _, rule := range rules {
 		output = append(output, formatAccessRule(rule))
 	}
-	writeTable(output, "ID", "Value", "Scope", "Mode", "Notes")
+	writeTable(c, output, "ID", "Value", "Scope", "Mode", "Notes")
 
 }
 
@@ -298,7 +298,7 @@ func firewallAccessRuleDelete(c *cli.Context) {
 	for _, rule := range rules {
 		output = append(output, formatAccessRule(rule))
 	}
-	writeTable(output, "ID", "Value", "Scope", "Mode", "Notes")
+	writeTable(c, output, "ID", "Value", "Scope", "Mode", "Notes")
 }
 
 func getScope(c *cli.Context) (string, string, error) {

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -21,6 +21,10 @@ func main() {
 			Value:  "",
 			EnvVar: "CF_ACCOUNT_ID",
 		},
+		cli.BoolFlag{
+			Name:  "json",
+			Usage: "show output as JSON instead of as a table",
+		},
 	}
 	app.Commands = []cli.Command{
 		{

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -93,17 +93,17 @@ func main() {
 						},
 					},
 				},
-                {
-                    Name: "delete",
-                    Action: zoneDelete,
-                    Usage: "Delete a zone",
-                    Flags: []cli.Flag{
-                        cli.StringFlag{
+				{
+					Name:   "delete",
+					Action: zoneDelete,
+					Usage:  "Delete a zone",
+					Flags: []cli.Flag{
+						cli.StringFlag{
 							Name:  "zone",
 							Usage: "zone name",
 						},
-                    },
-                },
+					},
+				},
 				{
 					Name:   "check",
 					Action: zoneCheck,

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -42,7 +42,7 @@ func initializeAPI(c *cli.Context) error {
 }
 
 // writeTable outputs tabular data to stdout.
-func writeTable(data [][]string, cols ...string) {
+func writeTable(c *cli.Context, data [][]string, cols ...string) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(cols)
 	table.SetBorder(false)
@@ -99,7 +99,7 @@ func _getIps(ipType string, showMsgType bool) {
 	}
 }
 
-func userInfo(*cli.Context) {
+func userInfo(c *cli.Context) {
 	user, err := api.UserDetails()
 	if err != nil {
 		fmt.Println(err)
@@ -113,7 +113,7 @@ func userInfo(*cli.Context) {
 		user.FirstName + " " + user.LastName,
 		fmt.Sprintf("%t", user.TwoFA),
 	})
-	writeTable(output, "ID", "Email", "Username", "Name", "2FA")
+	writeTable(c, output, "ID", "Email", "Username", "Name", "2FA")
 }
 
 func userUpdate(*cli.Context) {

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -41,14 +42,41 @@ func initializeAPI(c *cli.Context) error {
 	return nil
 }
 
-// writeTable outputs tabular data to stdout.
-func writeTable(c *cli.Context, data [][]string, cols ...string) {
+// writeTableTabular outputs tabular data to STDOUT
+func writeTableTabular(data [][]string, cols ...string) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(cols)
 	table.SetBorder(false)
 	table.AppendBulk(data)
 
 	table.Render()
+}
+
+// writeTableJSON outputs JSON data to STDOUT
+func writeTableJSON(data [][]string, cols ...string) {
+	mappedData := make([]map[string]string, 0)
+	for i := range data {
+		rowData := make(map[string]string)
+		for j := range data[i] {
+			rowData[cols[j]] = data[i][j]
+		}
+		mappedData = append(mappedData, rowData)
+	}
+	jsonData, err := json.Marshal(mappedData)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(string(jsonData))
+}
+
+// writeTable outputs JSON or tabular data to STDOUT
+func writeTable(c *cli.Context, data [][]string, cols ...string) {
+	if c.GlobalBool("json") {
+		writeTableJSON(data, cols...)
+	} else {
+		writeTableTabular(data, cols...)
+	}
 }
 
 // Utility function to check if CLI flags were given.

--- a/cmd/flarectl/user_agent.go
+++ b/cmd/flarectl/user_agent.go
@@ -51,7 +51,7 @@ func userAgentCreate(c *cli.Context) {
 		formatUserAgentRule(resp.Result),
 	}
 
-	writeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+	writeTable(c, output, "ID", "Description", "Mode", "Value", "Paused")
 }
 
 func userAgentUpdate(c *cli.Context) {
@@ -85,7 +85,7 @@ func userAgentUpdate(c *cli.Context) {
 		formatUserAgentRule(resp.Result),
 	}
 
-	writeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+	writeTable(c, output, "ID", "Description", "Mode", "Value", "Paused")
 }
 
 func userAgentDelete(c *cli.Context) {
@@ -109,7 +109,7 @@ func userAgentDelete(c *cli.Context) {
 		formatUserAgentRule(resp.Result),
 	}
 
-	writeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+	writeTable(c, output, "ID", "Description", "Mode", "Value", "Paused")
 }
 
 func userAgentList(c *cli.Context) {
@@ -134,5 +134,5 @@ func userAgentList(c *cli.Context) {
 		output = append(output, formatUserAgentRule(rule))
 	}
 
-	writeTable(output, "ID", "Description", "Mode", "Value", "Paused")
+	writeTable(c, output, "ID", "Description", "Mode", "Value", "Paused")
 }

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -77,22 +77,22 @@ func zoneList(c *cli.Context) {
 			z.Status,
 		})
 	}
-	writeTable(output, "ID", "Name", "Plan", "Status")
+	writeTable(c, output, "ID", "Name", "Plan", "Status")
 }
 
 func zoneDelete(c *cli.Context) {
-    if err := checkFlags(c, "zone"); err != nil {
+	if err := checkFlags(c, "zone"); err != nil {
 		return
 	}
 
-    zoneID, err := api.ZoneIDByName(c.String("zone"))
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 
 	_, err = api.DeleteZone(zoneID)
-    if err != nil {
+	if err != nil {
 		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s", err))
 		return
 	}
@@ -136,7 +136,7 @@ func zoneCreateLockdown(c *cli.Context) {
 	output := make([][]string, 0, 1)
 	output = append(output, formatLockdownResponse(resp))
 
-	writeTable(output, "ID")
+	writeTable(c, output, "ID")
 }
 
 func zoneInfo(c *cli.Context) {
@@ -172,7 +172,7 @@ func zoneInfo(c *cli.Context) {
 			z.Type,
 		})
 	}
-	writeTable(output, "ID", "Zone", "Plan", "Status", "Name Servers", "Paused", "Type")
+	writeTable(c, output, "ID", "Zone", "Plan", "Status", "Name Servers", "Paused", "Type")
 }
 
 func zonePlan(*cli.Context) {
@@ -232,7 +232,7 @@ func zoneCachePurge(c *cli.Context) {
 	output := make([][]string, 0, 1)
 	output = append(output, formatCacheResponse(resp))
 
-	writeTable(output, "ID")
+	writeTable(c, output, "ID")
 }
 
 func zoneRecords(c *cli.Context) {
@@ -298,7 +298,7 @@ func zoneRecords(c *cli.Context) {
 			fmt.Sprintf("%d", r.TTL),
 		})
 	}
-	writeTable(output, "ID", "Type", "Name", "Content", "Proxied", "TTL")
+	writeTable(c, output, "ID", "Type", "Name", "Content", "Proxied", "TTL")
 }
 
 func formatCacheResponse(resp cloudflare.PurgeCacheResponse) []string {


### PR DESCRIPTION
## Description

This PR adds a global `--json` support to `flarectl`, which allows the output that's currently output via the `writeTable` function (which is pretty much all of it, aside from the IP list) to be output as JSON instead of as a table.

This ensures that long lines (i.e. the likes of a SPF record) aren't needlessly split on whitespace, as well as allowing the output to be fed to other tools via pipes without having to needlessly parse textual tabular format: a simple `| jq .` will be enough to start the pipe with.

## Has your change been tested?

Locally, yes, via something along the lines of:

    CF_DOMAIN=example.com CF_API_KEY="$( /usr/bin/secret-tool lookup cf_api_key "$CF_DOMAIN" )"  CF_API_EMAIL="$( /usr/bin/secret-tool lookup cf_api_email "$CF_DOMAIN" )" go run . --json d l --zone $CF_DOMAIN

I've *not* added any tests, as there weren't any in the flarectl directory.

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
