### PR TITLE
Add --type filter to flarectl dns list

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -244,6 +244,10 @@ func main() {
 							Usage: "zone name",
 						},
 						cli.StringFlag{
+							Name:  "type",
+							Usage: "record type",
+						},
+						cli.StringFlag{
 							Name:  "name",
 							Usage: "record name",
 						},

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -263,6 +263,9 @@ func zoneRecords(c *cli.Context) {
 		}
 		records = append(records, rec)
 	} else {
+		if c.String("type") != "" {
+			rr.Type = c.String("type")
+		}
 		if c.String("name") != "" {
 			rr.Name = c.String("name")
 		}


### PR DESCRIPTION
i.e. allow the following to return only TXT records:

    flarectl dns list --zone ... --type TXT

... similarly to how flarectl can already filter by name and other
criteria, via:

    flarectl dns list --zone ... --name foo

## Has your change been tested?

This has been tested locally, via something like:

    CF_DOMAIN=example.com CF_API_KEY="$( /usr/bin/secret-tool lookup cf_api_key "$CF_DOMAIN" )"  CF_API_EMAIL="$( /usr/bin/secret-tool lookup cf_api_email "$CF_DOMAIN" )" go run . d l --zone $CF_DOMAIN --type TXT

... and it properly returned only the TXT records for the domain; same for A, MX etc.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/