### PR TITLE
Add zone export to API and flarectl

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -224,6 +224,18 @@ func main() {
 					Action:  zoneKeyless,
 					Usage:   "Keyless SSL for a zone",
 				},
+				{
+					Name:    "export",
+					Aliases: []string{"x"},
+					Action:  zoneExport,
+					Usage:   "Export DNS records for a zone",
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+					},
+				},
 			},
 		},
 

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -315,3 +315,28 @@ func formatLockdownResponse(resp *cloudflare.ZoneLockdownResponse) []string {
 		resp.Result.ID,
 	}
 }
+
+func zoneExport(c *cli.Context) {
+	var zone string
+	if len(c.Args()) > 0 {
+		zone = c.Args()[0]
+	} else if c.String("zone") != "" {
+		zone = c.String("zone")
+	} else {
+		cli.ShowSubcommandHelp(c)
+		return
+	}
+
+	zoneID, err := api.ZoneIDByName(zone)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	res, err := api.ZoneExport(zoneID)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Print(res)
+}

--- a/zone.go
+++ b/zone.go
@@ -832,3 +832,14 @@ func (api *API) UpdateZoneSingleSetting(zoneID, settingName string, setting Zone
 
 	return response, nil
 }
+
+// ZoneExport returns the text BIND config for the given zone
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-export-dns-records
+func (api *API) ZoneExport(zoneID string) (string, error) {
+	res, err := api.makeRequest("GET", "/zones/"+zoneID+"/dns_records/export", nil)
+	if err != nil {
+		return "", errors.Wrap(err, errMakeRequestError)
+	}
+	return string(res), nil
+}


### PR DESCRIPTION
These two commits:

- add a `ZoneExport` function to the API, which calls the proper API endpoint to return a textual BIND format dump of the given zone
- add a "zone export" command to `flarectl`, which in turn uses the above `ZoneExport` API endpoint to dump the textual BIND format for the given zone to screen (or file, if input redirection is used).

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Has your change been tested?

Locally, with a few zones and using both supported syntaxes:

    flarectl zone export --zone example.com
    flarectl zone export example.com

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
