### PR TITLE
Return proper error code on failure #373

### DIFF
--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -672,5 +672,9 @@ func main() {
 			},
 		},
 	}
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
A linter also complained about the Run() method not being error checked:

    [gometalinter][W][] error return value not checked (app.Run(os.Args)) (errcheck)

By checking the error returned, we can ensure the user gets a non-zero
return code on argument parse failure, as well as on command failure,
both of which are instances where returning a non-zero error code seems
like a good idea.

Closes/Fixes #373

I would tentatively consider this a "breaking change" in that it affects scripts which have, so far, interacted with the command line without having to bother about error checking, rather than a "bug fix" (which it sort of is, as it's a bug IMVHO that it _didn't_ return a non-zero exit code on failure).

## Has your change been tested?

Yup, locally.

Also, given the exact invocation given on #373 

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
