### PR TITLE
Fix unmarshalling of OriginCACertificate

### DIFF
--- a/origin_ca.go
+++ b/origin_ca.go
@@ -34,6 +34,7 @@ type originCACertificateResult struct {
 	CSR             string    `json:"csr,omitempty"`
 }
 
+// UnmarshalJSON handles custom parsing from an API response to an OriginCACertificate
 func (c *OriginCACertificate) UnmarshalJSON(data []byte) error {
 	var res originCACertificateResult
 	err := json.Unmarshal(data, &res)

--- a/origin_ca.go
+++ b/origin_ca.go
@@ -13,13 +13,54 @@ import (
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ca
 type OriginCACertificate struct {
-	ID              string    `json:"id"`
-	Certificate     string    `json:"certificate"`
-	Hostnames       []string  `json:"hostnames"`
-	ExpiresOn       time.Time `json:"expires_on"`
-	RequestType     string    `json:"request_type"`
-	RequestValidity int       `json:"requested_validity"`
-	CSR             string    `json:"csr"`
+	ID              string    `json:"id,omitempty"`
+	Certificate     string    `json:"certificate,omitempty"`
+	Hostnames       []string  `json:"hostnames,omitempty"`
+	ExpiresOn       time.Time `json:"expires_on,omitempty"`
+	RequestType     string    `json:"request_type,omitempty"`
+	RequestValidity int       `json:"requested_validity,omitempty"`
+	RevokedAt       time.Time `json:"revoked_at,omitempty"`
+	CSR             string    `json:"csr,omitempty"`
+}
+
+type originCACertificateResult struct {
+	ID              string    `json:"id,omitempty"`
+	Certificate     string    `json:"certificate,omitempty"`
+	Hostnames       []string  `json:"hostnames,omitempty"`
+	ExpiresOn       string    `json:"expires_on,omitempty"`
+	RequestType     string    `json:"request_type,omitempty"`
+	RequestValidity int       `json:"requested_validity,omitempty"`
+	RevokedAt       time.Time `json:"revoked_at,omitempty"`
+	CSR             string    `json:"csr,omitempty"`
+}
+
+func (c *OriginCACertificate) UnmarshalJSON(data []byte) error {
+	var res originCACertificateResult
+	err := json.Unmarshal(data, &res)
+	if err != nil {
+		return err
+	}
+
+	// This format comes from time.Time.String() source
+	expires, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", res.ExpiresOn)
+	if err != nil {
+		expires, err = time.Parse(time.RFC3339, res.ExpiresOn)
+	}
+	if err != nil {
+		return err
+	}
+
+	*c = OriginCACertificate{
+		ID:              res.ID,
+		Certificate:     res.Certificate,
+		Hostnames:       res.Hostnames,
+		ExpiresOn:       expires,
+		RequestType:     res.RequestType,
+		RequestValidity: res.RequestValidity,
+		RevokedAt:       res.RevokedAt,
+		CSR:             res.CSR,
+	}
+	return nil
 }
 
 // OriginCACertificateListOptions represents the parameters used to list Cloudflare-issued certificates.

--- a/origin_ca.go
+++ b/origin_ca.go
@@ -13,54 +13,44 @@ import (
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ca
 type OriginCACertificate struct {
-	ID              string    `json:"id,omitempty"`
-	Certificate     string    `json:"certificate,omitempty"`
-	Hostnames       []string  `json:"hostnames,omitempty"`
-	ExpiresOn       time.Time `json:"expires_on,omitempty"`
-	RequestType     string    `json:"request_type,omitempty"`
-	RequestValidity int       `json:"requested_validity,omitempty"`
-	RevokedAt       time.Time `json:"revoked_at,omitempty"`
-	CSR             string    `json:"csr,omitempty"`
-}
-
-type originCACertificateResult struct {
-	ID              string    `json:"id,omitempty"`
-	Certificate     string    `json:"certificate,omitempty"`
-	Hostnames       []string  `json:"hostnames,omitempty"`
-	ExpiresOn       string    `json:"expires_on,omitempty"`
-	RequestType     string    `json:"request_type,omitempty"`
-	RequestValidity int       `json:"requested_validity,omitempty"`
-	RevokedAt       time.Time `json:"revoked_at,omitempty"`
-	CSR             string    `json:"csr,omitempty"`
+	ID              string    `json:"id"`
+	Certificate     string    `json:"certificate"`
+	Hostnames       []string  `json:"hostnames"`
+	ExpiresOn       time.Time `json:"expires_on"`
+	RequestType     string    `json:"request_type"`
+	RequestValidity int       `json:"requested_validity"`
+	CSR             string    `json:"csr"`
 }
 
 // UnmarshalJSON handles custom parsing from an API response to an OriginCACertificate
+// http://choly.ca/post/go-json-marshalling/
 func (c *OriginCACertificate) UnmarshalJSON(data []byte) error {
-	var res originCACertificateResult
-	err := json.Unmarshal(data, &res)
-	if err != nil {
+	type alias OriginCACertificate
+
+	aux := &struct {
+		ExpiresOn string `json:"expires_on"`
+		*alias
+	}{
+		alias: (*alias)(c),
+	}
+
+	var err error
+
+	if err = json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
 	// This format comes from time.Time.String() source
-	expires, err := time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", res.ExpiresOn)
+	c.ExpiresOn, err = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", aux.ExpiresOn)
+
 	if err != nil {
-		expires, err = time.Parse(time.RFC3339, res.ExpiresOn)
+		c.ExpiresOn, err = time.Parse(time.RFC3339, aux.ExpiresOn)
 	}
+
 	if err != nil {
 		return err
 	}
 
-	*c = OriginCACertificate{
-		ID:              res.ID,
-		Certificate:     res.Certificate,
-		Hostnames:       res.Hostnames,
-		ExpiresOn:       expires,
-		RequestType:     res.RequestType,
-		RequestValidity: res.RequestValidity,
-		RevokedAt:       res.RevokedAt,
-		CSR:             res.CSR,
-	}
 	return nil
 }
 

--- a/origin_ca_test.go
+++ b/origin_ca_test.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -8,6 +9,40 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+var (
+	payloadTemplate = `{"expires_on":"%s"}`
+	unmarshalTime   = time.Now().Round(time.Second)
+)
+
+func TestOriginCA_UnmarshalRFC3339(t *testing.T) {
+	payload := fmt.Sprintf(payloadTemplate, unmarshalTime.Format(time.RFC3339))
+
+	var cert OriginCACertificate
+	err := json.Unmarshal([]byte(payload), &cert)
+	if assert.NoError(t, err) {
+		assert.Equal(t, unmarshalTime, cert.ExpiresOn)
+	}
+}
+
+func TestOriginCA_UnmarshalString(t *testing.T) {
+	payload := fmt.Sprintf(payloadTemplate, unmarshalTime.String())
+
+	var cert OriginCACertificate
+	err := json.Unmarshal([]byte(payload), &cert)
+	if assert.NoError(t, err) {
+		assert.Equal(t, unmarshalTime, cert.ExpiresOn)
+	}
+}
+
+func TestOriginCA_UnmarshalOther(t *testing.T) {
+	payload := fmt.Sprintf(payloadTemplate, unmarshalTime.Format(time.RFC1123))
+
+	var cert OriginCACertificate
+	err := json.Unmarshal([]byte(payload), &cert)
+	assert.Error(t, err)
+	assert.Equal(t, OriginCACertificate{}, cert)
+}
 
 func TestOriginCA_CreateOriginCertificate(t *testing.T) {
 	setup()

--- a/origin_ca_test.go
+++ b/origin_ca_test.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	payloadTemplate = `{"expires_on":"%s"}`
-	unmarshalTime   = time.Now().Round(time.Second)
+	unmarshalTime   = time.Now().UTC().Round(time.Second)
 )
 
 func TestOriginCA_UnmarshalRFC3339(t *testing.T) {


### PR DESCRIPTION
Fixes #190 

## Description

The format of the `expires_on` field differs from what is documented, and the json parser makes `CreateOriginCertificate()` always return an error, even if the certificate was created.  This change introduces custom timestamp parsing that works for both the actual and documented formats.

## Has your change been tested?

I wrote a tiny test program that calls `CreateOriginCertificate()` and checked that the cert object is populated and the error is `nil`.

## Screenshots (if appropriate):

N/A

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
