### PR TITLE
Add pagination for listing KV worker namespaces

### DIFF
--- a/workers_kv.go
+++ b/workers_kv.go
@@ -83,7 +83,7 @@ func (api *API) CreateWorkersKVNamespace(ctx context.Context, req *WorkersKVName
 // ListWorkersKVNamespaces lists storage namespaces
 //
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-list-namespaces
-func (api *API) ListWorkersKVNamespaces() ([]WorkersKVNamespace, error) {
+func (api *API) ListWorkersKVNamespaces(ctx context.Context) ([]WorkersKVNamespace, error) {
 	v := url.Values{}
 	v.Set("per_page", "100")
 
@@ -93,7 +93,7 @@ func (api *API) ListWorkersKVNamespaces() ([]WorkersKVNamespace, error) {
 	for {
 		v.Set("page", strconv.Itoa(page))
 		uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces?%s", api.AccountID, v.Encode())
-		res, err := api.makeRequest(http.MethodGet, uri, nil)
+		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 		if err != nil {
 			return []WorkersKVNamespace{}, errors.Wrap(err, errMakeRequestError)
 		}

--- a/workers_kv_example_test.go
+++ b/workers_kv_example_test.go
@@ -34,7 +34,7 @@ func ExampleAPI_ListWorkersKVNamespaces() {
 		log.Fatal(err)
 	}
 
-	lsr, err := api.ListWorkersKVNamespaces()
+	lsr, err := api.ListWorkersKVNamespaces(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/workers_kv_example_test.go
+++ b/workers_kv_example_test.go
@@ -34,7 +34,7 @@ func ExampleAPI_ListWorkersKVNamespaces() {
 		log.Fatal(err)
 	}
 
-	lsr, err := api.ListWorkersKVNamespaces(context.Background())
+	lsr, err := api.ListWorkersKVNamespaces()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/workers_kv_test.go
+++ b/workers_kv_test.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,39 +101,26 @@ func TestWorkersKV_ListWorkersKVNamespace(t *testing.T) {
 		fmt.Fprintf(w, response)
 	})
 
-	res, err := client.ListWorkersKVNamespaces(context.Background())
-	want := ListWorkersKVNamespacesResponse{
-		successResponse,
-		[]WorkersKVNamespace{
-			{
-				ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-				Title: "test_namespace_1",
-			},
-			{
-				ID:    "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
-				Title: "test_namespace_2",
-			},
+	res, err := client.ListWorkersKVNamespaces()
+	want := []WorkersKVNamespace{
+		WorkersKVNamespace {
+			ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Title: "test_namespace_1",
 		},
-		ResultInfo{
-			Page:       1,
-			PerPage:    100,
-			Count:      2,
-			TotalPages: 1,
-			Total:      2,
+		WorkersKVNamespace {
+			ID:    "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+			Title: "test_namespace_2",
 		},
 	}
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, want.Response, res.Response)
-		assert.Equal(t, want.ResultInfo, res.ResultInfo)
-
-		sort.Slice(res.Result, func(i, j int) bool {
-			return res.Result[i].ID < res.Result[j].ID
+		sort.Slice(res, func(i, j int) bool {
+			return res[i].ID < res[j].ID
 		})
-		sort.Slice(want.Result, func(i, j int) bool {
-			return want.Result[i].ID < want.Result[j].ID
+		sort.Slice(want, func(i, j int) bool {
+			return want[i].ID < want[j].ID
 		})
-		assert.Equal(t, res.Result, want.Result)
+		assert.Equal(t, res, want)
 	}
 }
 
@@ -180,47 +168,37 @@ func TestWorkersKV_ListWorkersKVNamespaceMultiplePages(t *testing.T) {
 		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
 
-		if r.URL.Query().Get("page") == "2" {
+		if r.URL.Query().Get("page") == "1" {
+			fmt.Fprintf(w, response1)
+			return
+		} else if r.URL.Query().Get("page") == "2" {
 			fmt.Fprintf(w, response2)
 			return
+		} else {
+			panic(errors.New("Got a request for an unexpected page"))
 		}
-
-		fmt.Fprintf(w, response1)
 	})
 
-	res, err := client.ListWorkersKVNamespaces(context.Background())
-	want := ListWorkersKVNamespacesResponse{
-		successResponse,
-		[]WorkersKVNamespace{
-			{
-				ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-				Title: "test_namespace_1",
-			},
-			{
-				ID:    "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
-				Title: "test_namespace_2",
-			},
+	res, err := client.ListWorkersKVNamespaces()
+	want := []WorkersKVNamespace{
+		WorkersKVNamespace {
+			ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			Title: "test_namespace_1",
 		},
-		ResultInfo{
-			Page:       1,
-			PerPage:    100,
-			Count:      1,
-			TotalPages: 2,
-			Total:      2,
+		WorkersKVNamespace {
+			ID:    "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
+			Title: "test_namespace_2",
 		},
 	}
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, want.Response, res.Response)
-		assert.Equal(t, want.ResultInfo, res.ResultInfo)
-
-		sort.Slice(res.Result, func(i, j int) bool {
-			return res.Result[i].ID < res.Result[j].ID
+		sort.Slice(res, func(i, j int) bool {
+			return res[i].ID < res[j].ID
 		})
-		sort.Slice(want.Result, func(i, j int) bool {
-			return want.Result[i].ID < want.Result[j].ID
+		sort.Slice(want, func(i, j int) bool {
+			return want[i].ID < want[j].ID
 		})
-		assert.Equal(t, res.Result, want.Result)
+		assert.Equal(t, res, want)
 	}
 }
 

--- a/workers_kv_test.go
+++ b/workers_kv_test.go
@@ -101,7 +101,7 @@ func TestWorkersKV_ListWorkersKVNamespace(t *testing.T) {
 		fmt.Fprintf(w, response)
 	})
 
-	res, err := client.ListWorkersKVNamespaces()
+	res, err := client.ListWorkersKVNamespaces(context.Background())
 	want := []WorkersKVNamespace{
 		WorkersKVNamespace {
 			ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -179,7 +179,7 @@ func TestWorkersKV_ListWorkersKVNamespaceMultiplePages(t *testing.T) {
 		}
 	})
 
-	res, err := client.ListWorkersKVNamespaces()
+	res, err := client.ListWorkersKVNamespaces(context.Background())
 	want := []WorkersKVNamespace{
 		WorkersKVNamespace {
 			ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",


### PR DESCRIPTION
## Description

Listing KV worker namespaces only brings back the first page of (20) results. While that's the default quota for a CF account, it is possible to have more than 20 namespaces, in which case the behavior is inadequate. We're seeing issues with this downstream in the Cloudflare Terraform provider, which is incorrectly trying to create a namespace that already exists (on the second page of results).

This PR updates `ListWorkersKVNamespaces` to return all namespaces by paging through the result set. This was modeled after the work done in ~~#288 and #377~~ #389 .

This changes the signature of the `ListWorkersKVNamespaces` function. Does that require a change to the docs? Where would that be made?

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) (**changes the signature of `ListWorkersKVNamespaces`**)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.