### PR TITLE
update SpectrumApplication to support string value for proxy_protocol

### DIFF
--- a/spectrum.go
+++ b/spectrum.go
@@ -46,7 +46,6 @@ type SpectrumApplication struct {
 	OriginDNS     *SpectrumApplicationOriginDNS `json:"origin_dns,omitempty"`
 	IPFirewall    bool                          `json:"ip_firewall,omitempty"`
 	ProxyProtocol ProxyProtocol                 `json:"proxy_protocol,omitempty"`
-	SPP           bool                          `json:"spp,omitempty"`
 	TLS           string                        `json:"tls,omitempty"`
 	TrafficType   string                        `json:"traffic_type,omitempty"`
 	CreatedOn     *time.Time                    `json:"created_on,omitempty"`
@@ -55,16 +54,21 @@ type SpectrumApplication struct {
 
 // UnmarshalJSON handles setting the `ProxyProtocol` field based on the value of the deprecated `spp` field.
 func (a *SpectrumApplication) UnmarshalJSON(data []byte) error {
-	var raw spectrumApplicationRaw
-	if err := json.Unmarshal(data, &raw); err != nil {
+	var body map[string]interface{}
+	if err := json.Unmarshal(data, &body); err != nil {
 		return err
 	}
 
-	if raw.SPP {
-		raw.ProxyProtocol = "simple"
+	var app spectrumApplicationRaw
+	if err := json.Unmarshal(data, &app); err != nil {
+		return err
 	}
 
-	*a = SpectrumApplication(raw)
+	if spp, ok := body["spp"]; ok && spp.(bool) == true {
+		app.ProxyProtocol = "simple"
+	}
+
+	*a = SpectrumApplication(app)
 	return nil
 }
 

--- a/spectrum.go
+++ b/spectrum.go
@@ -12,6 +12,8 @@ import (
 // value for `proxy_protocol`
 type ProxyProtocol string
 
+// UnmarshalJSON handles deserializing of both the deprecated boolean value and the current string value
+// for the `proxy_protocol` field.
 func (p *ProxyProtocol) UnmarshalJSON(data []byte) error {
 	var raw interface{}
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -51,6 +53,7 @@ type SpectrumApplication struct {
 	ModifiedOn    *time.Time                    `json:"modified_on,omitempty"`
 }
 
+// UnmarshalJSON handles setting the `ProxyProtocol` field based on the value of the deprecated `spp` field.
 func (a *SpectrumApplication) UnmarshalJSON(data []byte) error {
 	var raw spectrumApplicationRaw
 	if err := json.Unmarshal(data, &raw); err != nil {

--- a/spectrum_test.go
+++ b/spectrum_test.go
@@ -29,7 +29,8 @@ func TestSpectrumApplication(t *testing.T) {
 					"tcp://192.0.2.1:22"
 				],
 				"ip_firewall": true,
-				"proxy_protocol": false,
+				"proxy_protocol": "off",
+				"spp": false,
 				"tls": "off",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -55,7 +56,8 @@ func TestSpectrumApplication(t *testing.T) {
 		},
 		OriginDirect:  []string{"tcp://192.0.2.1:22"},
 		IPFirewall:    true,
-		ProxyProtocol: false,
+		ProxyProtocol: "off",
+		SPP:           false,
 		TLS:           "off",
 	}
 
@@ -86,7 +88,8 @@ func TestSpectrumApplications(t *testing.T) {
 						"tcp://192.0.2.1:22"
 					],
 					"ip_firewall": true,
-					"proxy_protocol": false,
+					"proxy_protocol": "off",
+					"spp": false,
 					"tls": "off",
 					"created_on": "2018-03-28T21:25:55.643771Z",
 					"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -114,7 +117,8 @@ func TestSpectrumApplications(t *testing.T) {
 			},
 			OriginDirect:  []string{"tcp://192.0.2.1:22"},
 			IPFirewall:    true,
-			ProxyProtocol: false,
+			ProxyProtocol: "off",
+			SPP:           false,
 			TLS:           "off",
 		},
 	}
@@ -145,7 +149,8 @@ func TestUpdateSpectrumApplication(t *testing.T) {
 					"tcp://192.0.2.1:23"
 				],
 				"ip_firewall": true,
-				"proxy_protocol": false,
+				"proxy_protocol": "off",
+				"spp": false,
 				"tls": "full",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -170,7 +175,8 @@ func TestUpdateSpectrumApplication(t *testing.T) {
 		},
 		OriginDirect:  []string{"tcp://192.0.2.1:23"},
 		IPFirewall:    true,
-		ProxyProtocol: false,
+		ProxyProtocol: "off",
+		SPP:           false,
 		TLS:           "full",
 		CreatedOn:     &createdOn,
 		ModifiedOn:    &modifiedOn,
@@ -202,7 +208,8 @@ func TestCreateSpectrumApplication(t *testing.T) {
 					"tcp://192.0.2.1:22"
 				],
 				"ip_firewall": true,
-				"proxy_protocol": false,
+				"proxy_protocol": "off",
+				"spp": false,
 				"tls": "full",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -227,7 +234,7 @@ func TestCreateSpectrumApplication(t *testing.T) {
 		},
 		OriginDirect:  []string{"tcp://192.0.2.1:22"},
 		IPFirewall:    true,
-		ProxyProtocol: false,
+		ProxyProtocol: "off",
 		TLS:           "full",
 		CreatedOn:     &createdOn,
 		ModifiedOn:    &modifiedOn,
@@ -259,7 +266,8 @@ func TestCreateSpectrumApplication_OriginDNS(t *testing.T) {
 					"name" : "spectrum.origin.example.com"
 				},
 				"ip_firewall": true,
-				"proxy_protocol": false,
+				"proxy_protocol": "off",
+				"spp": false,
 				"tls": "full",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -286,7 +294,7 @@ func TestCreateSpectrumApplication_OriginDNS(t *testing.T) {
 			Name: "spectrum.origin.example.com",
 		},
 		IPFirewall:    true,
-		ProxyProtocol: false,
+		ProxyProtocol: "off",
 		TLS:           "full",
 		CreatedOn:     &createdOn,
 		ModifiedOn:    &modifiedOn,
@@ -319,4 +327,85 @@ func TestDeleteSpectrumApplication(t *testing.T) {
 
 	err := client.DeleteSpectrumApplication("01a7362d577a6c3019a474fd6f485823", "f68579455bd947efb65ffa1bcf33b52c")
 	assert.NoError(t, err)
+}
+
+func TestSpectrumApplicationProxyProtocolDeprecations(t *testing.T) {
+	for _, testCase := range []struct {
+		actualProxyProtocol   bool
+		actualSPP             bool
+		expectedProxyProtocol ProxyProtocol
+	}{
+		{
+			actualProxyProtocol:   false,
+			actualSPP:             false,
+			expectedProxyProtocol: "off",
+		},
+		{
+			actualProxyProtocol:   true,
+			actualSPP:             false,
+			expectedProxyProtocol: "v1",
+		},
+		{
+			actualProxyProtocol:   false,
+			actualSPP:             true,
+			expectedProxyProtocol: "simple",
+		},
+	} {
+		setup()
+
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+			w.Header().Set("content-type", "application/json")
+			fmt.Fprintf(w, `{
+			"result": {
+				"id": "f68579455bd947efb65ffa1bcf33b52c",
+				"protocol": "tcp/22",
+				"ipv4": true,
+				"dns": {
+					"type": "CNAME",
+					"name": "spectrum.example.com"
+				},
+				"origin_direct": [
+					"tcp://192.0.2.1:22"
+				],
+				"ip_firewall": true,
+				"proxy_protocol": %v,
+				"spp": %v,
+				"tls": "off",
+				"created_on": "2018-03-28T21:25:55.643771Z",
+				"modified_on": "2018-03-28T21:25:55.643771Z"
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`, testCase.actualProxyProtocol, testCase.actualSPP)
+		}
+
+		mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/spectrum/apps/f68579455bd947efb65ffa1bcf33b52c", handler)
+		createdOn, _ := time.Parse(time.RFC3339, "2018-03-28T21:25:55.643771Z")
+		modifiedOn, _ := time.Parse(time.RFC3339, "2018-03-28T21:25:55.643771Z")
+		want := SpectrumApplication{
+			ID:         "f68579455bd947efb65ffa1bcf33b52c",
+			CreatedOn:  &createdOn,
+			ModifiedOn: &modifiedOn,
+			Protocol:   "tcp/22",
+			IPv4:       true,
+			DNS: SpectrumApplicationDNS{
+				Name: "spectrum.example.com",
+				Type: "CNAME",
+			},
+			OriginDirect:  []string{"tcp://192.0.2.1:22"},
+			IPFirewall:    true,
+			ProxyProtocol: testCase.expectedProxyProtocol,
+			SPP:           testCase.actualSPP,
+			TLS:           "off",
+		}
+
+		actual, err := client.SpectrumApplication("01a7362d577a6c3019a474fd6f485823", "f68579455bd947efb65ffa1bcf33b52c")
+		if assert.NoError(t, err) {
+			assert.Equal(t, want, actual)
+		}
+
+		teardown()
+	}
 }

--- a/spectrum_test.go
+++ b/spectrum_test.go
@@ -30,7 +30,6 @@ func TestSpectrumApplication(t *testing.T) {
 				],
 				"ip_firewall": true,
 				"proxy_protocol": "off",
-				"spp": false,
 				"tls": "off",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -57,7 +56,6 @@ func TestSpectrumApplication(t *testing.T) {
 		OriginDirect:  []string{"tcp://192.0.2.1:22"},
 		IPFirewall:    true,
 		ProxyProtocol: "off",
-		SPP:           false,
 		TLS:           "off",
 	}
 
@@ -89,7 +87,6 @@ func TestSpectrumApplications(t *testing.T) {
 					],
 					"ip_firewall": true,
 					"proxy_protocol": "off",
-					"spp": false,
 					"tls": "off",
 					"created_on": "2018-03-28T21:25:55.643771Z",
 					"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -118,7 +115,6 @@ func TestSpectrumApplications(t *testing.T) {
 			OriginDirect:  []string{"tcp://192.0.2.1:22"},
 			IPFirewall:    true,
 			ProxyProtocol: "off",
-			SPP:           false,
 			TLS:           "off",
 		},
 	}
@@ -150,7 +146,6 @@ func TestUpdateSpectrumApplication(t *testing.T) {
 				],
 				"ip_firewall": true,
 				"proxy_protocol": "off",
-				"spp": false,
 				"tls": "full",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -176,7 +171,6 @@ func TestUpdateSpectrumApplication(t *testing.T) {
 		OriginDirect:  []string{"tcp://192.0.2.1:23"},
 		IPFirewall:    true,
 		ProxyProtocol: "off",
-		SPP:           false,
 		TLS:           "full",
 		CreatedOn:     &createdOn,
 		ModifiedOn:    &modifiedOn,
@@ -209,7 +203,6 @@ func TestCreateSpectrumApplication(t *testing.T) {
 				],
 				"ip_firewall": true,
 				"proxy_protocol": "off",
-				"spp": false,
 				"tls": "full",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -267,7 +260,6 @@ func TestCreateSpectrumApplication_OriginDNS(t *testing.T) {
 				},
 				"ip_firewall": true,
 				"proxy_protocol": "off",
-				"spp": false,
 				"tls": "full",
 				"created_on": "2018-03-28T21:25:55.643771Z",
 				"modified_on": "2018-03-28T21:25:55.643771Z"
@@ -397,7 +389,6 @@ func TestSpectrumApplicationProxyProtocolDeprecations(t *testing.T) {
 			OriginDirect:  []string{"tcp://192.0.2.1:22"},
 			IPFirewall:    true,
 			ProxyProtocol: testCase.expectedProxyProtocol,
-			SPP:           testCase.actualSPP,
 			TLS:           "off",
 		}
 


### PR DESCRIPTION
## Description

Spectrum recently deprecated use of the `spp` field and the boolean value for the `proxy_protocol` field in its configuration API in favor of a string enum for the `proxy_protocol` field. This change updates the `SpectrumApplication` struct to support reading deprecated values from the API and writing with the updated schema.

- Breaking change: the type of the `ProxyProtocol` field on the `SpectrumApplication` struct has changed from a `bool` to a `string`. Clients using this library that manipulate the `spp`/`proxy_protocol` fields will need to update to use the new schema upon upgrading to the latest version of the library. 
- Adds the `SPP` boolean field to the `SpectrumApplication` struct, will be removed following the EOL date for support for the `proxy_protocol` boolean and the `spp` field.

## Has your change been tested?

Added automated test for validating new deserializing logic for `spp` and `proxy_protocol` fields, as well as manual testing against the production API.

## Types of changes

What sort of change does your code introduce/modify?

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.