### PR TITLE
api+flarectl: allow updating dns record type

### DIFF
--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -140,6 +140,7 @@ func dnsUpdate(c *cli.Context) {
 	zone := c.String("zone")
 	recordID := c.String("id")
 	name := c.String("name")
+	rtype := c.String("type")
 	content := c.String("content")
 	ttl := c.Int("ttl")
 	proxy := c.Bool("proxy")
@@ -153,6 +154,7 @@ func dnsUpdate(c *cli.Context) {
 	record := cloudflare.DNSRecord{
 		ID:      recordID,
 		Name:    name,
+		Type:    strings.ToUpper(rtype),
 		Content: content,
 		TTL:     ttl,
 		Proxied: proxy,

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -328,6 +328,10 @@ func main() {
 							Name:  "content",
 							Usage: "record content",
 						},
+						cli.StringFlag{
+							Name:  "type",
+							Usage: "record type",
+						},
 						cli.IntFlag{
 							Name:  "ttl",
 							Usage: "TTL (1 = automatic)",

--- a/dns.go
+++ b/dns.go
@@ -141,7 +141,9 @@ func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
 	if rr.Name == "" {
 		rr.Name = rec.Name
 	}
-	rr.Type = rec.Type
+	if rr.Type == "" {
+		rr.Type = rec.Type
+	}
 	uri := "/zones/" + zoneID + "/dns_records/" + recordID
 	res, err := api.makeRequest("PATCH", uri, rr)
 	if err != nil {


### PR DESCRIPTION
## Description

The Cloudflare REST API apparently allows one to change both a record's usual properties, such as the content; but also the record's Type.  This wasn't reflected in this repository's API subroutine which implements the `UpdateDNSRecord` call.   Consequently, it wasn't implemented in the `flarectl dns update ...` command, either.

It now is.

This allows one to swiftly change a record's _value_, _type_ and _proxy status_ in one go. Particularly useful (my own use case) when wanting to migrate an `A` record to a `CNAME` when implementing a Cloudflare Load Balancer on a domain.

## Has your change been tested?

Locally, as shown in the commit messages.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
