### PR TITLE
Add support for bypass action in firewall rules

### DIFF
--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -19,6 +19,7 @@ type FirewallRule struct {
 	Action      string      `json:"action"`
 	Priority    interface{} `json:"priority"`
 	Filter      Filter      `json:"filter"`
+	Products    []string    `json:"products,omitempty"`
 	CreatedOn   time.Time   `json:"created_on,omitempty"`
 	ModifiedOn  time.Time   `json:"modified_on,omitempty"`
 }

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -23,6 +23,20 @@ func TestFirewallRules(t *testing.T) {
 		fmt.Fprintf(w, `{
 			"result":[
 				{
+					"id":"2ae338944d6143383c3cf05a7c80d984",
+					"paused":false,
+					"description":"allow uploads without waf",
+					"action":"bypass",
+					"products": ["waf"],
+					"priority":null,
+					"filter":{
+						"id":"74217d7bd5ab435e84b1bd473bf4fb9f",
+						"expression":"http.request.uri.path matches \"^/upload$\"",
+						"paused":false,
+						"description":"/upload"
+					}
+				},
+				{
 					"id":"4ae338944d6143378c3cf05a7c77d983",
 					"paused":false,
 					"description":"allow API traffic without challenge",
@@ -81,8 +95,8 @@ func TestFirewallRules(t *testing.T) {
 			"result_info":{
 				"page":1,
 				"per_page":25,
-				"count":4,
-				"total_count":4
+				"count":5,
+				"total_count":5
 			}
 		}
 		`)
@@ -90,6 +104,20 @@ func TestFirewallRules(t *testing.T) {
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
 	want := []FirewallRule{
+		{
+			ID:          "2ae338944d6143383c3cf05a7c80d984",
+			Paused:      false,
+			Description: "allow uploads without waf",
+			Action:      "bypass",
+			Priority:    nil,
+			Products:    []string{"waf"},
+			Filter: Filter{
+				ID:          "74217d7bd5ab435e84b1bd473bf4fb9f",
+				Expression:  "http.request.uri.path matches \"^/upload$\"",
+				Paused:      false,
+				Description: "/upload",
+			},
+		},
 		{
 			ID:          "4ae338944d6143378c3cf05a7c77d983",
 			Paused:      false,


### PR DESCRIPTION
## Description

Adding support for the `bypass` action in firewall rules as described [here](https://api.cloudflare.com/#firewall-rules-create-firewall-rules)
This is required in order to add support for this in the terraform provider for cloudflare.

## Has your change been tested?

I've added tests in accordance to the existing ones and with matching the cloudflare documentation for the API.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
