### PR TITLE
access_identity_provider: Consolidate configuration fields

### DIFF
--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -9,192 +9,36 @@ import (
 
 // AccessIdentityProvider is the structure of the provider object.
 type AccessIdentityProvider struct {
-	ID     string      `json:"id,omitemtpy"`
-	Name   string      `json:"name"`
-	Type   string      `json:"type"`
-	Config interface{} `json:"config"`
+	ID     string                              `json:"id,omitemtpy"`
+	Name   string                              `json:"name"`
+	Type   string                              `json:"type"`
+	Config AccessIdentityProviderConfiguration `json:"config"`
 }
 
-// AccessAzureADConfiguration is the representation of the Azure AD identity
-// provider.
+// AccessIdentityProviderConfiguration is the combined structure of *all*
+// identity provider configuration fields. This is done to simplify the use of
+// Access products and their relationship to each other.
 //
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/azuread/
-type AccessAzureADConfiguration struct {
-	ClientID      string `json:"client_id"`
-	ClientSecret  string `json:"client_secret"`
-	DirectoryID   string `json:"directory_id"`
-	SupportGroups bool   `json:"support_groups"`
-}
-
-// AccessCentrifyConfiguration is the representation of the Centrify identity
-// provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/centrify/
-type AccessCentrifyConfiguration struct {
-	ClientID        string `json:"client_id"`
-	ClientSecret    string `json:"client_secret"`
-	CentrifyAccount string `json:"centrify_account"`
-	CentrifyAppID   string `json:"centrify_app_id"`
-}
-
-// AccessCentrifySAMLConfiguration is the representation of the Centrify
-// identity provider using SAML.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/saml-centrify/
-type AccessCentrifySAMLConfiguration struct {
-	IssuerURL          string   `json:"issuer_url"`
-	SsoTargetURL       string   `json:"sso_target_url"`
-	Attributes         []string `json:"attributes"`
-	EmailAttributeName string   `json:"email_attribute_name"`
-	SignRequest        bool     `json:"sign_request"`
-	IdpPublicCert      string   `json:"idp_public_cert"`
-}
-
-// AccessFacebookConfiguration is the representation of the Facebook identity
-// provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/facebook-login/
-type AccessFacebookConfiguration struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-}
-
-// AccessGSuiteConfiguration is the representation of the GSuite identity
-// provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/gsuite/
-type AccessGSuiteConfiguration struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	AppsDomain   string `json:"apps_domain"`
-}
-
-// AccessGenericOIDCConfiguration is the representation of the generic OpenID
-// Connect (OIDC) connector.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/generic-oidc/
-type AccessGenericOIDCConfiguration struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	AuthURL      string `json:"auth_url"`
-	TokenURL     string `json:"token_url"`
-	CertsURL     string `json:"certs_url"`
-}
-
-// AccessGitHubConfiguration is the representation of the GitHub identity
-// provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/github/
-type AccessGitHubConfiguration struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-}
-
-// AccessGoogleConfiguration is the representation of the Google identity
-// provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/google/
-type AccessGoogleConfiguration struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-}
-
-// AccessJumpCloudSAMLConfiguration is the representation of the Jump Cloud
-// identity provider using SAML.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/jumpcloud-saml/
-type AccessJumpCloudSAMLConfiguration struct {
-	IssuerURL          string   `json:"issuer_url"`
-	SsoTargetURL       string   `json:"sso_target_url"`
-	Attributes         []string `json:"attributes"`
-	EmailAttributeName string   `json:"email_attribute_name"`
-	SignRequest        bool     `json:"sign_request"`
-	IdpPublicCert      string   `json:"idp_public_cert"`
-}
-
-// AccessOktaConfiguration is the representation of the Okta identity provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/okta/
-type AccessOktaConfiguration struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	OktaAccount  string `json:"okta_account"`
-}
-
-// AccessOktaSAMLConfiguration is the representation of the Okta identity
-// provider using SAML.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/saml-okta/
-type AccessOktaSAMLConfiguration struct {
-	IssuerURL          string   `json:"issuer_url"`
-	SsoTargetURL       string   `json:"sso_target_url"`
-	Attributes         []string `json:"attributes"`
-	EmailAttributeName string   `json:"email_attribute_name"`
-	SignRequest        bool     `json:"sign_request"`
-	IdpPublicCert      string   `json:"idp_public_cert"`
-}
-
-// AccessOneTimePinConfiguration is the representation of the default One Time
-// Pin identity provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/one-time-pin/
-type AccessOneTimePinConfiguration struct{}
-
-// AccessOneLoginOIDCConfiguration is the representation of the OneLogin
-// OpenID connector as an identity provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/onelogin-oidc/
-type AccessOneLoginOIDCConfiguration struct {
-	ClientID        string `json:"client_id"`
-	ClientSecret    string `json:"client_secret"`
-	OneloginAccount string `json:"onelogin_account"`
-}
-
-// AccessOneLoginSAMLConfiguration is the representation of the OneLogin
-// identity provider using SAML.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/onelogin-saml/
-type AccessOneLoginSAMLConfiguration struct {
-	IssuerURL          string   `json:"issuer_url"`
-	SsoTargetURL       string   `json:"sso_target_url"`
-	Attributes         []string `json:"attributes"`
-	EmailAttributeName string   `json:"email_attribute_name"`
-	SignRequest        bool     `json:"sign_request"`
-	IdpPublicCert      string   `json:"idp_public_cert"`
-}
-
-// AccessPingSAMLConfiguration is the representation of the Ping identity
-// provider using SAML.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/ping-saml/
-type AccessPingSAMLConfiguration struct {
-	IssuerURL          string   `json:"issuer_url"`
-	SsoTargetURL       string   `json:"sso_target_url"`
-	Attributes         []string `json:"attributes"`
-	EmailAttributeName string   `json:"email_attribute_name"`
-	SignRequest        bool     `json:"sign_request"`
-	IdpPublicCert      string   `json:"idp_public_cert"`
-}
-
-// AccessYandexConfiguration is the representation of the Yandex identity provider.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/yandex/
-type AccessYandexConfiguration struct {
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-}
-
-// AccessADSAMLConfiguration is the representation of the Active Directory
-// identity provider using SAML.
-//
-// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/adfs/
-type AccessADSAMLConfiguration struct {
-	IssuerURL          string   `json:"issuer_url"`
-	SsoTargetURL       string   `json:"sso_target_url"`
-	Attributes         []string `json:"attributes"`
-	EmailAttributeName string   `json:"email_attribute_name"`
-	SignRequest        bool     `json:"sign_request"`
-	IdpPublicCert      string   `json:"idp_public_cert"`
+// API reference: https://developers.cloudflare.com/access/configuring-identity-providers/
+type AccessIdentityProviderConfiguration struct {
+	AppsDomain         string   `json:"apps_domain,omitempty"`
+	Attributes         []string `json:"attributes,omitempty"`
+	AuthURL            string   `json:"auth_url,omitempty"`
+	CentrifyAccount    string   `json:"centrify_account,omitempty"`
+	CentrifyAppID      string   `json:"centrify_app_id,omitempty"`
+	CertsURL           string   `json:"certs_url,omitempty"`
+	ClientID           string   `json:"client_id,omitempty"`
+	ClientSecret       string   `json:"client_secret,omitempty"`
+	DirectoryID        string   `json:"directory_id,omitempty"`
+	EmailAttributeName string   `json:"email_attribute_name,omitempty"`
+	IdpPublicCert      string   `json:"idp_public_cert,omitempty"`
+	IssuerURL          string   `json:"issuer_url,omitempty"`
+	OktaAccount        string   `json:"okta_account,omitempty"`
+	OneloginAccount    string   `json:"onelogin_account,omitempty"`
+	SignRequest        bool     `json:"sign_request,omitempty"`
+	SsoTargetURL       string   `json:"sso_target_url,omitempty"`
+	SupportGroups      bool     `json:"support_groups,omitempty"`
+	TokenURL           string   `json:"token_url,omitempty"`
 }
 
 // AccessIdentityProvidersListResponse is the API response for multiple

--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -35,6 +35,7 @@ type AccessIdentityProviderConfiguration struct {
 	IssuerURL          string   `json:"issuer_url,omitempty"`
 	OktaAccount        string   `json:"okta_account,omitempty"`
 	OneloginAccount    string   `json:"onelogin_account,omitempty"`
+	RedirectURL        string   `json:"redirect_url,omitempty"`
 	SignRequest        bool     `json:"sign_request,omitempty"`
 	SsoTargetURL       string   `json:"sso_target_url,omitempty"`
 	SupportGroups      bool     `json:"support_groups,omitempty"`

--- a/access_identity_provider_test.go
+++ b/access_identity_provider_test.go
@@ -40,9 +40,9 @@ func TestAccessIdentityProviders(t *testing.T) {
 		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: map[string]interface{}{
-			"client_id":     "example_id",
-			"client_secret": "a-secret-key",
+		Config: AccessIdentityProviderConfiguration{
+			ClientID:     "example_id",
+			ClientSecret: "a-secret-key",
 		},
 	}}
 
@@ -83,9 +83,9 @@ func TestAccessIdentityProviderDetails(t *testing.T) {
 		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: map[string]interface{}{
-			"client_id":     "example_id",
-			"client_secret": "a-secret-key",
+		Config: AccessIdentityProviderConfiguration{
+			ClientID:     "example_id",
+			ClientSecret: "a-secret-key",
 		},
 	}
 
@@ -125,7 +125,7 @@ func TestCreateAccessIdentityProvider(t *testing.T) {
 	newIdentityProvider := AccessIdentityProvider{
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: AccessGitHubConfiguration{
+		Config: AccessIdentityProviderConfiguration{
 			ClientID:     "example_id",
 			ClientSecret: "a-secret-key",
 		},
@@ -135,9 +135,9 @@ func TestCreateAccessIdentityProvider(t *testing.T) {
 		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: map[string]interface{}{
-			"client_id":     "example_id",
-			"client_secret": "a-secret-key",
+		Config: AccessIdentityProviderConfiguration{
+			ClientID:     "example_id",
+			ClientSecret: "a-secret-key",
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestUpdateAccessIdentityProvider(t *testing.T) {
 	updatedIdentityProvider := AccessIdentityProvider{
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: AccessGitHubConfiguration{
+		Config: AccessIdentityProviderConfiguration{
 			ClientID:     "example_id",
 			ClientSecret: "a-secret-key",
 		},
@@ -186,9 +186,9 @@ func TestUpdateAccessIdentityProvider(t *testing.T) {
 		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: map[string]interface{}{
-			"client_id":     "example_id",
-			"client_secret": "a-secret-key",
+		Config: AccessIdentityProviderConfiguration{
+			ClientID:     "example_id",
+			ClientSecret: "a-secret-key",
 		},
 	}
 
@@ -229,9 +229,9 @@ func TestDeleteAccessIdentityProvider(t *testing.T) {
 		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name: "Widget Corps OTP",
 		Type: "github",
-		Config: map[string]interface{}{
-			"client_id":     "example_id",
-			"client_secret": "a-secret-key",
+		Config: AccessIdentityProviderConfiguration{
+			ClientID:     "example_id",
+			ClientSecret: "a-secret-key",
 		},
 	}
 


### PR DESCRIPTION
While looking integration Access Identity Providers into Terraform, I
found that the configuration fields are super awkward to work with as we
either:

- Disregard Go's type system and make everything an `interface`; or
- Restrict the ability to use configuration options in a single step as
  we don't know what Type the incoming data actually is.

To rectify this, I've consolidated all the fields into a single struct
and move the onus to the end user to correctly define the fields that
are required. A nice side effect of this is that the fields aren't
repeated for each configuration and reduces the toil if/when a field is
updated.