### PR TITLE
Include new Dataset field/methods for Logpush jobs

### DIFF
--- a/logpush.go
+++ b/logpush.go
@@ -11,6 +11,7 @@ import (
 // LogpushJob describes a Logpush job.
 type LogpushJob struct {
 	ID                 int        `json:"id,omitempty"`
+	Dataset            string     `json:"dataset"`
 	Enabled            bool       `json:"enabled"`
 	Name               string     `json:"name"`
 	LogpullOptions     string     `json:"logpull_options"`
@@ -32,6 +33,15 @@ type LogpushJobDetailsResponse struct {
 	Response
 	Result LogpushJob `json:"result"`
 }
+
+// LogpushFieldsResponse is the API response for a datasets fields
+type LogpushFieldsResponse struct {
+	Response
+	Result LogpushFields `json:"result"`
+}
+
+// LogpushFields is a map of available Logpush field names & descriptions
+type LogpushFields map[string]string
 
 // LogpushGetOwnershipChallenge describes a ownership validation.
 type LogpushGetOwnershipChallenge struct {
@@ -110,6 +120,40 @@ func (api *API) LogpushJobs(zoneID string) ([]LogpushJob, error) {
 	err = json.Unmarshal(res, &r)
 	if err != nil {
 		return []LogpushJob{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LogpushJobsForDataset returns all Logpush Jobs for a dataset in a zone.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
+func (api *API) LogpushJobsForDataset(zoneID, dataset string) ([]LogpushJob, error) {
+	uri := "/zones/" + zoneID + "/logpush/datasets/" + dataset + "/jobs"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []LogpushJob{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r LogpushJobsResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []LogpushJob{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LogpushFields returns fields for a given dataset
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+func (api *API) LogpushFields(zoneID, dataset string) (LogpushFields, error) {
+	uri := "/zones/" + zoneID + "/logpush/datasets/" + dataset + "/fields"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return LogpushFields{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r LogpushFieldsResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return LogpushFields{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/logpush.go
+++ b/logpush.go
@@ -141,7 +141,7 @@ func (api *API) LogpushJobsForDataset(zoneID, dataset string) ([]LogpushJob, err
 	return r.Result, nil
 }
 
-// LogpushFields returns fields for a given dataset
+// LogpushFields returns fields for a given dataset.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
 func (api *API) LogpushFields(zoneID, dataset string) (LogpushFields, error) {

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 )
 
 const (
 	jobID                       = 1
 	serverLogpushJobDescription = `{
-    "id": %d,
+		"id": %d,
+		"dataset": "http_requests",
     "enabled": false,
 	"name": "example.com",
     "logpull_options": "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
@@ -37,6 +37,7 @@ var (
 	testLogpushTimestamp     = time.Now().UTC()
 	expectedLogpushJobStruct = LogpushJob{
 		ID:              jobID,
+		Dataset:         "http_requests",
 		Enabled:         false,
 		Name:            "example.com",
 		LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
@@ -51,14 +52,15 @@ var (
 		Message:  "",
 	}
 	expectedUpdatedLogpushJobStruct = LogpushJob{
-		ID: jobID, 
-		Enabled: true, 
-		Name: "updated.com", 
-		LogpullOptions: "fields=RayID,ClientIP,EdgeStartTimestamp", 
-		DestinationConf: "gs://mybucket/logs", 
-		LastComplete: &testLogpushTimestamp, 
-		LastError: &testLogpushTimestamp, 
-		ErrorMessage: "test",
+		ID:              jobID,
+		Dataset:         "http_requests",
+		Enabled:         true,
+		Name:            "updated.com",
+		LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp",
+		DestinationConf: "gs://mybucket/logs",
+		LastComplete:    &testLogpushTimestamp,
+		LastError:       &testLogpushTimestamp,
+		ErrorMessage:    "test",
 	}
 )
 
@@ -155,9 +157,9 @@ func TestUpdateLogpushJob(t *testing.T) {
 	setup()
 	defer teardown()
 	updatedJob := LogpushJob{
-		Enabled: true, 
-		Name: "updated.com", 
-		LogpullOptions: "fields=RayID,ClientIP,EdgeStartTimestamp", 
+		Enabled:         true,
+		Name:            "updated.com",
+		LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp",
 		DestinationConf: "gs://mybucket/logs",
 	}
 


### PR DESCRIPTION
## Description

Cloudflare Logpush jobs now support two different datasets, `http_requests` (Previously this was the default & only option), and `spectrum_events`

- Added method to get jobs for a specific dataset, `LogpushJobsForDataset`
- Added method to retrieve available fields for a given dataset, `LogpushFields`
- Added `Dataset` field to Logpush jobs 

## Has your change been tested?

Tests added, tested manually too

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

