### PR TITLE
Read correct AccountMember 2FA attribute

### DIFF
--- a/account_members.go
+++ b/account_members.go
@@ -25,7 +25,7 @@ type AccountMemberUserDetails struct {
 	FirstName                      string `json:"first_name"`
 	LastName                       string `json:"last_name"`
 	Email                          string `json:"email"`
-	TwoFactorAuthenticationEnabled bool `json:"two_factor_authentication_enabled"`
+	TwoFactorAuthenticationEnabled bool   `json:"two_factor_authentication_enabled"`
 }
 
 // AccountMembersListResponse represents the response from the list

--- a/account_members.go
+++ b/account_members.go
@@ -25,7 +25,7 @@ type AccountMemberUserDetails struct {
 	FirstName                      string `json:"first_name"`
 	LastName                       string `json:"last_name"`
 	Email                          string `json:"email"`
-	TwoFactorAuthenticationEnabled bool
+	TwoFactorAuthenticationEnabled bool `json:"two_factor_authentication_enabled"`
 }
 
 // AccountMembersListResponse represents the response from the list


### PR DESCRIPTION
The value for the 2FA attribute wasn't correctly read and seemed to always return false, I assume that it is because it wasn't processed from the JSON output.
This should fix it.