### PR TITLE
access_group/access_policy: Add support for non-identity clients

### DIFF
--- a/access_group.go
+++ b/access_group.go
@@ -61,6 +61,20 @@ type AccessGroupEveryone struct {
 	Everyone struct{} `json:"everyone"`
 }
 
+// AccessGroupServiceToken is used for managing access based on a specific
+// service token.
+type AccessGroupServiceToken struct {
+	ServiceToken struct {
+		ID string `json:"token_id"`
+	} `json:"service_token"`
+}
+
+// AccessGroupAnyValidServiceToken is used for managing access for all valid
+// service tokens (not restricted).
+type AccessGroupAnyValidServiceToken struct {
+	AnyValidServiceToken struct{} `json:"any_valid_service_token"`
+}
+
 // AccessGroupAccessGroup is used for managing access based on an
 // access group.
 type AccessGroupAccessGroup struct {

--- a/access_policy.go
+++ b/access_policy.go
@@ -50,7 +50,7 @@ type AccessPolicyEmailDomain struct {
 	} `json:"email_domain"`
 }
 
-// AccessPolicyIP is used for managing access based in the IP. It
+// AccessPolicyIP is used for managing access based on the IP. It
 // accepts individual IPs or CIDRs.
 type AccessPolicyIP struct {
 	IP struct {
@@ -61,6 +61,20 @@ type AccessPolicyIP struct {
 // AccessPolicyEveryone is used for managing access to everyone.
 type AccessPolicyEveryone struct {
 	Everyone struct{} `json:"everyone"`
+}
+
+// AccessPolicyServiceToken is used for managing access based on a specific
+// service token.
+type AccessPolicyServiceToken struct {
+	ServiceToken struct {
+		ID string `json:"token_id"`
+	} `json:"service_token"`
+}
+
+// AccessPolicyAnyValidServiceToken is used for managing access for all valid
+// service tokens (not restricted).
+type AccessPolicyAnyValidServiceToken struct {
+	AnyValidServiceToken struct{} `json:"any_valid_service_token"`
 }
 
 // AccessPolicyAccessGroup is used for managing access based on an


### PR DESCRIPTION
Updates the two places where we can provide a non-identity configuration
(access group and access policies) to support using them.