### PR TITLE
Update `*ListResponse` structs to match API responses

### DIFF
--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -45,25 +45,15 @@ type AccessIdentityProviderConfiguration struct {
 // AccessIdentityProvidersListResponse is the API response for multiple
 // Access Identity Providers.
 type AccessIdentityProvidersListResponse struct {
-	Success  bool                             `json:"success"`
-	Errors   []string                         `json:"errors"`
-	Messages []AccessIdentityProviderMessages `json:"messages"`
+	Response
 	Result   []AccessIdentityProvider         `json:"result"`
 }
 
 // AccessIdentityProviderListResponse is the API response for a single
 // Access Identity Provider.
 type AccessIdentityProviderListResponse struct {
-	Success  bool                             `json:"success"`
-	Errors   []string                         `json:"errors"`
-	Messages []AccessIdentityProviderMessages `json:"messages"`
+	Response
 	Result   AccessIdentityProvider           `json:"result"`
-}
-
-// AccessIdentityProviderMessages holds the API responses for any additional
-// messages from the service.
-type AccessIdentityProviderMessages struct {
-	Message string `json:"message"`
 }
 
 // AccessIdentityProviders returns all Access Identity Providers for an

--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -45,19 +45,25 @@ type AccessIdentityProviderConfiguration struct {
 // AccessIdentityProvidersListResponse is the API response for multiple
 // Access Identity Providers.
 type AccessIdentityProvidersListResponse struct {
-	Success  bool                     `json:"success"`
-	Errors   []string                 `json:"errors"`
-	Messages []string                 `json:"messages"`
-	Result   []AccessIdentityProvider `json:"result"`
+	Success  bool                             `json:"success"`
+	Errors   []string                         `json:"errors"`
+	Messages []AccessIdentityProviderMessages `json:"messages"`
+	Result   []AccessIdentityProvider         `json:"result"`
 }
 
 // AccessIdentityProviderListResponse is the API response for a single
 // Access Identity Provider.
 type AccessIdentityProviderListResponse struct {
-	Success  bool                   `json:"success"`
-	Errors   []string               `json:"errors"`
-	Messages []string               `json:"messages"`
-	Result   AccessIdentityProvider `json:"result"`
+	Success  bool                             `json:"success"`
+	Errors   []string                         `json:"errors"`
+	Messages []AccessIdentityProviderMessages `json:"messages"`
+	Result   AccessIdentityProvider           `json:"result"`
+}
+
+// AccessIdentityProviderMessages holds the API responses for any additional
+// messages from the service.
+type AccessIdentityProviderMessages struct {
+	Message string `json:"message"`
 }
 
 // AccessIdentityProviders returns all Access Identity Providers for an


### PR DESCRIPTION
When the work for
terraform-providers/terraform-provider-cloudflare#597 was started,
the `messages` object was either empty array or a single string (per
the original [`cloudflare.Response`](https://github.com/cloudflare/cloudflare-go/blob/master/cloudflare.go#L363) struct) but the API response is
now spitting out an array of `message` objects inside of the current
array.

old

```json
{
  "result": {
    "id": "566f1f64-3b1e-40b3-ae1b-807396f1a107",
    "type": "github",
    "uid": "566f1f64-3b1e-40b3-ae1b-807396f1a107",
    "name": "ytypfrkona",
    "config": {
      "client_id": "test",
      "client_secret": "**********************************",
      "redirect_url": "https://my-domain.cloudflareaccess.com/cdn-cgi/access/callback"
    },
    "version": "267eb3e7f2fc57dae9792a2315895d69"
  },
  "success": true,
  "errors": [],
  "messages": []
}
```

new

```json
{
  "result": {
    "id": "e0d1a74b-5b19-4dc8-823c-d1f2d42b01b3",
    "type": "github",
    "uid": "e0d1a74b-5b19-4dc8-823c-d1f2d42b01b3",
    "name": "iumxxidzao-updated",
    "config": {
      "client_id": "test",
      "client_secret": "**********************************",
      "redirect_url": "https://my-domain.cloudflareaccess.com/cdn-cgi/access/callback"
    },
    "version": "413f20d9ecce0e7b361843841764492a"
  },
  "success": true,
  "errors": [],
  "messages": [
    {
      "message": "Finish enterprise enablement by going to https://my-domain.cloudflareaccess.com/cdn-cgi/access/enterprise-setup/ZTBkMWE3NGItNWIxOS00ZGM4LTgyM2MtZDFmMmQ0MmIwMWIz246b90e12e49a1ed82f16be7f4433da49b7bd15ad7cea7fd96ee9cef81e571f45e6554b7"
    }
  ]
}
```

To fix the issue, the two structs have been updated to conform to the
required objects.