### PR TITLE
SDK-88: Add edge_ips support for Spectrum

### DIFF
--- a/spectrum_test.go
+++ b/spectrum_test.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -398,5 +399,72 @@ func TestSpectrumApplicationProxyProtocolDeprecations(t *testing.T) {
 		}
 
 		teardown()
+	}
+}
+
+func TestSpectrumApplicationEdgeIPs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"id": "f68579455bd947efb65ffa1bcf33b52c",
+				"protocol": "tcp/22",
+				"ipv4": true,
+				"dns": {
+					"type": "CNAME",
+					"name": "spectrum.example.com"
+				},
+				"origin_direct": [
+					"tcp://192.0.2.1:22"
+				],
+				"ip_firewall": true,
+				"proxy_protocol": "off",
+				"tls": "off",
+				"edge_ips": {
+					"type": "static",
+					"ips": [
+						"192.0.2.1",
+						"2001:db8::1"
+					]
+				},
+				"created_on": "2018-03-28T21:25:55.643771Z",
+				"modified_on": "2018-03-28T21:25:55.643771Z"
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/spectrum/apps/f68579455bd947efb65ffa1bcf33b52c", handler)
+	createdOn, _ := time.Parse(time.RFC3339, "2018-03-28T21:25:55.643771Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2018-03-28T21:25:55.643771Z")
+	want := SpectrumApplication{
+		ID:         "f68579455bd947efb65ffa1bcf33b52c",
+		CreatedOn:  &createdOn,
+		ModifiedOn: &modifiedOn,
+		Protocol:   "tcp/22",
+		IPv4:       true,
+		DNS: SpectrumApplicationDNS{
+			Name: "spectrum.example.com",
+			Type: "CNAME",
+		},
+		OriginDirect:  []string{"tcp://192.0.2.1:22"},
+		IPFirewall:    true,
+		ProxyProtocol: "off",
+		TLS:           "off",
+		EdgeIPs: &EdgeIPs{
+			Type: STATIC,
+			IPs:  []net.IP{net.ParseIP("192.0.2.1"), net.ParseIP("2001:db8::1")},
+		},
+	}
+
+	actual, err := client.SpectrumApplication("01a7362d577a6c3019a474fd6f485823", "f68579455bd947efb65ffa1bcf33b52c")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
 	}
 }


### PR DESCRIPTION
This PR adds initial Spectrum Bring-Your-Own-IP support.
https://developers.cloudflare.com/spectrum/getting-started/byoip/

## Description

New field is added and proper unmarshalling for enum type field. Only one value defined, but with possible future expansion.

Required for further Terraform integration.

## Has your change been tested?

Yes.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
