### PR TITLE
Remove duplicated Access Policy structs

### DIFF
--- a/access_policy.go
+++ b/access_policy.go
@@ -33,58 +33,6 @@ type AccessPolicy struct {
 	Require []interface{} `json:"require"`
 }
 
-// AccessPolicyEmail is used for managing access based on the email.
-// For example, restrict access to users with the email addresses
-// `test@example.com` or `someone@example.com`.
-type AccessPolicyEmail struct {
-	Email struct {
-		Email string `json:"email"`
-	} `json:"email"`
-}
-
-// AccessPolicyEmailDomain is used for managing access based on an email
-// domain domain such as `example.com` instead of individual addresses.
-type AccessPolicyEmailDomain struct {
-	EmailDomain struct {
-		Domain string `json:"domain"`
-	} `json:"email_domain"`
-}
-
-// AccessPolicyIP is used for managing access based on the IP. It
-// accepts individual IPs or CIDRs.
-type AccessPolicyIP struct {
-	IP struct {
-		IP string `json:"ip"`
-	} `json:"ip"`
-}
-
-// AccessPolicyEveryone is used for managing access to everyone.
-type AccessPolicyEveryone struct {
-	Everyone struct{} `json:"everyone"`
-}
-
-// AccessPolicyServiceToken is used for managing access based on a specific
-// service token.
-type AccessPolicyServiceToken struct {
-	ServiceToken struct {
-		ID string `json:"token_id"`
-	} `json:"service_token"`
-}
-
-// AccessPolicyAnyValidServiceToken is used for managing access for all valid
-// service tokens (not restricted).
-type AccessPolicyAnyValidServiceToken struct {
-	AnyValidServiceToken struct{} `json:"any_valid_service_token"`
-}
-
-// AccessPolicyAccessGroup is used for managing access based on an
-// access group.
-type AccessPolicyAccessGroup struct {
-	Group struct {
-		ID string `json:"id"`
-	} `json:"group"`
-}
-
 // AccessPolicyListResponse represents the response from the list
 // access polciies endpoint.
 type AccessPolicyListResponse struct {

--- a/access_policy_test.go
+++ b/access_policy_test.go
@@ -203,17 +203,17 @@ func TestCreateAccessPolicy(t *testing.T) {
 		AccessPolicy{
 			Name: "Allow devs",
 			Include: []interface{}{
-				AccessPolicyEmail{struct {
+				AccessGroupEmail{struct {
 					Email string `json:"email"`
 				}{Email: "test@example.com"}},
 			},
 			Exclude: []interface{}{
-				AccessPolicyEmail{struct {
+				AccessGroupEmail{struct {
 					Email string `json:"email"`
 				}{Email: "test@example.com"}},
 			},
 			Require: []interface{}{
-				AccessPolicyEmail{struct {
+				AccessGroupEmail{struct {
 					Email string `json:"email"`
 				}{Email: "test@example.com"}},
 			},


### PR DESCRIPTION
When I was first putting Access support together, I made a boo-boo and
duplicated the Access Group structs into the Access Policy itself. This
shouldn't have been the case as they are the same structs, but they
should be tied to the groups and only _referenced_ in the policies
instead.