### PR TITLE
page_rules: Add base support for `cache_key_fields`

### DIFF
--- a/page_rules.go
+++ b/page_rules.go
@@ -32,6 +32,7 @@ Valid IDs are:
   cache_by_device_type
   cache_deception_armor
   cache_level
+  cache_key_fields
   cache_on_cookie
   disable_apps
   disable_performance
@@ -75,6 +76,7 @@ var PageRuleActions = map[string]string{
 	"cache_by_device_type":        "Cache By Device Type",        // Value of type string
 	"cache_deception_armor":       "Cache Deception Armor",       // Value of type string
 	"cache_level":                 "Cache Level",                 // Value of type string
+	"cache_key_fields":            "Custom Cache Key",            // Value of type map[string]interface
 	"cache_on_cookie":             "Cache On Cookie",             // Value of type string
 	"disable_apps":                "Disable Apps",                // Value of type interface{}
 	"disable_performance":         "Disable Performance",         // Value of type interface{}


### PR DESCRIPTION
This adds the initital setup for custom cache keys support which landed
this morning. On it's own, it doesn't actually do anything but will
enable downstream providers to start work on it.