### PR TITLE
Allow flarectl to authenticate via API Token

### DIFF
--- a/cmd/flarectl/README.md
+++ b/cmd/flarectl/README.md
@@ -12,12 +12,24 @@ go get -u github.com/cloudflare/cloudflare-go/...
 
 # Usage
 
-You must set your API key and account email address in the environment variables `CF_API_KEY` and `CF_API_EMAIL`.
+You must authenticate with Cloudflare using either an API Token or API Key.
+
+To use an API Token, set the `CF_API_TOKEN` environment variable:
+
+```
+$ export CF_API_TOKEN=Abc123Xyz
+```
+
+To use an API Key, set the `CF_API_KEY` and `CF_API_EMAIL` environment variables:
 
 ```
 $ export CF_API_KEY=abcdef1234567890
 $ export CF_API_EMAIL=someone@example.com
+```
 
+Once authenticated, you can run flarectl commands:
+
+```
 $ flarectl:
 
    flarectl - Cloudflare CLI

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -13,23 +13,31 @@ import (
 )
 
 func initializeAPI(c *cli.Context) error {
+	apiToken := os.Getenv("CF_API_TOKEN")
 	apiKey := os.Getenv("CF_API_KEY")
-	if apiKey == "" {
-		err := errors.New("No CF_API_KEY environment set")
-		fmt.Fprintln(os.Stderr, err)
-		return err
-	}
-
 	apiEmail := os.Getenv("CF_API_EMAIL")
-	if apiEmail == "" {
-		err := errors.New("No CF_API_EMAIL environment set")
-		fmt.Fprintln(os.Stderr, err)
-		return err
-	}
 
 	// Be aware the following code sets the global package `api` variable
 	var err error
-	api, err = cloudflare.New(apiKey, apiEmail)
+
+	if apiToken != "" {
+		api, err = cloudflare.NewWithAPIToken(apiToken)
+	} else {
+		if apiKey == "" {
+			err := errors.New("No CF_API_KEY or CF_API_TOKEN environment set")
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+
+		if apiEmail == "" {
+			err := errors.New("No CF_API_EMAIL environment set")
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+
+		api, err = cloudflare.New(apiKey, apiEmail)
+	}
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cloudflare api: %s", err)
 		return err


### PR DESCRIPTION
## Description

In [August 2019](https://blog.cloudflare.com/api-tokens-general-availability/), Cloudflare added the ability to authenticate with their API using API Tokens.

This PR adds the ability to use API Tokens in addition to API Keys. Fixes #408.

## Has your change been tested?

I am not aware of any existing tests for `flarectl`, but I'm happy to add them if you can point me in the right direction. My testing was manual; See below:

## Examples:

No env variables set:
```
$ env | grep CF_API
$ ./flarectl zone list
No CF_API_KEY or CF_API_TOKEN environment set
```

With API Token:
```
$ CF_API_TOKEN=SECRET ./flarectl zone list
...
```

With API Key:
```

$ CF_API_EMAIL=user@example.com CF_API_KEY=SECRET ./flarectl zone list
...
```

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
