### PR TITLE
Added support for  SSL-For-SaaS v2 fields to CustomHostname struct

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -8,12 +8,29 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CustomHostnameState is the enumeration of valid state values in the CustomHostnameSSL
+type CustomHostnameState string
+
+const (
+	PENDING CustomHostnameState = "pending"
+	ACTIVE  CustomHostnameState = "active"
+	MOVED   CustomHostnameState = "moved"
+	REMOVED CustomHostnameState = "removed"
+)
+
 // CustomHostnameSSLSettings represents the SSL settings for a custom hostname.
 type CustomHostnameSSLSettings struct {
 	HTTP2         string   `json:"http2,omitempty"`
 	TLS13         string   `json:"tls_1_3,omitempty"`
 	MinTLSVersion string   `json:"min_tls_version,omitempty"`
 	Ciphers       []string `json:"ciphers,omitempty"`
+}
+
+//CustomHostnameOwnershipVerification represents certificate status of a given custom hostname.
+type CustomHostnameOwnershipVerification struct {
+	Type  string `json:"type,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
@@ -31,11 +48,14 @@ type CustomMetadata map[string]interface{}
 
 // CustomHostname represents a custom hostname in a zone.
 type CustomHostname struct {
-	ID                 string            `json:"id,omitempty"`
-	Hostname           string            `json:"hostname,omitempty"`
-	CustomOriginServer string            `json:"custom_origin_server,omitempty"`
-	SSL                CustomHostnameSSL `json:"ssl,omitempty"`
-	CustomMetadata     CustomMetadata    `json:"custom_metadata,omitempty"`
+	ID                    string                              `json:"id,omitempty"`
+	Hostname              string                              `json:"hostname,omitempty"`
+	CustomOriginServer    string                              `json:"custom_origin_server,omitempty"`
+	SSL                   CustomHostnameSSL                   `json:"ssl,omitempty"`
+	CustomMetadata        CustomMetadata                      `json:"custom_metadata,omitempty"`
+	State                 CustomHostnameState                 `json:"state,omitempty"`
+	VerificationErrors    []string                            `json:"verification_errors,omitempty"`
+	OwnershipVerification CustomHostnameOwnershipVerification `json:"ownership_verification,omitempty"`
 }
 
 // CustomHostnameResponse represents a response from the Custom Hostnames endpoints.

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -26,7 +26,7 @@ type CustomHostnameSSLSettings struct {
 	Ciphers       []string `json:"ciphers,omitempty"`
 }
 
-//CustomHostnameOwnershipVerification represents certificate status of a given custom hostname.
+//CustomHostnameOwnershipVerification represents ownership verification status of a given custom hostname.
 type CustomHostnameOwnershipVerification struct {
 	Type  string `json:"type,omitempty"`
 	Name  string `json:"name,omitempty"`

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -12,9 +12,13 @@ import (
 type CustomHostnameStatus string
 
 const (
+	// PENDING status represents state of CustomHostname is pending.
 	PENDING CustomHostnameStatus = "pending"
-	ACTIVE  CustomHostnameStatus = "active"
-	MOVED   CustomHostnameStatus = "moved"
+	// ACTIVE status represents state of CustomHostname is active.
+	ACTIVE CustomHostnameStatus = "active"
+	// MOVED status represents state of CustomHostname is moved.
+	MOVED CustomHostnameStatus = "moved"
+	// REMOVED status represents state of CustomHostname is removed.
 	REMOVED CustomHostnameStatus = "removed"
 )
 

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -8,14 +8,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-// CustomHostnameState is the enumeration of valid state values in the CustomHostnameSSL
-type CustomHostnameState string
+// CustomHostnameStatus is the enumeration of valid state values in the CustomHostnameSSL
+type CustomHostnameStatus string
 
 const (
-	PENDING CustomHostnameState = "pending"
-	ACTIVE  CustomHostnameState = "active"
-	MOVED   CustomHostnameState = "moved"
-	REMOVED CustomHostnameState = "removed"
+	PENDING CustomHostnameStatus = "pending"
+	ACTIVE  CustomHostnameStatus = "active"
+	MOVED   CustomHostnameStatus = "moved"
+	REMOVED CustomHostnameStatus = "removed"
 )
 
 // CustomHostnameSSLSettings represents the SSL settings for a custom hostname.
@@ -53,7 +53,7 @@ type CustomHostname struct {
 	CustomOriginServer    string                              `json:"custom_origin_server,omitempty"`
 	SSL                   CustomHostnameSSL                   `json:"ssl,omitempty"`
 	CustomMetadata        CustomMetadata                      `json:"custom_metadata,omitempty"`
-	State                 CustomHostnameState                 `json:"state,omitempty"`
+	Status                CustomHostnameStatus                `json:"status,omitempty"`
 	VerificationErrors    []string                            `json:"verification_errors,omitempty"`
 	OwnershipVerification CustomHostnameOwnershipVerification `json:"ownership_verification,omitempty"`
 }

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -164,7 +164,16 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 			},
 			"custom_metadata": {
 				"a_random_field": "random field value"
-			}
+			},
+			"status": "pending",
+			"verification_errors": [
+				"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
+    		],
+			"ownership_verification": {
+				"type": "txt",
+      			"name": "_cf-custom-hostname.app.example.com",
+      			"value": "5cc07c04-ea62-4a5a-95f0-419334a875a4"
+    		}
 		}
 	],
 	"result_info": {
@@ -190,6 +199,14 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
 			},
 			CustomMetadata: CustomMetadata{"a_random_field": "random field value"},
+			State:          PENDING,
+			VerificationErrors: []string{"None of the A or AAAA records are owned " +
+				"by this account and the pre-generated ownership verification token was not found."},
+			OwnershipVerification: CustomHostnameOwnershipVerification{
+				Type:  "txt",
+				Name:  "_cf-custom-hostname.app.example.com",
+				Value: "5cc07c04-ea62-4a5a-95f0-419334a875a4",
+			},
 		},
 	}
 
@@ -224,6 +241,15 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
     "custom_metadata": {
       "origin": "a.custom.origin"
     }
+	"status": "pending",
+	"verification_errors": [
+		"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
+    ],
+	"ownership_verification": {
+		"type": "txt",
+     	"name": "_cf-custom-hostname.app.example.com",
+    	"value": "5cc07c04-ea62-4a5a-95f0-419334a875a4"
+    }
   }
 }`)
 	})
@@ -244,6 +270,14 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
 			},
 		},
 		CustomMetadata: CustomMetadata{"origin": "a.custom.origin"},
+		State:          PENDING,
+		VerificationErrors: []string{"None of the A or AAAA records are owned " +
+			"by this account and the pre-generated ownership verification token was not found."},
+		OwnershipVerification: CustomHostnameOwnershipVerification{
+			Type:  "txt",
+			Name:  "_cf-custom-hostname.app.example.com",
+			Value: "5cc07c04-ea62-4a5a-95f0-419334a875a4",
+		},
 	}
 
 	if assert.NoError(t, err) {

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -199,7 +199,7 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
 			},
 			CustomMetadata: CustomMetadata{"a_random_field": "random field value"},
-			State:          PENDING,
+			Status:         PENDING,
 			VerificationErrors: []string{"None of the A or AAAA records are owned " +
 				"by this account and the pre-generated ownership verification token was not found."},
 			OwnershipVerification: CustomHostnameOwnershipVerification{
@@ -240,7 +240,7 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
     },
     "custom_metadata": {
       "origin": "a.custom.origin"
-    }
+    },
 	"status": "pending",
 	"verification_errors": [
 		"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
@@ -270,7 +270,7 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
 			},
 		},
 		CustomMetadata: CustomMetadata{"origin": "a.custom.origin"},
-		State:          PENDING,
+		Status:         PENDING,
 		VerificationErrors: []string{"None of the A or AAAA records are owned " +
 			"by this account and the pre-generated ownership verification token was not found."},
 		OwnershipVerification: CustomHostnameOwnershipVerification{


### PR DESCRIPTION
As part of v2 SSL-For-SaaS offering CF added new field for CustomHostname i.e. status, ownership_verification and verification_errors, this PR address those fields to be returned as part of CRUD operations of CustomHostname.

This PR addresses https://github.com/cloudflare/cloudflare-go/issues/435

## Description

As part of v2 SSL-For-SaaS offering CF added new field for CustomHostname i.e. status, ownership_verification and verification_errors, this PR address those fields to be returned as part of CRUD operations of CustomHostname.

Struct for three fields are added based response returned on below documentation.
https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames

## Has your change been tested?

Updated unit tests to reflect the changes.

Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
