### PR TITLE
access_group: Fix spelling of Okta

### DIFF
--- a/access_group.go
+++ b/access_group.go
@@ -123,10 +123,10 @@ type AccessGroupAzure struct {
 
 // AccessGroupOkta is used to configure access based on a Okta group.
 type AccessGroupOkta struct {
-	Otka struct {
+	Okta struct {
 		Name               string `json:"name"`
 		IdentityProviderID string `json:"identity_provider_id"`
-	} `json:"otka"`
+	} `json:"okta"`
 }
 
 // AccessGroupSAML is used to allow SAML users with a specific attribute


### PR DESCRIPTION
This struct was copied directly from the [documentation](https://developers.cloudflare.com/access/setting-up-access/api-examples/#okta-group) cargo-culting
the spelling mistake.

1861590 has been raised to get the documentation fixed.