### PR TITLE
Adds IP Address Management APIs for managing IP prefixes and their BGP status

### DIFF
--- a/ip_address_management.go
+++ b/ip_address_management.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// IPPrefix contains information about an IP prefix
+type IPPrefix struct {
+	ID                   string     `json:"id"`
+	CreatedAt            *time.Time `json:"created_at"`
+	ModifiedAt           *time.Time `json:"modified_at"`
+	CIDR                 string     `json:"cidr"`
+	AccountID            string     `json:"account_id"`
+	Description          string     `json:"description"`
+	Approved             string     `json:"approved"`
+	OnDemandEnabled      bool       `json:"on_demand_enabled"`
+	Advertised           bool       `json:"advertised"`
+	AdvertisedModifiedAt *time.Time `json:"advertised_modified_at"`
+}
+
+// AdvertisementStatus contains information about the BGP status of an IP prefix
+type AdvertisementStatus struct {
+	Advertised           bool       `json:"advertised"`
+	AdvertisedModifiedAt *time.Time `json:"advertised_modified_at"`
+}
+
+// ListIPPrefixResponse contains a slice of IP prefixes
+type ListIPPrefixResponse struct {
+	Response
+	Result []IPPrefix `json:"result"`
+}
+
+// GetIPPrefixResponse contains a specific IP prefix's API Response
+type GetIPPrefixResponse struct {
+	Response
+	Result IPPrefix `json:"result"`
+}
+
+// GetAdvertisementStatusResponse contains an API Response for the BGP status of the IP Prefix
+type GetAdvertisementStatusResponse struct {
+	Response
+	Result AdvertisementStatus `json:"result"`
+}
+
+// IPPrefixUpdateRequest contains information about prefix updates
+type IPPrefixUpdateRequest struct {
+	Description string `json:"description"`
+}
+
+// AdvertisementStatusUpdateRequest contains information about bgp status updates
+type AdvertisementStatusUpdateRequest struct {
+	Advertised bool `json:"advertised"`
+}
+
+// ListPrefixes lists all IP prefixes for a given account
+//
+// API reference: https://api.cloudflare.com/#ip-address-management-prefixes-list-prefixes
+func (api *API) ListPrefixes(ctx context.Context) ([]IPPrefix, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes", api.AccountID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []IPPrefix{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := ListIPPrefixResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []IPPrefix{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+// GetPrefix returns a specific IP prefix
+//
+// API reference: https://api.cloudflare.com/#ip-address-management-prefixes-prefix-details
+func (api *API) GetPrefix(ctx context.Context, id string) (IPPrefix, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s", api.AccountID, id)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return IPPrefix{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := GetIPPrefixResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return IPPrefix{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+// UpdatePrefixDescription edits the description of the IP prefix
+//
+// API reference: https://api.cloudflare.com/#ip-address-management-prefixes-update-prefix-description
+func (api *API) UpdatePrefixDescription(ctx context.Context, id string, description string) (IPPrefix, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s", api.AccountID, id)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, IPPrefixUpdateRequest{Description: description})
+	if err != nil {
+		return IPPrefix{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := GetIPPrefixResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return IPPrefix{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+// GetAdvertisementStatus returns the BGP status of the IP prefix
+//
+// API reference: https://api.cloudflare.com/#ip-address-management-prefixes-update-prefix-description
+func (api *API) GetAdvertisementStatus(ctx context.Context, id string) (AdvertisementStatus, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s/bgp/status", api.AccountID, id)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return AdvertisementStatus{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := GetAdvertisementStatusResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return AdvertisementStatus{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+// UpdateAdvertisementStatus changes the BGP status of an IP prefix
+//
+// API reference: https://api.cloudflare.com/#ip-address-management-prefixes-update-prefix-description
+func (api *API) UpdateAdvertisementStatus(ctx context.Context, id string, advertised bool) (AdvertisementStatus, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s/bgp/status", api.AccountID, id)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, AdvertisementStatusUpdateRequest{Advertised: advertised})
+	if err != nil {
+		return AdvertisementStatus{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := GetAdvertisementStatusResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return AdvertisementStatus{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}

--- a/ip_address_management_test.go
+++ b/ip_address_management_test.go
@@ -1,0 +1,234 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListIPPrefix(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": [
+				{
+					"id": "f68579455bd947efb65ffa1bcf33b52c",
+					"created_at": "2020-04-24T21:25:55.643771Z",
+					"modified_at": "2020-04-24T21:25:55.643771Z",
+					"cidr": "10.1.2.3/24",
+					"account_id": "foo",
+					"description": "Sample Prefix",
+					"approved": "V",
+					"on_demand_enabled": true,
+					"advertised": true,
+					"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
+				}
+			],
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/foo/addressing/prefixes", handler)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+	modifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+	advertisedModifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+
+	want := []IPPrefix{
+		{
+			ID:                   "f68579455bd947efb65ffa1bcf33b52c",
+			CreatedAt:            &createdAt,
+			ModifiedAt:           &modifiedAt,
+			CIDR:                 "10.1.2.3/24",
+			AccountID:            "foo",
+			Description:          "Sample Prefix",
+			Approved:             "V",
+			OnDemandEnabled:      true,
+			Advertised:           true,
+			AdvertisedModifiedAt: &advertisedModifiedAt,
+		},
+	}
+
+	actual, err := client.ListPrefixes(context.Background())
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetIPPrefix(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"id": "f68579455bd947efb65ffa1bcf33b52c",
+				"created_at": "2020-04-24T21:25:55.643771Z",
+				"modified_at": "2020-04-24T21:25:55.643771Z",
+				"cidr": "10.1.2.3/24",
+				"account_id": "foo",
+				"description": "Sample Prefix",
+				"approved": "V",
+				"on_demand_enabled": true,
+				"advertised": true,
+				"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c", handler)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+	modifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+	advertisedModifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+
+	want := IPPrefix{
+		ID:                   "f68579455bd947efb65ffa1bcf33b52c",
+		CreatedAt:            &createdAt,
+		ModifiedAt:           &modifiedAt,
+		CIDR:                 "10.1.2.3/24",
+		AccountID:            "foo",
+		Description:          "Sample Prefix",
+		Approved:             "V",
+		OnDemandEnabled:      true,
+		Advertised:           true,
+		AdvertisedModifiedAt: &advertisedModifiedAt,
+	}
+
+	actual, err := client.GetPrefix(context.Background(), "f68579455bd947efb65ffa1bcf33b52c")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdatePrefixDescription(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PATCH", "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"id": "f68579455bd947efb65ffa1bcf33b52c",
+				"created_at": "2020-04-24T21:25:55.643771Z",
+				"modified_at": "2020-04-24T21:25:55.643771Z",
+				"cidr": "10.1.2.3/24",
+				"account_id": "foo",
+				"description": "My IP Prefix",
+				"approved": "V",
+				"on_demand_enabled": true,
+				"advertised": true,
+				"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c", handler)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+	modifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+	advertisedModifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+
+	want := IPPrefix{
+		ID:                   "f68579455bd947efb65ffa1bcf33b52c",
+		CreatedAt:            &createdAt,
+		ModifiedAt:           &modifiedAt,
+		CIDR:                 "10.1.2.3/24",
+		AccountID:            "foo",
+		Description:          "My IP Prefix",
+		Approved:             "V",
+		OnDemandEnabled:      true,
+		Advertised:           true,
+		AdvertisedModifiedAt: &advertisedModifiedAt,
+	}
+
+	actual, err := client.UpdatePrefixDescription(context.Background(), "f68579455bd947efb65ffa1bcf33b52c", "My IP Prefix")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetAdvertisementStatus(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"advertised": true,
+				"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c/bgp/status", handler)
+
+	advertisedModifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+
+	want := AdvertisementStatus{
+		Advertised:           true,
+		AdvertisedModifiedAt: &advertisedModifiedAt,
+	}
+
+	actual, err := client.GetAdvertisementStatus(context.Background(), "f68579455bd947efb65ffa1bcf33b52c")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateAdvertisementStatus(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PATCH", "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"advertised": false,
+				"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c/bgp/status", handler)
+
+	advertisedModifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
+
+	want := AdvertisementStatus{
+		Advertised:           false,
+		AdvertisedModifiedAt: &advertisedModifiedAt,
+	}
+
+	actual, err := client.UpdateAdvertisementStatus(context.Background(), "f68579455bd947efb65ffa1bcf33b52c", false)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
This PR introduces interfaces for using IP Address Management APIs.
- List Prefixes
- Prefix Details
- Update Prefix Description
- Get Advertisement Status
- Update Prefix Dynamic Advertisement Status

This is the prerequisite for implementation in the Terraform Provider.
Tests have been implemented.

```
=== RUN   TestListIPPrefix
--- PASS: TestListIPPrefix (0.00s)
=== RUN   TestGetIPPrefix
--- PASS: TestGetIPPrefix (0.00s)
=== RUN   TestUpdatePrefixDescription
--- PASS: TestUpdatePrefixDescription (0.00s)
=== RUN   TestGetAdvertisementStatus
--- PASS: TestGetAdvertisementStatus (0.00s)
=== RUN   TestUpdateAdvertisementStatus
--- PASS: TestUpdateAdvertisementStatus (0.00s)
```
