### PR TITLE
logpull: Add initial support for retention flag

### DIFF
--- a/logpull.go
+++ b/logpull.go
@@ -1,0 +1,56 @@
+package cloudflare
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// LogpullRentionConfiguration describes a the structure of a Logpull Rention
+// payload.
+type LogpullRentionConfiguration struct {
+	Flag bool `json:"flag"`
+}
+
+// LogpullRentionConfigurationResponse is the API response, containing the
+// Logpull rentention result.
+type LogpullRentionConfigurationResponse struct {
+	Response
+	Result LogpullRentionConfiguration `json:"result"`
+}
+
+// GetLogpullRentionFlag gets the current setting flag.
+//
+// API reference: https://developers.cloudflare.com/logs/logpull-api/enabling-log-retention/
+func (api *API) GetLogpullRentionFlag(zoneID string) (*LogpullRentionConfiguration, error) {
+	uri := "/zones/" + zoneID + "/logs/control/retention/flag"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return &LogpullRentionConfiguration{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r LogpullRentionConfigurationResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return &r.Result, nil
+}
+
+// SetLogpullRentionFlag updates the retention flag to the defined boolean.
+//
+// API reference: https://developers.cloudflare.com/logs/logpull-api/enabling-log-retention/
+func (api *API) SetLogpullRentionFlag(zoneID string, enabled bool) (*LogpullRentionConfiguration, error) {
+	uri := "/zones/" + zoneID + "/logs/control/retention/flag"
+	flagPayload := LogpullRentionConfiguration{Flag: enabled}
+
+	res, err := api.makeRequest("POST", uri, flagPayload)
+	if err != nil {
+		return &LogpullRentionConfiguration{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r LogpullRentionConfigurationResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return &LogpullRentionConfiguration{}, errors.Wrap(err, errMakeRequestError)
+	}
+	return &r.Result, nil
+}

--- a/logpull_test.go
+++ b/logpull_test.go
@@ -1,0 +1,61 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLogpullRentionFlag(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		"errors": [],
+		"messages": [],
+		"result": {
+			"flag": true
+		},
+		"success": true
+	}`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/logs/control/retention/flag", handler)
+	want := &LogpullRentionConfiguration{Flag: true}
+
+	actual, err := client.GetLogpullRentionFlag("d56084adb405e0b7e32c52321bf07be6")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestSetLogpullRentionFlag(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		"errors": [],
+		"messages": [],
+		"result": {
+			"flag": false
+		},
+		"success": true
+	}`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/logs/control/retention/flag", handler)
+	want := &LogpullRentionConfiguration{Flag: false}
+
+	actual, err := client.SetLogpullRentionFlag("d56084adb405e0b7e32c52321bf07be6", false)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
Updates the library to add support for logpull retention flag.

API documentation: https://developers.cloudflare.com/logs/logpull-api/enabling-log-retention/

Paves the way for support in the Terraform provider at
terraform-providers/terraform-provider-cloudflare#665