### PR TITLE
Update the Okta and Gsuite access group structs to match the 'connection_id' format returned by the API

### DIFF
--- a/access_group.go
+++ b/access_group.go
@@ -101,7 +101,7 @@ type AccessGroupCertificateCommonName struct {
 type AccessGroupGSuite struct {
 	Gsuite struct {
 		Email              string `json:"email"`
-		IdentityProviderID string `json:"identity_provider_id"`
+		ConnectionID       string `json:"connection_id"`
 	} `json:"gsuite"`
 }
 
@@ -125,7 +125,7 @@ type AccessGroupAzure struct {
 type AccessGroupOkta struct {
 	Okta struct {
 		Name               string `json:"name"`
-		IdentityProviderID string `json:"identity_provider_id"`
+		ConnectionID       string `json:"connection_id"`
 	} `json:"okta"`
 }
 


### PR DESCRIPTION
identity_provider_id is not the returned value within the access group object at least for okta or gsuite

Note that this may apply to more of the AccessGroup structs, but I am presently unable to test those integrations

This is related to https://github.com/terraform-providers/terraform-provider-cloudflare/issues/682
