### PR TITLE
Revert "Update the Okta and Gsuite access group structs to match the 'connection_id' format returned by the API"

### DIFF
--- a/access_group.go
+++ b/access_group.go
@@ -101,7 +101,7 @@ type AccessGroupCertificateCommonName struct {
 type AccessGroupGSuite struct {
 	Gsuite struct {
 		Email              string `json:"email"`
-		ConnectionID       string `json:"connection_id"`
+		IdentityProviderID string `json:"identity_provider_id"`
 	} `json:"gsuite"`
 }
 
@@ -125,7 +125,7 @@ type AccessGroupAzure struct {
 type AccessGroupOkta struct {
 	Okta struct {
 		Name               string `json:"name"`
-		ConnectionID       string `json:"connection_id"`
+		IdentityProviderID string `json:"identity_provider_id"`
 	} `json:"okta"`
 }
 


### PR DESCRIPTION
Reverts cloudflare/cloudflare-go#458
It turns out API accepts both formats. UI uses `connection_id`, API recommends `identity_provider_id`.