### PR TITLE
Fixes #453 updating CustomHostnames

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -97,7 +97,29 @@ type CustomHostnameFallbackOriginResponse struct {
 // API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-update-custom-hostname-configuration
 func (api *API) UpdateCustomHostnameSSL(zoneID string, customHostnameID string, ssl CustomHostnameSSL) (*CustomHostnameResponse, error) {
 	uri := "/zones/" + zoneID + "/custom_hostnames/" + customHostnameID
-	res, err := api.makeRequest("PATCH", uri, ssl)
+	ch := CustomHostname{
+		SSL: ssl,
+	}
+	res, err := api.makeRequest("PATCH", uri, ch)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response *CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return response, nil
+}
+
+// UpdateCustomHostname modifies configuration for the given custom
+// hostname in the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-update-custom-hostname-configuration
+func (api *API) UpdateCustomHostname(zoneID string, customHostnameID string, ch CustomHostname) (*CustomHostnameResponse, error) {
+	uri := "/zones/" + zoneID + "/custom_hostnames/" + customHostnameID
+	res, err := api.makeRequest("PATCH", uri, ch)
 	if err != nil {
 		return nil, errors.Wrap(err, errMakeRequestError)
 	}


### PR DESCRIPTION
## Description

This fixes #453  updating custom hostnames. The API expects a full CustomHostname NOT a CustomHostnameSSL struct as per here - https://api.cloudflare.com/#custom-hostname-for-a-zone-edit-custom-hostname

I've updated UpdateCustomHostnameSSL to send a CustomHostname struct whilst keeping the availability to just pass a CustomHostnameSSL struct.

Along with that I've added a UpdateCustomHostname function which lets you update the whole CustomHostname.

Could probably remove the UpdateCustomHostnameSSL function altogether however to keep it backward compatible I've left it in place.

## Has your change been tested?

I've updated the tests for both functions.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (I've updated the notes? I presume that auto updates the documentation?)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
