### PR TITLE
Add SSL-For-SaaS v2 fields to CustomHostname struct 

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -55,8 +55,19 @@ type CustomHostnameListResponse struct {
 // hostname in the given zone.
 //
 // API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-update-custom-hostname-configuration
-func (api *API) UpdateCustomHostnameSSL(zoneID string, customHostnameID string, ssl CustomHostnameSSL) (CustomHostname, error) {
-	return CustomHostname{}, errors.New("Not implemented")
+func (api *API) UpdateCustomHostnameSSL(zoneID string, customHostnameID string, ssl CustomHostnameSSL) (*CustomHostnameResponse, error) {
+	uri := "/zones/" + zoneID + "/custom_hostnames/" + customHostnameID
+	res, err := api.makeRequest("PATCH", uri, ssl)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response *CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return response, nil
 }
 
 // DeleteCustomHostname deletes a custom hostname (and any issued SSL

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -31,11 +31,28 @@ type CustomMetadata map[string]interface{}
 
 // CustomHostname represents a custom hostname in a zone.
 type CustomHostname struct {
-	ID                 string            `json:"id,omitempty"`
-	Hostname           string            `json:"hostname,omitempty"`
-	CustomOriginServer string            `json:"custom_origin_server,omitempty"`
-	SSL                CustomHostnameSSL `json:"ssl,omitempty"`
-	CustomMetadata     CustomMetadata    `json:"custom_metadata,omitempty"`
+	ID                        string                                 `json:"id,omitempty"`
+	Hostname                  string                                 `json:"hostname,omitempty"`
+	CustomOriginServer        string                                 `json:"custom_origin_server,omitempty"`
+	SSL                       CustomHostnameSSL                      `json:"ssl,omitempty"`
+	Status                    string                                 `json:"status,omitempty"`
+	VerificationErrors        []string                               `json:"verification_errors,omitempty"`
+	CustomMetadata            CustomMetadata                         `json:"custom_metadata,omitempty"`
+	OwnershipVerification     CustomHostnameOwnershipVerification    `json:"ownership_verification,omitempty"`
+	OwnershipVerificationHTTP CustomHosnameOwnershipVerificationHTTP `json:"ownership_verification_http,omitempty"`
+}
+
+// CustomHostnameOwnershipVerification represents a response from the Custom Hostnames endpoints.
+type CustomHostnameOwnershipVerification struct {
+	Type  string `json:"type,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// CustomHosnameOwnershipVerificationHTTP represents a response from the Custom Hostnames endpoints.
+type CustomHosnameOwnershipVerificationHTTP struct {
+	HTTPUrl  string `json:"http_url,omitempty"`
+	HTTPBody string `json:"http_body,omitempty"`
 }
 
 // CustomHostnameResponse represents a response from the Custom Hostnames endpoints.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -110,6 +110,19 @@ func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 			"settings": {
 			"http2": "on"
 			}
+		},
+		"status": "pending",
+		"verification_errors": [
+		  "None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
+		],
+		"ownership_verification": {
+		  "type": "txt",
+		  "name": "_cf-custom-hostname.app.example.com",
+		  "value": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
+		},
+		"ownership_verification_http": {
+		  "http_url": "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+		  "http_body": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
 		}
   	}
 }`)
@@ -131,6 +144,17 @@ func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 				Settings: CustomHostnameSSLSettings{
 					HTTP2: "on",
 				},
+			},
+			Status:             "pending",
+			VerificationErrors: []string{"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."},
+			OwnershipVerification: CustomHostnameOwnershipVerification{
+				Type:  "txt",
+				Name:  "_cf-custom-hostname.app.example.com",
+				Value: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
+			},
+			OwnershipVerificationHTTP: CustomHosnameOwnershipVerificationHTTP{
+				HTTPUrl:  "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+				HTTPBody: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
 			},
 		},
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -119,8 +119,8 @@ func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 
 	want := &CustomHostnameResponse{
 		Result: CustomHostname{
-			ID:       "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
-			Hostname: "app.example.com",
+			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+			Hostname:           "app.example.com",
 			CustomOriginServer: "example.app.com",
 			SSL: CustomHostnameSSL{
 				Type:        "dv",
@@ -248,5 +248,65 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, customHostname)
+	}
+}
+
+func TestCustomHostname_UpdateCustomHostnameSSL(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/zones/foo/custom_hostnames/0d89c70d-ad9f-4843-b99f-6cc0252067e9", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "Expected method 'PATCH', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `
+{
+	"success": true,
+	"errors": [],
+	"messages": [],
+	"result": {
+		"id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+		"hostname": "app.example.com",
+		"custom_origin_server": "example.app.com",
+		"ssl": {
+			"status": "pending_validation",
+			"method": "cname",
+			"type": "dv",
+			"cname_target": "dcv.digicert.com",
+			"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+			"settings": {
+			"http2": "off",
+			"tls_1_3": "on"
+			}
+		}
+  	}
+}`)
+	})
+
+	response, err := client.UpdateCustomHostnameSSL("foo", "0d89c70d-ad9f-4843-b99f-6cc0252067e9", CustomHostnameSSL{Method: "cname", Type: "dv", Settings: CustomHostnameSSLSettings{HTTP2: "off", TLS13: "on"}})
+
+	want := &CustomHostnameResponse{
+		Result: CustomHostname{
+			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+			Hostname:           "app.example.com",
+			CustomOriginServer: "example.app.com",
+			SSL: CustomHostnameSSL{
+				Type:        "dv",
+				Method:      "cname",
+				Status:      "pending_validation",
+				CnameTarget: "dcv.digicert.com",
+				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				Settings: CustomHostnameSSLSettings{
+					HTTP2: "off",
+					TLS13: "on",
+				},
+			},
+		},
+		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, response)
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -51,7 +51,6 @@ golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191125084936-ffdde1057850 h1:Vq85/r8R9IdcUHmZ0/nQlUg1v15rzvQ2sHdnZAj/x7s=
 golang.org/x/net v0.0.0-20191125084936-ffdde1057850/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191125084936-ffdde1057850 h1:Vq85/r8R9IdcUHmZ0/nQlUg1v15rzvQ2sHdnZAj/x7s=
 golang.org/x/net v0.0.0-20191125084936-ffdde1057850/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553 h1:efeOvDhwQ29Dj3SdAV/MJf8oukgn+8D8WgaCaRMchF8=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
We are using the cloudflare-go client for our integration with Cloudflare. Some of our zones are being migrated to the SSL-for-SaaS v2 format. We are using the go-client to do CRUD operations on CustomHostnames and would like the go-client to return the new v2 fields in the CustomHostname struct

**Expected behavior**
This is the response on a GET for the customHostnames API endpoint if there are verification errors. Per our discussions with Cloudflare, the status and verification_errors fields are newly added in the response

We would like those fields added in the CustomHostnames struct and properly populated with the values from the customHostname in question

`{ "result": { "id": "348696e6-0d6c-45da-8b92-b96adf07fcfb", "hostname": "le-test.partial.cf", "ssl": null, "status": "pending", "ownership_verification": { "txt_name": "_cf-custom-hostname.le-test.partial.cf", "txt_value": "89fdb4b6-9b68-40e6-b021-2ddc84e47217" }, "verification_errors": [ "fallback origin is pending_deployment, not active." ], "created_at": "2019-10-30T22:12:31.266787Z" }, "success": true, "errors": [], "messages": [] }`

**Current behavior**
We use the CustomHostname, CreateCustomHostname and other similar CRUD API methods which return a CustomHostname or CustomHostnameResponse struct. We need the v2 fields of status and verification_errors in the responses of those objects

**Context**
Our API needs to expose to our customers the status of the CustomHostname object so that they know if they can use the domain or need to restart verification. So we need to be able to display the status and corresponding errors as appropriate to them