### PR TITLE
Adding new SSL for SaaSv2 fields

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -66,7 +66,7 @@ type CustomHostname struct {
 	OwnershipVerificationHTTP CustomHosnameOwnershipVerificationHTTP `json:"ownership_verification_http,omitempty"`
 }
 
-// CustomHosnameOwnershipVerificationHTTP represents a response from the Custom Hostnames endpoints.
+// CustomHostnameOwnershipVerificationHTTP represents a response from the Custom Hostnames endpoints.
 type CustomHostnameOwnershipVerificationHTTP struct {
 	HTTPUrl  string `json:"http_url,omitempty"`
 	HTTPBody string `json:"http_body,omitempty"`

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -55,15 +55,15 @@ type CustomMetadata map[string]interface{}
 
 // CustomHostname represents a custom hostname in a zone.
 type CustomHostname struct {
-	ID                        string                                 `json:"id,omitempty"`
-	Hostname                  string                                 `json:"hostname,omitempty"`
-	CustomOriginServer        string                                 `json:"custom_origin_server,omitempty"`
-	SSL                       CustomHostnameSSL                      `json:"ssl,omitempty"`
-	CustomMetadata            CustomMetadata                         `json:"custom_metadata,omitempty"`
-	Status                    CustomHostnameStatus                   `json:"status,omitempty"`
-	VerificationErrors        []string                               `json:"verification_errors,omitempty"`
-	OwnershipVerification     CustomHostnameOwnershipVerification    `json:"ownership_verification,omitempty"`
-	OwnershipVerificationHTTP CustomHosnameOwnershipVerificationHTTP `json:"ownership_verification_http,omitempty"`
+	ID                        string                                  `json:"id,omitempty"`
+	Hostname                  string                                  `json:"hostname,omitempty"`
+	CustomOriginServer        string                                  `json:"custom_origin_server,omitempty"`
+	SSL                       CustomHostnameSSL                       `json:"ssl,omitempty"`
+	CustomMetadata            CustomMetadata                          `json:"custom_metadata,omitempty"`
+	Status                    CustomHostnameStatus                    `json:"status,omitempty"`
+	VerificationErrors        []string                                `json:"verification_errors,omitempty"`
+	OwnershipVerification     CustomHostnameOwnershipVerification     `json:"ownership_verification,omitempty"`
+	OwnershipVerificationHTTP CustomHostnameOwnershipVerificationHTTP `json:"ownership_verification_http,omitempty"`
 }
 
 // CustomHostnameOwnershipVerificationHTTP represents a response from the Custom Hostnames endpoints.

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -67,7 +67,7 @@ type CustomHostname struct {
 }
 
 // CustomHosnameOwnershipVerificationHTTP represents a response from the Custom Hostnames endpoints.
-type CustomHosnameOwnershipVerificationHTTP struct {
+type CustomHostnameOwnershipVerificationHTTP struct {
 	HTTPUrl  string `json:"http_url,omitempty"`
 	HTTPBody string `json:"http_body,omitempty"`
 }

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -18,8 +18,8 @@ const (
 	ACTIVE CustomHostnameStatus = "active"
 	// MOVED status represents state of CustomHostname is moved.
 	MOVED CustomHostnameStatus = "moved"
-	// REMOVED status represents state of CustomHostname is removed.
-	REMOVED CustomHostnameStatus = "removed"
+	// DELETED status represents state of CustomHostname is removed.
+	DELETED CustomHostnameStatus = "deleted"
 )
 
 // CustomHostnameSSLSettings represents the SSL settings for a custom hostname.
@@ -55,14 +55,21 @@ type CustomMetadata map[string]interface{}
 
 // CustomHostname represents a custom hostname in a zone.
 type CustomHostname struct {
-	ID                    string                              `json:"id,omitempty"`
-	Hostname              string                              `json:"hostname,omitempty"`
-	CustomOriginServer    string                              `json:"custom_origin_server,omitempty"`
-	SSL                   CustomHostnameSSL                   `json:"ssl,omitempty"`
-	CustomMetadata        CustomMetadata                      `json:"custom_metadata,omitempty"`
-	Status                CustomHostnameStatus                `json:"status,omitempty"`
-	VerificationErrors    []string                            `json:"verification_errors,omitempty"`
-	OwnershipVerification CustomHostnameOwnershipVerification `json:"ownership_verification,omitempty"`
+	ID                        string                                 `json:"id,omitempty"`
+	Hostname                  string                                 `json:"hostname,omitempty"`
+	CustomOriginServer        string                                 `json:"custom_origin_server,omitempty"`
+	SSL                       CustomHostnameSSL                      `json:"ssl,omitempty"`
+	CustomMetadata            CustomMetadata                         `json:"custom_metadata,omitempty"`
+	Status                    CustomHostnameStatus                   `json:"status,omitempty"`
+	VerificationErrors        []string                               `json:"verification_errors,omitempty"`
+	OwnershipVerification     CustomHostnameOwnershipVerification    `json:"ownership_verification,omitempty"`
+	OwnershipVerificationHTTP CustomHosnameOwnershipVerificationHTTP `json:"ownership_verification_http,omitempty"`
+}
+
+// CustomHosnameOwnershipVerificationHTTP represents a response from the Custom Hostnames endpoints.
+type CustomHosnameOwnershipVerificationHTTP struct {
+	HTTPUrl  string `json:"http_url,omitempty"`
+	HTTPBody string `json:"http_body,omitempty"`
 }
 
 // CustomHostnameResponse represents a response from the Custom Hostnames endpoints.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -96,7 +96,7 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 				Name:  "_cf-custom-hostname.app.example.com",
 				Value: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
 			},
-			OwnershipVerificationHTTP: CustomHosnameOwnershipVerificationHTTP{
+			OwnershipVerificationHTTP: CustomHostnameOwnershipVerificationHTTP{
 				HTTPUrl:  "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
 				HTTPBody: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
 			},

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -38,25 +38,37 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(w, `
 {
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
-    "hostname": "app.example.com",
-    "ssl": {
-      "status": "pending_validation",
-      "method": "cname",
-      "type": "dv",
-      "cname_target": "dcv.digicert.com",
-      "cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
-      "custom_certificate": "-----BEGIN CERTIFICATE-----\\nMIIFJDCCBAygAwIBAgIQD0ifmj/Yi5NP/2gdUySbfzANBgkqhkiG9w0BAQsFADBN\\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMScwJQYDVQQDEx5E...SzSHfXp5lnu/3V08I72q1QNzOCgY1XeL4GKVcj4or6cT6tX6oJH7ePPmfrBfqI/O\\nOeH8gMJ+FuwtXYEPa4hBf38M5eU5xWG7\\n-----END CERTIFICATE-----\\n",
-      "custom_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmG\ndtcGbg/1CGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKn\nabIRuGvBKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpid\ntnKX/a+50GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+py\nFxIXjbEIdZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pE\newooaeO2izNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABAoIBACbhTYXBZYKmYPCb\nHBR1IBlCQA2nLGf0qRuJNJZg5iEzXows/6tc8YymZkQE7nolapWsQ+upk2y5Xdp/\naxiuprIs9JzkYK8Ox0r+dlwCG1kSW+UAbX0bQ/qUqlsTvU6muVuMP8vZYHxJ3wmb\n+ufRBKztPTQ/rYWaYQcgC0RWI20HTFBMxlTAyNxYNWzX7RKFkGVVyB9RsAtmcc8g\n+j4OdosbfNoJPS0HeIfNpAznDfHKdxDk2Yc1tV6RHBrC1ynyLE9+TaflIAdo2MVv\nKLMLq51GqYKtgJFIlBRPQqKoyXdz3fGvXrTkf/WY9QNq0J1Vk5ERePZ54mN8iZB7\n9lwy/AkCgYEA6FXzosxswaJ2wQLeoYc7ceaweX/SwTvxHgXzRyJIIT0eJWgx13Wo\n/WA3Iziimsjf6qE+SI/8laxPp2A86VMaIt3Z3mJN/CqSVGw8LK2AQst+OwdPyDMu\niacE8lj/IFGC8mwNUAb9CzGU3JpU4PxxGFjS/eMtGeRXCWkK4NE+G08CgYEA1Kp9\nN2JrVlqUz+gAX+LPmE9OEMAS9WQSQsfCHGogIFDGGcNf7+uwBM7GAaSJIP01zcoe\nVAgWdzXCv3FLhsaZoJ6RyLOLay5phbu1iaTr4UNYm5WtYTzMzqh8l1+MFFDl9xDB\nvULuCIIrglM5MeS/qnSg1uMoH2oVPj9TVst/ir8CgYEAxrI7Ws9Zc4Bt70N1As+U\nlySjaEVZCMkqvHJ6TCuVZFfQoE0r0whdLdRLU2PsLFP+q7qaeZQqgBaNSKeVcDYR\n9B+nY/jOmQoPewPVsp/vQTCnE/R81spu0mp0YI6cIheT1Z9zAy322svcc43JaWB7\nmEbeqyLOP4Z4qSOcmghZBSECgYACvR9Xs0DGn+wCsW4vze/2ei77MD4OQvepPIFX\ndFZtlBy5ADcgE9z0cuVB6CiL8DbdK5kwY9pGNr8HUCI03iHkW6Zs+0L0YmihfEVe\nPG19PSzK9CaDdhD9KFZSbLyVFmWfxOt50H7YRTTiPMgjyFpfi5j2q348yVT0tEQS\nfhRqaQKBgAcWPokmJ7EbYQGeMbS7HC8eWO/RyamlnSffdCdSc7ue3zdVJxpAkQ8W\nqu80pEIF6raIQfAf8MXiiZ7auFOSnHQTXUbhCpvDLKi0Mwq3G8Pl07l+2s6dQG6T\nlv6XTQaMyf6n1yjzL+fzDrH3qXMxHMO/b13EePXpDMpY7HQpoLDi\n-----END RSA PRIVATE KEY-----\n",
-      "settings": {
-        "http2": "on"
-      }
-    }
-  }
+	"success": true,
+	"errors": [],
+	"messages": [],
+	"result": {
+		"id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+		"hostname": "app.example.com",
+		"custom_origin_server": "example.app.com",
+		"ssl": {
+			"status": "pending_validation",
+			"method": "cname",
+			"type": "dv",
+			"cname_target": "dcv.digicert.com",
+			"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+			"settings": {
+			"http2": "on"
+			}
+		},
+		"status": "pending",
+		"verification_errors": [
+		  "None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
+		],
+		"ownership_verification": {
+		  "type": "txt",
+		  "name": "_cf-custom-hostname.app.example.com",
+		  "value": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
+		},
+		"ownership_verification_http": {
+		  "http_url": "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+		  "http_body": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
+		}
+  	}
 }`)
 	})
 
@@ -64,19 +76,29 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 
 	want := &CustomHostnameResponse{
 		Result: CustomHostname{
-			ID:       "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
-			Hostname: "app.example.com",
+			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+			Hostname:           "app.example.com",
+			CustomOriginServer: "example.app.com",
 			SSL: CustomHostnameSSL{
 				Type:        "dv",
 				Method:      "cname",
 				Status:      "pending_validation",
 				CnameTarget: "dcv.digicert.com",
 				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
-				CustomCertificate: "-----BEGIN CERTIFICATE-----\\nMIIFJDCCBAygAwIBAgIQD0ifmj/Yi5NP/2gdUySbfzANBgkqhkiG9w0BAQsFADBN\\nMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMScwJQYDVQQDEx5E...SzSHfXp5lnu/3V08I72q1QNzOCgY1XeL4GKVcj4or6cT6tX6oJH7ePPmfrBfqI/O\\nOeH8gMJ+FuwtXYEPa4hBf38M5eU5xWG7\\n-----END CERTIFICATE-----\\n",
-				CustomKey: "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmG\ndtcGbg/1CGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKn\nabIRuGvBKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpid\ntnKX/a+50GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+py\nFxIXjbEIdZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pE\newooaeO2izNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABAoIBACbhTYXBZYKmYPCb\nHBR1IBlCQA2nLGf0qRuJNJZg5iEzXows/6tc8YymZkQE7nolapWsQ+upk2y5Xdp/\naxiuprIs9JzkYK8Ox0r+dlwCG1kSW+UAbX0bQ/qUqlsTvU6muVuMP8vZYHxJ3wmb\n+ufRBKztPTQ/rYWaYQcgC0RWI20HTFBMxlTAyNxYNWzX7RKFkGVVyB9RsAtmcc8g\n+j4OdosbfNoJPS0HeIfNpAznDfHKdxDk2Yc1tV6RHBrC1ynyLE9+TaflIAdo2MVv\nKLMLq51GqYKtgJFIlBRPQqKoyXdz3fGvXrTkf/WY9QNq0J1Vk5ERePZ54mN8iZB7\n9lwy/AkCgYEA6FXzosxswaJ2wQLeoYc7ceaweX/SwTvxHgXzRyJIIT0eJWgx13Wo\n/WA3Iziimsjf6qE+SI/8laxPp2A86VMaIt3Z3mJN/CqSVGw8LK2AQst+OwdPyDMu\niacE8lj/IFGC8mwNUAb9CzGU3JpU4PxxGFjS/eMtGeRXCWkK4NE+G08CgYEA1Kp9\nN2JrVlqUz+gAX+LPmE9OEMAS9WQSQsfCHGogIFDGGcNf7+uwBM7GAaSJIP01zcoe\nVAgWdzXCv3FLhsaZoJ6RyLOLay5phbu1iaTr4UNYm5WtYTzMzqh8l1+MFFDl9xDB\nvULuCIIrglM5MeS/qnSg1uMoH2oVPj9TVst/ir8CgYEAxrI7Ws9Zc4Bt70N1As+U\nlySjaEVZCMkqvHJ6TCuVZFfQoE0r0whdLdRLU2PsLFP+q7qaeZQqgBaNSKeVcDYR\n9B+nY/jOmQoPewPVsp/vQTCnE/R81spu0mp0YI6cIheT1Z9zAy322svcc43JaWB7\nmEbeqyLOP4Z4qSOcmghZBSECgYACvR9Xs0DGn+wCsW4vze/2ei77MD4OQvepPIFX\ndFZtlBy5ADcgE9z0cuVB6CiL8DbdK5kwY9pGNr8HUCI03iHkW6Zs+0L0YmihfEVe\nPG19PSzK9CaDdhD9KFZSbLyVFmWfxOt50H7YRTTiPMgjyFpfi5j2q348yVT0tEQS\nfhRqaQKBgAcWPokmJ7EbYQGeMbS7HC8eWO/RyamlnSffdCdSc7ue3zdVJxpAkQ8W\nqu80pEIF6raIQfAf8MXiiZ7auFOSnHQTXUbhCpvDLKi0Mwq3G8Pl07l+2s6dQG6T\nlv6XTQaMyf6n1yjzL+fzDrH3qXMxHMO/b13EePXpDMpY7HQpoLDi\n-----END RSA PRIVATE KEY-----\n",
 				Settings: CustomHostnameSSLSettings{
 					HTTP2: "on",
 				},
+			},
+			Status:             "pending",
+			VerificationErrors: []string{"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."},
+			OwnershipVerification: CustomHostnameOwnershipVerification{
+				Type:  "txt",
+				Name:  "_cf-custom-hostname.app.example.com",
+				Value: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
+			},
+			OwnershipVerificationHTTP: CustomHosnameOwnershipVerificationHTTP{
+				HTTPUrl:  "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+				HTTPBody: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
 			},
 		},
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
@@ -378,7 +400,7 @@ func TestCustomHostname_CustomHostnameFallbackOrigin(t *testing.T) {
 	want := CustomHostnameFallbackOrigin{
 		Origin: "fallback.example.com",
 		Status: "pending_deployment",
-		Errors: []string {"DNS records are not setup correctly. Origin should be a proxied A/AAAA/CNAME dns record", },
+		Errors: []string{"DNS records are not setup correctly. Origin should be a proxied A/AAAA/CNAME dns record"},
 	}
 
 	if assert.NoError(t, err) {
@@ -412,13 +434,13 @@ func TestCustomHostname_UpdateCustomHostnameFallbackOrigin(t *testing.T) {
 }`)
 	})
 
-	response, err := client.UpdateCustomHostnameFallbackOrigin("foo", CustomHostnameFallbackOrigin{Origin: "fallback.example.com",})
+	response, err := client.UpdateCustomHostnameFallbackOrigin("foo", CustomHostnameFallbackOrigin{Origin: "fallback.example.com"})
 
 	want := &CustomHostnameFallbackOriginResponse{
 		Result: CustomHostnameFallbackOrigin{
 			Origin: "fallback.example.com",
 			Status: "pending_deployment",
-			Errors: []string {"DNS records are not setup correctly. Origin should be a proxied A/AAAA/CNAME dns record", },
+			Errors: []string{"DNS records are not setup correctly. Origin should be a proxied A/AAAA/CNAME dns record"},
 		},
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
 	}


### PR DESCRIPTION
We are using the cloudflare-go client for our integration with Cloudflare. Some of our zones are being migrated to the SSL-for-SaaS v2 format. We are using the go-client to do CRUD operations on CustomHostnames and would like the go-client to return the new v2 fields in the CustomHostname struct

**Expected behavior**
This is the response on a GET for the customHostnames API endpoint if there are verification errors. Per our discussions with Cloudflare, the status and verification_errors fields are newly added in the response

We would like those fields added in the CustomHostnames struct and properly populated with the values from the customHostname in question

`{ "result": { "id": "348696e6-0d6c-45da-8b92-b96adf07fcfb", "hostname": "le-test.partial.cf", "ssl": null, "status": "pending", "ownership_verification": { "txt_name": "_cf-custom-hostname.le-test.partial.cf", "txt_value": "89fdb4b6-9b68-40e6-b021-2ddc84e47217" }, "verification_errors": [ "fallback origin is pending_deployment, not active." ], "created_at": "2019-10-30T22:12:31.266787Z" }, "success": true, "errors": [], "messages": [] }`

**Current behavior**
We use the CustomHostname, CreateCustomHostname and other similar CRUD API methods which return a CustomHostname or CustomHostnameResponse struct. We need the v2 fields of status and verification_errors in the responses of those objects

**Context**
Our API needs to expose to our customers the status of the CustomHostname object so that they know if they can use the domain or need to restart verification. So we need to be able to display the status and corresponding errors as appropriate to them