### PR TITLE
Support workers plain and secret text bindings

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -93,6 +93,10 @@ const (
 	WorkerKvNamespaceBindingType WorkerBindingType = "kv_namespace"
 	// WorkerWebAssemblyBindingType is the type for Web Assembly module bindings
 	WorkerWebAssemblyBindingType WorkerBindingType = "wasm_module"
+	// WorkerSecretTextBindingType is the type for secret text bindings
+	WorkerSecretTextBindingType WorkerBindingType = "secret_text"
+	// WorkerPlainTextBindingType is the type for plain text bindings
+	WorkerPlainTextBindingType WorkerBindingType = "plain_text"
 )
 
 // WorkerBindingListItem a struct representing an individual binding in a list of bindings
@@ -212,6 +216,54 @@ func (b WorkerWebAssemblyBinding) serialize(bindingName string) (workerBindingMe
 		"type": b.Type(),
 		"part": partName,
 	}, bodyWriter, nil
+}
+
+// WorkerPlainTextBinding is a binding to plain text
+//
+// https://developers.cloudflare.com/workers/tooling/api/scripts/#add-a-plain-text-binding
+type WorkerPlainTextBinding struct {
+	Text string
+}
+
+// Type returns the type of the binding
+func (b WorkerPlainTextBinding) Type() WorkerBindingType {
+	return WorkerPlainTextBindingType
+}
+
+func (b WorkerPlainTextBinding) serialize(bindingName string) (workerBindingMeta, workerBindingBodyWriter, error) {
+	if b.Text == "" {
+		return nil, nil, errors.Errorf(`Text for binding "%s" cannot be empty`, bindingName)
+	}
+
+	return workerBindingMeta{
+		"name": bindingName,
+		"type": b.Type(),
+		"text": b.Text,
+	}, nil, nil
+}
+
+// WorkerSecretTextBinding is a binding to secret text
+//
+// https://developers.cloudflare.com/workers/tooling/api/scripts/#add-a-secret-text-binding
+type WorkerSecretTextBinding struct {
+	Text string
+}
+
+// Type returns the type of the binding
+func (b WorkerSecretTextBinding) Type() WorkerBindingType {
+	return WorkerSecretTextBindingType
+}
+
+func (b WorkerSecretTextBinding) serialize(bindingName string) (workerBindingMeta, workerBindingBodyWriter, error) {
+	if b.Text == "" {
+		return nil, nil, errors.Errorf(`Text for binding "%s" cannot be empty`, bindingName)
+	}
+
+	return workerBindingMeta{
+		"name": bindingName,
+		"type": b.Type(),
+		"text": b.Text,
+	}, nil, nil
 }
 
 // Each binding that adds a part to the multipart form body will need
@@ -356,6 +408,13 @@ func (api *API) ListWorkerBindings(requestParams *WorkerRequestParams) (WorkerBi
 					bindingName:   name,
 				},
 			}
+		case WorkerPlainTextBindingType:
+			text := jsonBinding["text"].(string)
+			bindingListItem.Binding = WorkerPlainTextBinding{
+				Text: text,
+			}
+		case WorkerSecretTextBindingType:
+			bindingListItem.Binding = WorkerSecretTextBinding{}
 		default:
 			bindingListItem.Binding = WorkerInheritBinding{}
 		}


### PR DESCRIPTION
Closes https://github.com/cloudflare/cloudflare-go/issues/464.

## Description

Adds support for `plain_text` and `secret_text` bindings to workers.

## Has your change been tested?

I have included tests locally based on the documentation and results from curl commands on my local account.
## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
