### PR TITLE
[WIP] Update deprecated field name in access group structs

### DIFF
--- a/access_group.go
+++ b/access_group.go
@@ -100,32 +100,32 @@ type AccessGroupCertificateCommonName struct {
 // AccessGroupGSuite is used to configure access based on GSuite group.
 type AccessGroupGSuite struct {
 	Gsuite struct {
-		Email              string `json:"email"`
-		IdentityProviderID string `json:"identity_provider_id"`
+		Email        string `json:"email"`
+		ConnectionID string `json:"connection_id"`
 	} `json:"gsuite"`
 }
 
 // AccessGroupGitHub is used to configure access based on a GitHub organisation.
 type AccessGroupGitHub struct {
 	GitHubOrganization struct {
-		Name               string `json:"name"`
-		IdentityProviderID string `json:"identity_provider_id"`
+		Name         string `json:"name"`
+		ConnectionID string `json:"connection_id"`
 	} `json:"github-organization"`
 }
 
 // AccessGroupAzure is used to configure access based on a Azure group.
 type AccessGroupAzure struct {
 	AzureAD struct {
-		ID                 string `json:"id"`
-		IdentityProviderID string `json:"identity_provider_id"`
+		ID           string `json:"id"`
+		ConnectionID string `json:"connection_id"`
 	} `json:"azureAD"`
 }
 
 // AccessGroupOkta is used to configure access based on a Okta group.
 type AccessGroupOkta struct {
 	Okta struct {
-		Name               string `json:"name"`
-		IdentityProviderID string `json:"identity_provider_id"`
+		Name         string `json:"name"`
+		ConnectionID string `json:"connection_id"`
 	} `json:"okta"`
 }
 
@@ -133,9 +133,9 @@ type AccessGroupOkta struct {
 // configuration.
 type AccessGroupSAML struct {
 	Saml struct {
-		AttributeName      string `json:"attribute_name"`
-		AttributeValue     string `json:"attribute_value"`
-		IdentityProviderID string `json:"identity_provider_id"`
+		AttributeName  string `json:"attribute_name"`
+		AttributeValue string `json:"attribute_value"`
+		ConnectionID   string `json:"connection_id"`
 	} `json:"saml"`
 }
 


### PR DESCRIPTION
~The `identity_provider_id` field has been deprecated and replaced with the `connection_id` field. While `identity_provider_id` is still valid when creating policies, it will likely be removed in the near future.~ Hold tight, the Access team is discussing the best way to move forward.

Related:
- terraform-providers/terraform-provider-cloudflare#682
- https://github.com/cloudflare/cloudflare-go/pull/458
- https://github.com/cloudflare/cloudflare-go/pull/459