### PR TITLE
Expand `WithZoneFilter` to allow more customisation

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -138,7 +138,7 @@ func (api *API) SetAuthType(authType int) {
 // ZoneIDByName retrieves a zone's ID from the name.
 func (api *API) ZoneIDByName(zoneName string) (string, error) {
 	zoneName = normalizeZoneName(zoneName)
-	res, err := api.ListZonesContext(context.TODO(), WithZoneFilter(zoneName))
+	res, err := api.ListZonesContext(context.TODO(), WithZoneFilters(zoneName, "", ""))
 	if err != nil {
 		return "", errors.Wrap(err, "ListZonesContext command failed")
 	}
@@ -420,10 +420,20 @@ type reqOption struct {
 	params url.Values
 }
 
-// WithZoneFilter applies a filter based on zone name.
-func WithZoneFilter(zone string) ReqOption {
+// WithZoneFilters applies a filter based on zone properties.
+func WithZoneFilters(zoneName, accountID, status string) ReqOption {
 	return func(opt *reqOption) {
-		opt.params.Set("name", normalizeZoneName(zone))
+		if zoneName != "" {
+			opt.params.Set("name", normalizeZoneName(zoneName))
+		}
+
+		if accountID != "" {
+			opt.params.Set("account.id", accountID)
+		}
+
+		if status != "" {
+			opt.params.Set("status", status)
+		}
 	}
 }
 

--- a/zone_test.go
+++ b/zone_test.go
@@ -610,11 +610,11 @@ func TestWithPagination(t *testing.T) {
 	}
 }
 
-func TestZoneFilter(t *testing.T) {
+func TestZoneFilters(t *testing.T) {
 	opt := reqOption{
 		params: url.Values{},
 	}
-	of := WithZoneFilter("example.org")
+	of := WithZoneFilters("example.org", "", "")
 	of(&opt)
 
 	if got := opt.params.Get("name"); got != "example.org" {
@@ -1093,6 +1093,6 @@ func TestZonePartialHasVerificationKey(t *testing.T) {
 	z, err := client.ZoneDetails("foo")
 	if assert.NoError(t, err) {
 		assert.NotEmpty(t, z.VerificationKey)
-		assert.Equal(t, z.VerificationKey,"foo-bar")
+		assert.Equal(t, z.VerificationKey, "foo-bar")
 	}
 }


### PR DESCRIPTION
Updates the `WithZoneFilter` method to be renamed to `WithZoneFilters`
and allow further customisation of the query response and perform
sorting on the server side.

This will be used upstream in Terraform to replace the custom zone
filtering in favour of doing it via the API request.

I did consider making this _more_ reusable by accepting any `url.Values`
parameter but decided against it to avoid having to battle type issues.