### PR TITLE
implements a custom marshaler for the ZoneCustomSSLOptions struct

### DIFF
--- a/ssl.go
+++ b/ssl.go
@@ -52,6 +52,26 @@ type ZoneCustomSSLOptions struct {
 	Type            string                       `json:"type,omitempty"`
 }
 
+func (r ZoneCustomSSLOptions) MarshalJSON() ([]byte, error) {
+	var geoRestrictions *ZoneCustomSSLGeoRestrictions
+	if r.GeoRestrictions != (ZoneCustomSSLGeoRestrictions{}) {
+		geoRestrictions = &r.GeoRestrictions
+	}
+	return json.Marshal(struct {
+		Certificate     string                        `json:"certificate"`
+		PrivateKey      string                        `json:"private_key"`
+		BundleMethod    string                        `json:"bundle_method,omitempty"`
+		GeoRestrictions *ZoneCustomSSLGeoRestrictions `json:"geo_restrictions,omitempty"`
+		Type            string                        `json:"type,omitempty"`
+	}{
+		Certificate:     r.Certificate,
+		PrivateKey:      r.PrivateKey,
+		BundleMethod:    r.BundleMethod,
+		GeoRestrictions: geoRestrictions,
+		Type:            r.Type,
+	})
+}
+
 // ZoneCustomSSLPriority represents a certificate's ID and priority. It is a
 // subset of ZoneCustomSSL used for patch requests.
 type ZoneCustomSSLPriority struct {

--- a/ssl.go
+++ b/ssl.go
@@ -52,6 +52,8 @@ type ZoneCustomSSLOptions struct {
 	Type            string                       `json:"type,omitempty"`
 }
 
+// MarshalJSON Marshalls ZoneCustomSSLOptions to JSON,
+// ensuring the GeoRestrictions struct is omitted if empty.
 func (r ZoneCustomSSLOptions) MarshalJSON() ([]byte, error) {
 	var geoRestrictions *ZoneCustomSSLGeoRestrictions
 	if r.GeoRestrictions != (ZoneCustomSSLGeoRestrictions{}) {

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -84,6 +85,26 @@ func TestCreateSSL(t *testing.T) {
 
 	_, err = client.CreateSSL("bar", ZoneCustomSSLOptions{})
 	assert.Error(t, err)
+}
+
+func TestMarshalZoneCustomSSLOptions(t *testing.T) {
+	options := ZoneCustomSSLOptions{
+		Certificate: "test",
+		PrivateKey:  "test",
+		GeoRestrictions: ZoneCustomSSLGeoRestrictions{
+			Label: "test",
+		},
+	}
+	result, err := json.Marshal(&options)
+	assert.NoError(t, err, "Expected no error when marshalling ZoneCustomSSLOptions to JSON")
+	assert.Contains(t, string(result), "geo_restrictions", "expected marshalled ZoneCustomSSLOptions to contain geo_restrictions when set")
+	options = ZoneCustomSSLOptions{
+		Certificate: "test",
+		PrivateKey:  "test",
+	}
+	result, err = json.Marshal(&options)
+	assert.NoError(t, err, "Expected no error when marshalling ZoneCustomSSLOptions to JSON")
+	assert.NotContains(t, string(result), "geo_restrictions", "expected mashalled ZoneCustomSSLOptions not to contain geo_restrictions when not set")
 }
 
 func TestListSSL(t *testing.T) {


### PR DESCRIPTION
This change fixes issue #479 with the second proposed solution; implementing a custom marshaler for the ZoneCustomSSLOptions struct to handle omiting the ZoneCustomSSLGeoRestrictions property if it's not set. This is a slightly less clean way of fixing this issue compared to PR #480 but isn't a breaking change.

## Description
This is described in detail in the related Issue #479. Implementing a custom marshaler allows us to parse the `ZoneCustomSSLOptions` struct as intended without breaking its current api.

## Has your change been tested?
I have added a test case to cover the specific behavior the new `MarshalJSON` implements.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.