### PR TITLE
Add allowed_idps and auto_redirect_to_identity to Access Apps

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -12,13 +12,15 @@ import (
 
 // AccessApplication represents an Access application.
 type AccessApplication struct {
-	ID              string     `json:"id,omitempty"`
-	CreatedAt       *time.Time `json:"created_at,omitempty"`
-	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
-	AUD             string     `json:"aud,omitempty"`
-	Name            string     `json:"name"`
-	Domain          string     `json:"domain"`
-	SessionDuration string     `json:"session_duration,omitempty"`
+	ID                     string     `json:"id,omitempty"`
+	CreatedAt              *time.Time `json:"created_at,omitempty"`
+	UpdatedAt              *time.Time `json:"updated_at,omitempty"`
+	AUD                    string     `json:"aud,omitempty"`
+	Name                   string     `json:"name"`
+	Domain                 string     `json:"domain"`
+	SessionDuration        string     `json:"session_duration,omitempty"`
+	AutoRedirectToIdentity bool       `json:"auto_redirect_to_identity,omitempty"`
+	AllowedIdps            []string   `json:"allowed_idps,omitempty"`
 }
 
 // AccessApplicationListResponse represents the response from the list

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -28,7 +28,9 @@ func TestAccessApplications(t *testing.T) {
 					"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 					"name": "Admin Site",
 					"domain": "test.example.com/admin",
-					"session_duration": "24h"
+					"session_duration": "24h",
+					"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
+					"auto_redirect_to_identity": false
 				}
 			],
 			"result_info": {
@@ -46,13 +48,15 @@ func TestAccessApplications(t *testing.T) {
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
 	want := []AccessApplication{AccessApplication{
-		ID:              "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		CreatedAt:       &createdAt,
-		UpdatedAt:       &updatedAt,
-		AUD:             "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-		Name:            "Admin Site",
-		Domain:          "test.example.com/admin",
-		SessionDuration: "24h",
+		ID:                     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		CreatedAt:              &createdAt,
+		UpdatedAt:              &updatedAt,
+		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		Name:                   "Admin Site",
+		Domain:                 "test.example.com/admin",
+		SessionDuration:        "24h",
+		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity: false,
 	}}
 
 	actual, _, err := client.AccessApplications("01a7362d577a6c3019a474fd6f485823", PaginationOptions{})
@@ -80,7 +84,9 @@ func TestAccessApplication(t *testing.T) {
 				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 				"name": "Admin Site",
 				"domain": "test.example.com/admin",
-				"session_duration": "24h"
+				"session_duration": "24h",
+				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
+				"auto_redirect_to_identity": false
 			}
 		}
 		`)
@@ -92,13 +98,15 @@ func TestAccessApplication(t *testing.T) {
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
 	want := AccessApplication{
-		ID:              "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		CreatedAt:       &createdAt,
-		UpdatedAt:       &updatedAt,
-		AUD:             "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-		Name:            "Admin Site",
-		Domain:          "test.example.com/admin",
-		SessionDuration: "24h",
+		ID:                     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		CreatedAt:              &createdAt,
+		UpdatedAt:              &updatedAt,
+		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		Name:                   "Admin Site",
+		Domain:                 "test.example.com/admin",
+		SessionDuration:        "24h",
+		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity: false,
 	}
 
 	actual, err := client.AccessApplication("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
@@ -126,7 +134,9 @@ func TestCreateAccessApplications(t *testing.T) {
 				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 				"name": "Admin Site",
 				"domain": "test.example.com/admin",
-				"session_duration": "24h"
+				"session_duration": "24h",
+				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
+				"auto_redirect_to_identity": false
 			}
 		}
 		`)
@@ -146,13 +156,15 @@ func TestCreateAccessApplications(t *testing.T) {
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	fullAccessApplication := AccessApplication{
-		ID:              "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:            "Admin Site",
-		Domain:          "test.example.com/admin",
-		SessionDuration: "24h",
-		AUD:             "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-		CreatedAt:       &createdAt,
-		UpdatedAt:       &updatedAt,
+		ID:                     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:                   "Admin Site",
+		Domain:                 "test.example.com/admin",
+		SessionDuration:        "24h",
+		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity: false,
+		CreatedAt:              &createdAt,
+		UpdatedAt:              &updatedAt,
 	}
 
 	if assert.NoError(t, err) {
@@ -178,7 +190,9 @@ func TestUpdateAccessApplication(t *testing.T) {
 				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 				"name": "Admin Site",
 				"domain": "test.example.com/admin",
-				"session_duration": "24h"
+				"session_duration": "24h",
+				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
+				"auto_redirect_to_identity": false
 			}
 		}
 		`)
@@ -189,13 +203,15 @@ func TestUpdateAccessApplication(t *testing.T) {
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	fullAccessApplication := AccessApplication{
-		ID:              "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:            "Admin Site",
-		Domain:          "test.example.com/admin",
-		SessionDuration: "24h",
-		AUD:             "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-		CreatedAt:       &createdAt,
-		UpdatedAt:       &updatedAt,
+		ID:                     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:                   "Admin Site",
+		Domain:                 "test.example.com/admin",
+		SessionDuration:        "24h",
+		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity: false,
+		CreatedAt:              &createdAt,
+		UpdatedAt:              &updatedAt,
 	}
 
 	actual, err := client.UpdateAccessApplication(


### PR DESCRIPTION
This commit adds support for the new Cloudflare Access application options `auto_redirect_to_identity` and `allowed_idps`.

## Description

This PR adds support for the new Cloudflare Access features introduced recently (https://blog.cloudflare.com/releasing-cloudflare-access-most-requested-feature/) where users can select which IdP they want to activate on a per-app basis (#483), it's a blocker to support this feature part of the Cloudflare Terraform Provider (https://github.com/terraform-providers/terraform-provider-cloudflare).

## Has your change been tested?

Yes my changes have been tested in my personal account, here's the tests that I did.

Creation of a Cloudflare Access application from the cloudflare-go library (the version with my changes...):

1. Without specifying the IdP -> the default IdP is selected by default.
2. By creating two IdPs and selecting on of the other during the creation of the application -> the correct IdP is applied on the application
3. By selecting the auto_redirect_to_identity without providing an IdP -> the default IdP is selected with auto_redirect_to_identity = true
4. By selecting the auto_redirect_to_identity and providing and IdP -> the correct IdP is selected with auto_redirect_to_identity = true

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
