### PR TITLE
access_application: Add support for CORS HTTP headers

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -12,13 +12,27 @@ import (
 
 // AccessApplication represents an Access application.
 type AccessApplication struct {
-	ID              string     `json:"id,omitempty"`
-	CreatedAt       *time.Time `json:"created_at,omitempty"`
-	UpdatedAt       *time.Time `json:"updated_at,omitempty"`
-	AUD             string     `json:"aud,omitempty"`
-	Name            string     `json:"name"`
-	Domain          string     `json:"domain"`
-	SessionDuration string     `json:"session_duration,omitempty"`
+	ID              string                       `json:"id,omitempty"`
+	CreatedAt       *time.Time                   `json:"created_at,omitempty"`
+	UpdatedAt       *time.Time                   `json:"updated_at,omitempty"`
+	AUD             string                       `json:"aud,omitempty"`
+	Name            string                       `json:"name"`
+	Domain          string                       `json:"domain"`
+	SessionDuration string                       `json:"session_duration,omitempty"`
+	CorsHeaders     AccessApplicationCorsHeaders `json:"cors_headers,omitempty"`
+}
+
+// AccessApplicationCorsHeaders represents the CORS HTTP headers for an Access
+// Application.
+type AccessApplicationCorsHeaders struct {
+	AllowedMethods   []string `json:"allowed_methods,omitempty"`
+	AllowedOrigins   []string `json:"allowed_origins,omitempty"`
+	AllowedHeaders   []string `json:"allowed_headers,omitempty"`
+	AllowAllMethods  bool     `json:"allow_all_methods,omitempty"`
+	AllowAllHeaders  bool     `json:"allow_all_headers,omitempty"`
+	AllowAllOrigins  bool     `json:"allow_all_origins,omitempty"`
+	AllowCredentials bool     `json:"allow_credentials,omitempty"`
+	MaxAge           int      `json:"max_age,omitempty"`
 }
 
 // AccessApplicationListResponse represents the response from the list

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -17,28 +17,28 @@ func TestAccessApplications(t *testing.T) {
 		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-			"success": true,
-			"errors": [],
-			"messages": [],
-			"result": [
-				{
-					"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-					"created_at": "2014-01-01T05:20:00.12345Z",
-					"updated_at": "2014-01-01T05:20:00.12345Z",
-					"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-					"name": "Admin Site",
-					"domain": "test.example.com/admin",
-					"session_duration": "24h"
-				}
-			],
-			"result_info": {
-				"page": 1,
-				"per_page": 20,
-				"count": 1,
-				"total_count": 2000
-			}
-		}
-		`)
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": [
+        {
+          "id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+          "created_at": "2014-01-01T05:20:00.12345Z",
+          "updated_at": "2014-01-01T05:20:00.12345Z",
+          "aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+          "name": "Admin Site",
+          "domain": "test.example.com/admin",
+          "session_duration": "24h"
+        }
+      ],
+      "result_info": {
+        "page": 1,
+        "per_page": 20,
+        "count": 1,
+        "total_count": 2000
+      }
+    }
+    `)
 	}
 
 	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
@@ -70,20 +70,20 @@ func TestAccessApplication(t *testing.T) {
 		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-			"success": true,
-			"errors": [],
-			"messages": [],
-			"result": {
-				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-				"created_at": "2014-01-01T05:20:00.12345Z",
-				"updated_at": "2014-01-01T05:20:00.12345Z",
-				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-				"name": "Admin Site",
-				"domain": "test.example.com/admin",
-				"session_duration": "24h"
-			}
-		}
-		`)
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+        "created_at": "2014-01-01T05:20:00.12345Z",
+        "updated_at": "2014-01-01T05:20:00.12345Z",
+        "aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+        "name": "Admin Site",
+        "domain": "test.example.com/admin",
+        "session_duration": "24h"
+      }
+    }
+    `)
 	}
 
 	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
@@ -116,20 +116,20 @@ func TestCreateAccessApplications(t *testing.T) {
 		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-			"success": true,
-			"errors": [],
-			"messages": [],
-			"result": {
-				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-				"created_at": "2014-01-01T05:20:00.12345Z",
-				"updated_at": "2014-01-01T05:20:00.12345Z",
-				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-				"name": "Admin Site",
-				"domain": "test.example.com/admin",
-				"session_duration": "24h"
-			}
-		}
-		`)
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+        "created_at": "2014-01-01T05:20:00.12345Z",
+        "updated_at": "2014-01-01T05:20:00.12345Z",
+        "aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+        "name": "Admin Site",
+        "domain": "test.example.com/admin",
+        "session_duration": "24h"
+      }
+    }
+    `)
 	}
 
 	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
@@ -168,20 +168,20 @@ func TestUpdateAccessApplication(t *testing.T) {
 		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-			"success": true,
-			"errors": [],
-			"messages": [],
-			"result": {
-				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-				"created_at": "2014-01-01T05:20:00.12345Z",
-				"updated_at": "2014-01-01T05:20:00.12345Z",
-				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-				"name": "Admin Site",
-				"domain": "test.example.com/admin",
-				"session_duration": "24h"
-			}
-		}
-		`)
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+        "created_at": "2014-01-01T05:20:00.12345Z",
+        "updated_at": "2014-01-01T05:20:00.12345Z",
+        "aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+        "name": "Admin Site",
+        "domain": "test.example.com/admin",
+        "session_duration": "24h"
+      }
+    }
+    `)
 	}
 
 	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
@@ -224,14 +224,14 @@ func TestDeleteAccessApplication(t *testing.T) {
 		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-			"success": true,
-			"errors": [],
-			"messages": [],
-			"result": {
-				"id": "699d98642c564d2e855e9661899b7252"
-			}
-		}
-		`)
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "id": "699d98642c564d2e855e9661899b7252"
+      }
+    }
+    `)
 	}
 
 	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
@@ -248,15 +248,79 @@ func TestRevokeAccessApplicationTokens(t *testing.T) {
 		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-			"success": true,
-			"errors": [],
-			"messages": []
-		}
-		`)
+      "success": true,
+      "errors": [],
+      "messages": []
+    }
+    `)
 	}
 
 	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db/revoke-tokens", handler)
 	err := client.RevokeAccessApplicationTokens("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
 
 	assert.NoError(t, err)
+}
+
+func TestAccessApplicationWithCORS(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [
+
+      ],
+      "result":{
+        "id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+        "created_at": "2014-01-01T05:20:00.12345Z",
+        "updated_at": "2014-01-01T05:20:00.12345Z",
+        "aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+        "name": "Admin Site",
+        "domain": "test.example.com/admin",
+        "session_duration": "24h",
+        "cors_headers": {
+          "allowed_methods": [
+            "GET"
+          ],
+          "allowed_origins": [
+            "https://example.com"
+          ],
+          "allow_all_headers": true,
+          "max_age": -1
+        }
+      }
+    }
+    `)
+	}
+
+	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+
+	want := AccessApplication{
+		ID:              "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		CreatedAt:       &createdAt,
+		UpdatedAt:       &updatedAt,
+		AUD:             "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		Name:            "Admin Site",
+		Domain:          "test.example.com/admin",
+		SessionDuration: "24h",
+		CorsHeaders: AccessApplicationCorsHeaders{
+			AllowedMethods:  []string{"GET"},
+			AllowedOrigins:  []string{"https://example.com"},
+			AllowAllHeaders: true,
+			MaxAge:          -1,
+		},
+	}
+
+	actual, err := client.AccessApplication("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
 }


### PR DESCRIPTION
Updates the Access Application support for setting CORS HTTP headers.

Documentation: https://api.cloudflare.com/#access-applications-properties

~Will need to resolve conflicts once #484 is merged.~

Unblocks work in Terraform Provider terraform-providers/terraform-provider-cloudflare#473