### PR TITLE
Convert /zones -> /accounts routes for access resources

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -40,10 +40,10 @@ type AccessApplicationDetailResponse struct {
 	Result   AccessApplication `json:"result"`
 }
 
-// AccessApplications returns all applications within a zone.
+// AccessApplications returns all applications within an account.
 //
 // API reference: https://api.cloudflare.com/#access-applications-list-access-applications
-func (api *API) AccessApplications(zoneID string, pageOpts PaginationOptions) ([]AccessApplication, ResultInfo, error) {
+func (api *API) AccessApplications(accountID string, pageOpts PaginationOptions) ([]AccessApplication, ResultInfo, error) {
 	v := url.Values{}
 	if pageOpts.PerPage > 0 {
 		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
@@ -52,7 +52,7 @@ func (api *API) AccessApplications(zoneID string, pageOpts PaginationOptions) ([
 		v.Set("page", strconv.Itoa(pageOpts.Page))
 	}
 
-	uri := "/zones/" + zoneID + "/access/apps"
+	uri := "/accounts/" + accountID + "/access/apps"
 	if len(v) > 0 {
 		uri = uri + "?" + v.Encode()
 	}
@@ -75,10 +75,10 @@ func (api *API) AccessApplications(zoneID string, pageOpts PaginationOptions) ([
 // application ID.
 //
 // API reference: https://api.cloudflare.com/#access-applications-access-applications-details
-func (api *API) AccessApplication(zoneID, applicationID string) (AccessApplication, error) {
+func (api *API) AccessApplication(accountID, applicationID string) (AccessApplication, error) {
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s",
-		zoneID,
+		"/accounts/%s/access/apps/%s",
+		accountID,
 		applicationID,
 	)
 
@@ -99,8 +99,8 @@ func (api *API) AccessApplication(zoneID, applicationID string) (AccessApplicati
 // CreateAccessApplication creates a new access application.
 //
 // API reference: https://api.cloudflare.com/#access-applications-create-access-application
-func (api *API) CreateAccessApplication(zoneID string, accessApplication AccessApplication) (AccessApplication, error) {
-	uri := "/zones/" + zoneID + "/access/apps"
+func (api *API) CreateAccessApplication(accountID string, accessApplication AccessApplication) (AccessApplication, error) {
+	uri := "/accounts/" + accountID + "/access/apps"
 
 	res, err := api.makeRequest("POST", uri, accessApplication)
 	if err != nil {
@@ -119,14 +119,14 @@ func (api *API) CreateAccessApplication(zoneID string, accessApplication AccessA
 // UpdateAccessApplication updates an existing access application.
 //
 // API reference: https://api.cloudflare.com/#access-applications-update-access-application
-func (api *API) UpdateAccessApplication(zoneID string, accessApplication AccessApplication) (AccessApplication, error) {
+func (api *API) UpdateAccessApplication(accountID string, accessApplication AccessApplication) (AccessApplication, error) {
 	if accessApplication.ID == "" {
 		return AccessApplication{}, errors.Errorf("access application ID cannot be empty")
 	}
 
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s",
-		zoneID,
+		"/accounts/%s/access/apps/%s",
+		accountID,
 		accessApplication.ID,
 	)
 
@@ -147,10 +147,10 @@ func (api *API) UpdateAccessApplication(zoneID string, accessApplication AccessA
 // DeleteAccessApplication deletes an access application.
 //
 // API reference: https://api.cloudflare.com/#access-applications-delete-access-application
-func (api *API) DeleteAccessApplication(zoneID, applicationID string) error {
+func (api *API) DeleteAccessApplication(accountID, applicationID string) error {
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s",
-		zoneID,
+		"/accounts/%s/access/apps/%s",
+		accountID,
 		applicationID,
 	)
 
@@ -166,10 +166,10 @@ func (api *API) DeleteAccessApplication(zoneID, applicationID string) error {
 // access application.
 //
 // API reference: https://api.cloudflare.com/#access-applications-revoke-access-tokens
-func (api *API) RevokeAccessApplicationTokens(zoneID, applicationID string) error {
+func (api *API) RevokeAccessApplicationTokens(accountID, applicationID string) error {
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s/revoke-tokens",
-		zoneID,
+		"/accounts/%s/access/apps/%s/revoke-tokens",
+		accountID,
 		applicationID,
 	)
 

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -43,7 +43,7 @@ func TestAccessApplications(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
@@ -92,7 +92,7 @@ func TestAccessApplication(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
 
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
@@ -142,7 +142,7 @@ func TestCreateAccessApplications(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
 
 	actual, err := client.CreateAccessApplication(
 		"01a7362d577a6c3019a474fd6f485823",
@@ -198,7 +198,7 @@ func TestUpdateAccessApplication(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
 
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
@@ -250,7 +250,7 @@ func TestDeleteAccessApplication(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
 	err := client.DeleteAccessApplication("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
 
 	assert.NoError(t, err)
@@ -271,7 +271,7 @@ func TestRevokeAccessApplicationTokens(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db/revoke-tokens", handler)
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db/revoke-tokens", handler)
 	err := client.RevokeAccessApplicationTokens("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
 
 	assert.NoError(t, err)

--- a/access_policy.go
+++ b/access_policy.go
@@ -53,7 +53,7 @@ type AccessPolicyDetailResponse struct {
 // AccessPolicies returns all access policies for an access application.
 //
 // API reference: https://api.cloudflare.com/#access-policy-list-access-policies
-func (api *API) AccessPolicies(zoneID, applicationID string, pageOpts PaginationOptions) ([]AccessPolicy, ResultInfo, error) {
+func (api *API) AccessPolicies(accountID, applicationID string, pageOpts PaginationOptions) ([]AccessPolicy, ResultInfo, error) {
 	v := url.Values{}
 	if pageOpts.PerPage > 0 {
 		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
@@ -63,8 +63,8 @@ func (api *API) AccessPolicies(zoneID, applicationID string, pageOpts Pagination
 	}
 
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s/policies",
-		zoneID,
+		"/accounts/%s/access/apps/%s/policies",
+		accountID,
 		applicationID,
 	)
 
@@ -89,10 +89,10 @@ func (api *API) AccessPolicies(zoneID, applicationID string, pageOpts Pagination
 // AccessPolicy returns a single policy based on the policy ID.
 //
 // API reference: https://api.cloudflare.com/#access-policy-access-policy-details
-func (api *API) AccessPolicy(zoneID, applicationID, policyID string) (AccessPolicy, error) {
+func (api *API) AccessPolicy(accountID, applicationID, policyID string) (AccessPolicy, error) {
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s/policies/%s",
-		zoneID,
+		"/accounts/%s/access/apps/%s/policies/%s",
+		accountID,
 		applicationID,
 		policyID,
 	)
@@ -114,10 +114,10 @@ func (api *API) AccessPolicy(zoneID, applicationID, policyID string) (AccessPoli
 // CreateAccessPolicy creates a new access policy.
 //
 // API reference: https://api.cloudflare.com/#access-policy-create-access-policy
-func (api *API) CreateAccessPolicy(zoneID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
+func (api *API) CreateAccessPolicy(accountID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s/policies",
-		zoneID,
+		"/accounts/%s/access/apps/%s/policies",
+		accountID,
 		applicationID,
 	)
 
@@ -138,13 +138,13 @@ func (api *API) CreateAccessPolicy(zoneID, applicationID string, accessPolicy Ac
 // UpdateAccessPolicy updates an existing access policy.
 //
 // API reference: https://api.cloudflare.com/#access-policy-update-access-policy
-func (api *API) UpdateAccessPolicy(zoneID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
+func (api *API) UpdateAccessPolicy(accountID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
 	if accessPolicy.ID == "" {
 		return AccessPolicy{}, errors.Errorf("access policy ID cannot be empty")
 	}
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s/policies/%s",
-		zoneID,
+		"/accounts/%s/access/apps/%s/policies/%s",
+		accountID,
 		applicationID,
 		accessPolicy.ID,
 	)
@@ -166,10 +166,10 @@ func (api *API) UpdateAccessPolicy(zoneID, applicationID string, accessPolicy Ac
 // DeleteAccessPolicy deletes an access policy.
 //
 // API reference: https://api.cloudflare.com/#access-policy-update-access-policy
-func (api *API) DeleteAccessPolicy(zoneID, applicationID, accessPolicyID string) error {
+func (api *API) DeleteAccessPolicy(accountID, applicationID, accessPolicyID string) error {
 	uri := fmt.Sprintf(
-		"/zones/%s/access/apps/%s/policies/%s",
-		zoneID,
+		"/accounts/%s/access/apps/%s/policies/%s",
+		accountID,
 		applicationID,
 		accessPolicyID,
 	)

--- a/access_policy_test.go
+++ b/access_policy_test.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	pageOptions         = PaginationOptions{}
-	zoneID              = "01a7362d577a6c3019a474fd6f485823"
 	accessApplicationID = "6e1c88f1-6b06-4b8a-a9e9-3ec7da2ee0c1"
 	accessPolicyID      = "699d98642c564d2e855e9661899b7252"
 
@@ -89,9 +88,9 @@ func TestAccessPolicies(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/"+zoneID+"/access/apps/"+accessApplicationID+"/policies", handler)
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/"+accessApplicationID+"/policies", handler)
 
-	actual, _, err := client.AccessPolicies(zoneID, accessApplicationID, pageOptions)
+	actual, _, err := client.AccessPolicies(accountID, accessApplicationID, pageOptions)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, []AccessPolicy{expectedAccessPolicy}, actual)
@@ -142,9 +141,9 @@ func TestAccessPolicy(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/"+zoneID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
 
-	actual, err := client.AccessPolicy(zoneID, accessApplicationID, accessPolicyID)
+	actual, err := client.AccessPolicy(accountID, accessApplicationID, accessPolicyID)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, expectedAccessPolicy, actual)
@@ -195,10 +194,10 @@ func TestCreateAccessPolicy(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/"+zoneID+"/access/apps/"+accessApplicationID+"/policies", handler)
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/"+accessApplicationID+"/policies", handler)
 
 	actual, err := client.CreateAccessPolicy(
-		zoneID,
+		accountID,
 		accessApplicationID,
 		AccessPolicy{
 			Name: "Allow devs",
@@ -270,8 +269,8 @@ func TestUpdateAccessPolicy(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/"+zoneID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
-	actual, err := client.UpdateAccessPolicy(zoneID, accessApplicationID, expectedAccessPolicy)
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
+	actual, err := client.UpdateAccessPolicy(accountID, accessApplicationID, expectedAccessPolicy)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, expectedAccessPolicy, actual)
@@ -282,7 +281,7 @@ func TestUpdateAccessPolicyWithMissingID(t *testing.T) {
 	setup()
 	defer teardown()
 
-	_, err := client.UpdateAccessPolicy(zoneID, accessApplicationID, AccessPolicy{})
+	_, err := client.UpdateAccessPolicy(accountID, accessApplicationID, AccessPolicy{})
 	assert.EqualError(t, err, "access policy ID cannot be empty")
 }
 
@@ -304,8 +303,8 @@ func TestDeleteAccessPolicy(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/"+zoneID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
-	err := client.DeleteAccessPolicy(zoneID, accessApplicationID, accessPolicyID)
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
+	err := client.DeleteAccessPolicy(accountID, accessApplicationID, accessPolicyID)
 
 	assert.NoError(t, err)
 }

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -650,7 +650,7 @@ func TestErrorFromResponse(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
 
 	_, err := client.CreateAccessApplication(
 		"01a7362d577a6c3019a474fd6f485823",


### PR DESCRIPTION
## Description

The access team has deprecated the `/zones` routes in favor of `/accounts`. The public docs should be released over the next several days that reflect the changes in this PR. I'll be referencing a corresponding PR in the Terraform provider repository once that's complete.

## Types of changes

What sort of change does your code introduce/modify?

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
