### PR TITLE
Adds support for Access CA certificates

### DIFF
--- a/access_ca_certificate.go
+++ b/access_ca_certificate.go
@@ -1,0 +1,115 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// AccessCACertificate is the structure of the CA certificate used for
+// short lived certificates.
+type AccessCACertificate struct {
+	ID        string `json:"id"`
+	Aud       string `json:"aud"`
+	PublicKey string `json:"public_key"`
+}
+
+// AccessCACertificateListResponse represents the response of all CA
+// certificates within Access.
+type AccessCACertificateListResponse struct {
+	Response
+	Result []AccessCACertificate `json:"result"`
+}
+
+// AccessCACertificateResponse represents the response of a single CA
+// certificate.
+type AccessCACertificateResponse struct {
+	Response
+	Result AccessCACertificate `json:"result"`
+}
+
+// AccessCACertificates returns all CA certificates within Access.
+//
+// API reference: https://api.cloudflare.com/#access-short-lived-certificates-list-short-lived-certificates
+func (api *API) AccessCACertificates(accountID string) ([]AccessCACertificate, error) {
+	uri := fmt.Sprintf("/accounts/%s/access/apps/ca", accountID)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []AccessCACertificate{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessCAListResponse AccessCACertificateListResponse
+	err = json.Unmarshal(res, &accessCAListResponse)
+	if err != nil {
+		return []AccessCACertificate{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessCAListResponse.Result, nil
+}
+
+// AccessCACertificate returns a single CA certificate associated with an Access
+// Application.
+//
+// API reference: https://api.cloudflare.com/#access-short-lived-certificates-short-lived-certificate-details
+func (api *API) AccessCACertificate(accountID, applicationID string) (AccessCACertificate, error) {
+	uri := fmt.Sprintf("/accounts/%s/access/apps/%s/ca", accountID, applicationID)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return AccessCACertificate{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessCAResponse AccessCACertificateResponse
+	err = json.Unmarshal(res, &accessCAResponse)
+	if err != nil {
+		return AccessCACertificate{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessCAResponse.Result, nil
+}
+
+// CreateAccessCACertificate creates a new CA certificate for an Access
+// Application.
+//
+// API reference: https://api.cloudflare.com/#access-short-lived-certificates-create-short-lived-certificate
+func (api *API) CreateAccessCACertificate(accountID, applicationID string) (AccessCACertificate, error) {
+	uri := fmt.Sprintf(
+		"/accounts/%s/access/apps/%s/ca",
+		accountID,
+		applicationID,
+	)
+
+	res, err := api.makeRequest("POST", uri, nil)
+	if err != nil {
+		return AccessCACertificate{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessCACertificate AccessCACertificateResponse
+	err = json.Unmarshal(res, &accessCACertificate)
+	if err != nil {
+		return AccessCACertificate{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessCACertificate.Result, nil
+}
+
+// DeleteAccessCACertificate deletes an Access CA certificate on a defined
+// Access Application.
+//
+// API reference: https://api.cloudflare.com/#access-short-lived-certificates-delete-access-certificate
+func (api *API) DeleteAccessCACertificate(accountID, applicationID string) error {
+	uri := fmt.Sprintf(
+		"/accounts/%s/access/apps/%s/ca",
+		accountID,
+		applicationID,
+	)
+
+	_, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	return nil
+}

--- a/access_ca_certificate_test.go
+++ b/access_ca_certificate_test.go
@@ -1,0 +1,139 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAcessCACertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+  "result": {
+    "id": "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
+    "aud": "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
+    "public_key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org"
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	want := AccessCACertificate{
+		ID:        "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
+		Aud:       "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
+		PublicKey: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org",
+	}
+
+	actual, err := client.AccessCACertificate("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestAcessCACertificates(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+  "result": [{
+    "id": "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
+    "aud": "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
+    "public_key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org"
+  }],
+  "success": true,
+  "errors": [],
+  "messages": []
+}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/ca", handler)
+
+	want := []AccessCACertificate{{
+		ID:        "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
+		Aud:       "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
+		PublicKey: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org",
+	}}
+
+	actual, err := client.AccessCACertificates("01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateAcessCACertificates(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+  "result": {
+    "id": "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
+    "aud": "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
+    "public_key": "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org"
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	want := AccessCACertificate{
+		ID:        "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
+		Aud:       "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
+		PublicKey: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org",
+	}
+
+	actual, err := client.CreateAccessCACertificate("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeleteAcessCACertificates(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+  "result": {
+    "id": "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4"
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	err := client.DeleteAccessCACertificate("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This introduces support for managing Access CA certificates (often
referenced as short lived certificates) via the API.

I opted to call this "Access CA certificates" as that is what the functionality
technically is. Should this instead be "Access Short Lived certificates" to
line up with documentation?

Documentation: https://api.cloudflare.com/#access-short-lived-certificates-properties

Note: When I raised this PR, the create new certificate + list single
certificate details were missing the response payload in the
documentation. I instead made actual calls to confirm the correctness of
these tests and updated a Cloudflare support ticket to get this fixed
for others.