### PR TITLE
Allow `AccessApplicationCorsHeaders` to be a pointer

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -12,16 +12,16 @@ import (
 
 // AccessApplication represents an Access application.
 type AccessApplication struct {
-	ID                     string                       `json:"id,omitempty"`
-	CreatedAt              *time.Time                   `json:"created_at,omitempty"`
-	UpdatedAt              *time.Time                   `json:"updated_at,omitempty"`
-	AUD                    string                       `json:"aud,omitempty"`
-	Name                   string                       `json:"name"`
-	Domain                 string                       `json:"domain"`
-	SessionDuration        string                       `json:"session_duration,omitempty"`
-	AutoRedirectToIdentity bool                         `json:"auto_redirect_to_identity,omitempty"`
-	AllowedIdps            []string                     `json:"allowed_idps,omitempty"`
-	CorsHeaders            AccessApplicationCorsHeaders `json:"cors_headers,omitempty"`
+	ID                     string                        `json:"id,omitempty"`
+	CreatedAt              *time.Time                    `json:"created_at,omitempty"`
+	UpdatedAt              *time.Time                    `json:"updated_at,omitempty"`
+	AUD                    string                        `json:"aud,omitempty"`
+	Name                   string                        `json:"name"`
+	Domain                 string                        `json:"domain"`
+	SessionDuration        string                        `json:"session_duration,omitempty"`
+	AutoRedirectToIdentity bool                          `json:"auto_redirect_to_identity,omitempty"`
+	AllowedIdps            []string                      `json:"allowed_idps,omitempty"`
+	CorsHeaders            *AccessApplicationCorsHeaders `json:"cors_headers,omitempty"`
 }
 
 // AccessApplicationCorsHeaders represents the CORS HTTP headers for an Access

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -326,7 +326,7 @@ func TestAccessApplicationWithCORS(t *testing.T) {
 		Name:            "Admin Site",
 		Domain:          "test.example.com/admin",
 		SessionDuration: "24h",
-		CorsHeaders: AccessApplicationCorsHeaders{
+		CorsHeaders: &AccessApplicationCorsHeaders{
 			AllowedMethods:  []string{"GET"},
 			AllowedOrigins:  []string{"https://example.com"},
 			AllowAllHeaders: true,


### PR DESCRIPTION
Updates the `AccessApplicationCorsHeaders` struct to be a pointer to
allow conditional use without sending an empty payload.