### PR TITLE
Update Optional Arguments for Workers KV API

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -365,11 +365,12 @@ type Response struct {
 
 // ResultInfo contains metadata about the Response.
 type ResultInfo struct {
-	Page       int `json:"page"`
-	PerPage    int `json:"per_page"`
-	TotalPages int `json:"total_pages"`
-	Count      int `json:"count"`
-	Total      int `json:"total_count"`
+	Page       int    `json:"page"`
+	PerPage    int    `json:"per_page"`
+	TotalPages int    `json:"total_pages"`
+	Count      int    `json:"count"`
+	Total      int    `json:"total_count"`
+	Cursor     string `json:"cursor"`
 }
 
 // RawResponse keeps the result as JSON form

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -51,7 +51,9 @@ type ListWorkersKVNamespacesResponse struct {
 
 // StorageKey is a key name used to identify a storage value
 type StorageKey struct {
-	Name string `json:"name"`
+	Name       string      `json:"name"`
+	Expiration int         `json:"expiration"`
+	Metadata   interface{} `json:"metadata"`
 }
 
 // ListStorageKeysResponse contains a slice of keys belonging to a storage namespace,

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -17,11 +17,13 @@ type WorkersKVNamespaceRequest struct {
 }
 
 // WorkersKVPair is used in an array in the request to the bulk KV api
-type WorkersKVPair struct{
-	Key string `json:"key"`
-	Value string `json:"value"`
-	Expiration int `json:"expiration,omitempty"`
-	ExpirationTTL int `json:"expiration_ttl,omitempty"`
+type WorkersKVPair struct {
+	Key           string      `json:"key"`
+	Value         string      `json:"value"`
+	Expiration    int         `json:"expiration,omitempty"`
+	ExpirationTTL int         `json:"expiration_ttl,omitempty"`
+	Metadata      interface{} `json:"metadata,omitempty"`
+	Base64        bool        `json:"base64,omitempty"`
 }
 
 // WorkersKVBulkWriteRequest is the request to the bulk KV api

--- a/workers_kv_test.go
+++ b/workers_kv_test.go
@@ -429,7 +429,11 @@ func TestWorkersKV_ListStorageKeysWithOptions(t *testing.T) {
 		fmt.Fprintf(w, response)
 	})
 
-	res, err := client.ListWorkersKVs(context.Background(), namespace)
+	limit, prefix := 25, "test-prefix"
+	res, err := client.ListWorkersKVsWithOptions(context.Background(), namespace, ListWorkersKVsOptions{
+		Limit:  &limit,
+		Prefix: &prefix,
+	})
 
 	want := ListStorageKeysResponse{
 		successResponse,

--- a/workers_kv_test.go
+++ b/workers_kv_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWorkersKV_CreateWorkersKVNamespace(t *testing.T) {
@@ -103,11 +104,11 @@ func TestWorkersKV_ListWorkersKVNamespace(t *testing.T) {
 
 	res, err := client.ListWorkersKVNamespaces(context.Background())
 	want := []WorkersKVNamespace{
-		WorkersKVNamespace {
+		WorkersKVNamespace{
 			ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 			Title: "test_namespace_1",
 		},
-		WorkersKVNamespace {
+		WorkersKVNamespace{
 			ID:    "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
 			Title: "test_namespace_2",
 		},
@@ -181,11 +182,11 @@ func TestWorkersKV_ListWorkersKVNamespaceMultiplePages(t *testing.T) {
 
 	res, err := client.ListWorkersKVNamespaces(context.Background())
 	want := []WorkersKVNamespace{
-		WorkersKVNamespace {
+		WorkersKVNamespace{
 			ID:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
 			Title: "test_namespace_1",
 		},
-		WorkersKVNamespace {
+		WorkersKVNamespace{
 			ID:    "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
 			Title: "test_namespace_2",
 		},
@@ -260,7 +261,7 @@ func TestWorkersKV_WriteWorkersKVBulk(t *testing.T) {
 	setup(UsingAccount("foo"))
 	defer teardown()
 
-	kvs := WorkersKVBulkWriteRequest{{Key: "key1", Value: "value1"}, {Key: "key2", Value: "value2"}}
+	kvs := WorkersKVBulkWriteRequest{{Key: "key1", Value: "value1"}, {Key: "key2", Value: "value2"}, {Key: "key3", Value: "value3", Metadata: "meta3", Base64: true}}
 
 	namespace := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 	response := `{
@@ -372,6 +373,85 @@ func TestWorkersKV_ListStorageKeys(t *testing.T) {
 			Count:      2,
 			TotalPages: 1,
 			Total:      2,
+		},
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want.Response, res.Response)
+		assert.Equal(t, want.ResultInfo, res.ResultInfo)
+
+		sort.Slice(res.Result, func(i, j int) bool {
+			return res.Result[i].Name < res.Result[j].Name
+		})
+
+		sort.Slice(want.Result, func(i, j int) bool {
+			return want.Result[i].Name < want.Result[j].Name
+		})
+		assert.Equal(t, want.Result, res.Result)
+	}
+}
+
+func TestWorkersKV_ListStorageKeysWithOptions(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	cursor := "AArAbNSOuYcr4HmzGH02-cfDN8Ck9ejOwkn_Ai5rsn7S9NEqVJBenU9-gYRlrsziyjKLx48hNDLvtYzBAmkPsLGdye8ECr5PqFYcIOfUITdhkyTc1x6bV8nmyjz5DO-XaZH4kYY1KfqT8NRBIe5sic6yYt3FUDttGjafy0ivi-Up-TkVdRB0OxCf3O3OB-svG6DXheV5XTdDNrNx1o_CVqy2l2j0F4iKV1qFe_KhdkjC7Y6QjhUZ1MOb3J_uznNYVCoxZ-bVAAsJmXA"
+	namespace := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	response := `{
+		"result": [
+			{
+				"name": "test_key_1",
+				"metadata": "test_key_1_meta"
+			},
+			{
+				"name": "test_key_2",
+				"metadata": {
+					"test2_meta_key": "test2_meta_value"
+				}
+			}
+		],
+		"success": true,
+		"errors": [],
+		"messages": [],
+		"result_info": {
+			"page": 1,
+			"per_page": 20,
+			"count": 2,
+			"total_count": 2,
+			"total_pages": 1,
+			"cursor": "` + cursor + `"
+		}
+	}`
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/keys", namespace), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/javascript")
+		fmt.Fprintf(w, response)
+	})
+
+	res, err := client.ListWorkersKVs(context.Background(), namespace)
+
+	want := ListStorageKeysResponse{
+		successResponse,
+		[]StorageKey{
+			{
+				Name:     "test_key_1",
+				Metadata: "test_key_1_meta",
+			},
+			{
+				Name: "test_key_2",
+				Metadata: map[string]interface{}{
+					"test2_meta_key": "test2_meta_value",
+				},
+			},
+		},
+		ResultInfo{
+			Page:       1,
+			PerPage:    20,
+			Count:      2,
+			TotalPages: 1,
+			Total:      2,
+			Cursor:     cursor,
 		},
 	}
 


### PR DESCRIPTION
## Description

Currently, `cloudflare-go` lacks fine-tuning for some Workers KV requests/responses. This change is focused on updating `cloudflare-go` to the current API docs with respect to [writing to KV in bulk](https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs) and [listing a namespace's keys](https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys).

For writing to KV in bulk, JSON tags for `metadata` and `base64` were added to the `WorkersKVPair` struct.

When receiving a list response, JSON tags for `metadata` and `expiration` were added to the `StorageKey` struct.

The function `ListWorkersKVsWithOptions` was introduced to allow the options for `limit`, `cursor`, and `prefix` to be set when requesting a namespace's keys, as opposed to the existing function `ListWorkersKVs`.


## Has your change been tested?

My change has been tested thoroughly by updating/querying a KV namespace. I added a unit test for the new `ListWorkersKVsWithOptions` function, and updated the unit test for `WriteWorkersKVBulk`. All tests pass.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
