### PR TITLE
KV Bulk Delete Request / More KV Examples

### DIFF
--- a/workers_kv.go
+++ b/workers_kv.go
@@ -237,6 +237,26 @@ func (api API) DeleteWorkersKV(ctx context.Context, namespaceID, key string) (Re
 	return result, err
 }
 
+// DeleteWorkersKVBulk deletes multiple KVs at once.
+//
+// API reference: https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs
+func (api *API) DeleteWorkersKVBulk(ctx context.Context, namespaceID string, keys []string) (Response, error) {
+	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk", api.AccountID, namespaceID)
+	res, err := api.makeRequestWithAuthTypeAndHeaders(
+		ctx, http.MethodDelete, uri, keys, api.authType, http.Header{"Content-Type": []string{"application/json"}},
+	)
+	if err != nil {
+		return Response{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := Response{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return result, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result, err
+}
+
 // ListWorkersKVs lists a namespace's keys
 //
 // API Reference: https://api.cloudflare.com/#workers-kv-namespace-list-a-namespace-s-keys

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -171,8 +171,8 @@ func (api *API) UpdateWorkersKVNamespace(ctx context.Context, namespaceID string
 func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, value []byte) (Response, error) {
 	key = url.PathEscape(key)
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.AccountID, namespaceID, key)
-	res, err := api.makeRequestWithAuthTypeAndHeaders(
-		ctx, http.MethodPut, uri, value, api.authType, http.Header{"Content-Type": []string{"application/octet-stream"}},
+	res, err := api.makeRequestWithHeaders(
+		http.MethodPut, uri, value, http.Header{"Content-Type": []string{"application/octet-stream"}},
 	)
 	if err != nil {
 		return Response{}, errors.Wrap(err, errMakeRequestError)
@@ -191,8 +191,8 @@ func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, val
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs
 func (api *API) WriteWorkersKVBulk(ctx context.Context, namespaceID string, kvs WorkersKVBulkWriteRequest) (Response, error) {
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk", api.AccountID, namespaceID)
-	res, err := api.makeRequestWithAuthTypeAndHeaders(
-		ctx, http.MethodPut, uri, kvs, api.authType, http.Header{"Content-Type": []string{"application/json"}},
+	res, err := api.makeRequestWithHeaders(
+		http.MethodPut, uri, kvs, http.Header{"Content-Type": []string{"application/json"}},
 	)
 	if err != nil {
 		return Response{}, errors.Wrap(err, errMakeRequestError)
@@ -242,8 +242,8 @@ func (api API) DeleteWorkersKV(ctx context.Context, namespaceID, key string) (Re
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs
 func (api *API) DeleteWorkersKVBulk(ctx context.Context, namespaceID string, keys []string) (Response, error) {
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk", api.AccountID, namespaceID)
-	res, err := api.makeRequestWithAuthTypeAndHeaders(
-		ctx, http.MethodDelete, uri, keys, api.authType, http.Header{"Content-Type": []string{"application/json"}},
+	res, err := api.makeRequestWithHeaders(
+		http.MethodDelete, uri, keys, http.Header{"Content-Type": []string{"application/json"}},
 	)
 	if err != nil {
 		return Response{}, errors.Wrap(err, errMakeRequestError)

--- a/workers_kv_example_test.go
+++ b/workers_kv_example_test.go
@@ -2,6 +2,7 @@ package cloudflare_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log"
 
@@ -94,7 +95,18 @@ func ExampleAPI_WriteWorkersKVBulk() {
 		log.Fatal(err)
 	}
 
-	payload := cloudflare.WorkersKVBulkWriteRequest{{Key: "key1", Value: "value1"}, {Key: "key2", Value: "value2"}}
+	payload := cloudflare.WorkersKVBulkWriteRequest{
+		{
+			Key:   "key1",
+			Value: "value1",
+		},
+		{
+			Key:      "key2",
+			Value:    base64.StdEncoding.EncodeToString([]byte("value2")),
+			Base64:   true,
+			Metadata: "key2's value will be decoded in base64 before it is stored",
+		},
+	}
 
 	resp, err := api.WriteWorkersKVBulk(context.Background(), namespace, payload)
 	if err != nil {
@@ -134,6 +146,22 @@ func ExampleAPI_DeleteWorkersKV() {
 	fmt.Printf("%+v\n", resp)
 }
 
+func ExampleAPI_DeleteWorkersKVBulk() {
+	api, err := cloudflare.New(apiKey, user, cloudflare.UsingAccount(accountID))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	keys := []string{"key1", "key2", "key3"}
+
+	resp, err := api.DeleteWorkersKVBulk(context.Background(), namespace, keys)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(resp)
+}
+
 func ExampleAPI_ListWorkersKVs() {
 	api, err := cloudflare.New(apiKey, user, cloudflare.UsingAccount(accountID))
 	if err != nil {
@@ -141,6 +169,30 @@ func ExampleAPI_ListWorkersKVs() {
 	}
 
 	resp, err := api.ListWorkersKVs(context.Background(), namespace)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(resp)
+}
+
+func ExampleAPI_ListWorkersKVsWithOptions() {
+	api, err := cloudflare.New(apiKey, user, cloudflare.UsingAccount(accountID))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	limit := 50
+	prefix := "my-prefix"
+	cursor := "AArAbNSOuYcr4HmzGH02-cfDN8Ck9ejOwkn_Ai5rsn7S9NEqVJBenU9-gYRlrsziyjKLx48hNDLvtYzBAmkPsLGdye8ECr5PqFYcIOfUITdhkyTc1x6bV8nmyjz5DO-XaZH4kYY1KfqT8NRBIe5sic6yYt3FUDttGjafy0ivi-Up-TkVdRB0OxCf3O3OB-svG6DXheV5XTdDNrNx1o_CVqy2l2j0F4iKV1qFe_KhdkjC7Y6QjhUZ1MOb3J_uznNYVCoxZ-bVAAsJmXA"
+
+	options := cloudflare.ListWorkersKVsOptions{
+		Limit:  &limit,
+		Prefix: &prefix,
+		Cursor: &cursor,
+	}
+
+	resp, err := api.ListWorkersKVsWithOptions(context.Background(), namespace, options)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/workers_kv_test.go
+++ b/workers_kv_test.go
@@ -331,6 +331,32 @@ func TestWorkersKV_DeleteWorkersKV(t *testing.T) {
 	}
 }
 
+func TestWorkersKV_DeleteWorkersKVBulk(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	keys := []string{"key1", "key2", "key3"}
+
+	namespace := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	response := `{
+		"result": null,
+		"success": true,
+		"errors": [],
+		"messages": []
+	}`
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/bulk", namespace), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+
+	want := successResponse
+	res, err := client.DeleteWorkersKVBulk(context.Background(), namespace, keys)
+	require.NoError(t, err)
+	assert.Equal(t, want, res)
+}
+
 func TestWorkersKV_ListStorageKeys(t *testing.T) {
 	setup(UsingAccount("foo"))
 	defer teardown()


### PR DESCRIPTION
## Description

This PR extends #494, updating the requests/responses for Workers KV. This change focuses on updating to the API docs for [deleting KVs in bulk](https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs).

A new function `DeleteWorkersKVBulk` is added, similar to the existing `WriteWorkersKVBulk`.

KV examples for the new `DeleteWorkersKVBulk` as well as the new functionality from #494 are added.

## Has your change been tested?

My change has been tested thoroughly by updating/querying a KV namespace. I added a unit test for the new `DeleteWorkersKVBulk` function. All tests pass.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.