### PR TITLE
logpush: Handle invalid destination configuration

### DIFF
--- a/logpush.go
+++ b/logpush.go
@@ -225,6 +225,11 @@ func (api *API) GetLogpushOwnershipChallenge(zoneID, destinationConf string) (*L
 	if err != nil {
 		return nil, errors.Wrap(err, errUnmarshalError)
 	}
+
+	if !r.Result.Valid {
+		return nil, errors.New(r.Result.Message)
+	}
+
 	return &r.Result, nil
 }
 


### PR DESCRIPTION
In the event that the destination configuration of a logpush job
challenge returns an erorr, we don't currently catch that. Instead, we
return the ownership challenge struct successfully which is slightly
misleading.

This introduces more error checking on the API itself to inspect the
response payload for the `valid` parameter being set to true which
handles the scenarios where ownership validation fails.

Fixes #499