### PR TITLE
Add support for all forms of Authenticated Origin Pulls

### DIFF
--- a/authenticated_origin_pulls.go
+++ b/authenticated_origin_pulls.go
@@ -7,40 +7,40 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AOP represents global AOP (tls_client_auth) metadata.
-type AOP struct {
+// AuthenticatedOriginPulls represents global AuthenticatedOriginPulls (tls_client_auth) metadata.
+type AuthenticatedOriginPulls struct {
 	ID         string    `json:"id"`
 	Value      string    `json:"value"`
 	Editable   bool      `json:"editable"`
 	ModifiedOn time.Time `json:"modified_on"`
 }
 
-// AOPResponse represents the response from the global AOP (tls_client_auth) details endpoint.
-type AOPResponse struct {
+// AuthenticatedOriginPullsResponse represents the response from the global AuthenticatedOriginPulls (tls_client_auth) details endpoint.
+type AuthenticatedOriginPullsResponse struct {
 	Response
-	Result AOP `json:"result"`
+	Result AuthenticatedOriginPulls `json:"result"`
 }
 
-// GetAOPStatus returns the configuration details for global AOP (tls_client_auth).
+// GetAuthenticatedOriginPullsStatus returns the configuration details for global AuthenticatedOriginPulls (tls_client_auth).
 //
 // API reference: https://api.cloudflare.com/#zone-settings-get-tls-client-auth-setting
-func (api *API) GetAOPStatus(zoneID string) (AOP, error) {
+func (api *API) GetAuthenticatedOriginPullsStatus(zoneID string) (AuthenticatedOriginPulls, error) {
 	uri := "/zones/" + zoneID + "/settings/tls_client_auth"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return AOP{}, errors.Wrap(err, errMakeRequestError)
+		return AuthenticatedOriginPulls{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r AOPResponse
+	var r AuthenticatedOriginPullsResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return AOP{}, errors.Wrap(err, errUnmarshalError)
+		return AuthenticatedOriginPulls{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// SetAOPStatus toggles whether global AOP is enabled for the zone.
+// SetAuthenticatedOriginPullsStatus toggles whether global AuthenticatedOriginPulls is enabled for the zone.
 //
 // API reference: https://api.cloudflare.com/#zone-settings-change-tls-client-auth-setting
-func (api *API) SetAOPStatus(zoneID string, enable bool) (AOP, error) {
+func (api *API) SetAuthenticatedOriginPullsStatus(zoneID string, enable bool) (AuthenticatedOriginPulls, error) {
 	uri := "/zones/" + zoneID + "/settings/tls_client_auth"
 	var val string
 	if enable {
@@ -55,11 +55,11 @@ func (api *API) SetAOPStatus(zoneID string, enable bool) (AOP, error) {
 	}
 	res, err := api.makeRequest("PATCH", uri, params)
 	if err != nil {
-		return AOP{}, errors.Wrap(err, errMakeRequestError)
+		return AuthenticatedOriginPulls{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r AOPResponse
+	var r AuthenticatedOriginPullsResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return AOP{}, errors.Wrap(err, errUnmarshalError)
+		return AuthenticatedOriginPulls{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/authenticated_origin_pulls.go
+++ b/authenticated_origin_pulls.go
@@ -1,0 +1,65 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// AOP represents global AOP (tls_client_auth) metadata.
+type AOP struct {
+	ID         string    `json:"id"`
+	Value      string    `json:"value"`
+	Editable   bool      `json:"editable"`
+	ModifiedOn time.Time `json:"modified_on"`
+}
+
+// AOPResponse represents the response from the global AOP (tls_client_auth) details endpoint.
+type AOPResponse struct {
+	Response
+	Result AOP `json:"result"`
+}
+
+// GetAOPStatus returns the configuration details for global AOP (tls_client_auth).
+//
+// API reference: https://api.cloudflare.com/#zone-settings-get-tls-client-auth-setting
+func (api *API) GetAOPStatus(zoneID string) (AOP, error) {
+	uri := "/zones/" + zoneID + "/settings/tls_client_auth"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return AOP{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r AOPResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return AOP{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// SetAOPStatus toggles whether global AOP is enabled for the zone.
+//
+// API reference: https://api.cloudflare.com/#zone-settings-change-tls-client-auth-setting
+func (api *API) SetAOPStatus(zoneID string, enable bool) (AOP, error) {
+	uri := "/zones/" + zoneID + "/settings/tls_client_auth"
+	var val string
+	if enable {
+		val = "on"
+	} else {
+		val = "off"
+	}
+	params := struct {
+		Value string `json:"value"`
+	}{
+		Value: val,
+	}
+	res, err := api.makeRequest("PATCH", uri, params)
+	if err != nil {
+		return AOP{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r AOPResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return AOP{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/authenticated_origin_pulls_per_hostname.go
+++ b/authenticated_origin_pulls_per_hostname.go
@@ -7,8 +7,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PerHostnameAOPCertificateDetails represents the metadata for a Per Hostname AOP certificate.
-type PerHostnameAOPCertificateDetails struct {
+// PerHostnameAuthenticatedOriginPullsCertificateDetails represents the metadata for a Per Hostname AuthenticatedOriginPulls certificate.
+type PerHostnameAuthenticatedOriginPullsCertificateDetails struct {
 	ID           string    `json:"id"`
 	Certificate  string    `json:"certificate"`
 	Issuer       string    `json:"issuer"`
@@ -19,14 +19,14 @@ type PerHostnameAOPCertificateDetails struct {
 	UploadedOn   time.Time `json:"uploaded_on"`
 }
 
-// PerHostnameAOPCertificateResponse represents the response from endpoints relating to creating and deleting a Per Hostname AOP certificate.
-type PerHostnameAOPCertificateResponse struct {
+// PerHostnameAuthenticatedOriginPullsCertificateResponse represents the response from endpoints relating to creating and deleting a Per Hostname AuthenticatedOriginPulls certificate.
+type PerHostnameAuthenticatedOriginPullsCertificateResponse struct {
 	Response
-	Result PerHostnameAOPCertificateDetails `json:"result"`
+	Result PerHostnameAuthenticatedOriginPullsCertificateDetails `json:"result"`
 }
 
-// PerHostnameAOPDetails contains metadata about the Per Hostname AOP configuration on a hostname.
-type PerHostnameAOPDetails struct {
+// PerHostnameAuthenticatedOriginPullsDetails contains metadata about the Per Hostname AuthenticatedOriginPulls configuration on a hostname.
+type PerHostnameAuthenticatedOriginPullsDetails struct {
 	Hostname       string    `json:"hostname"`
 	CertID         string    `json:"cert_id"`
 	Enabled        bool      `json:"enabled"`
@@ -43,107 +43,107 @@ type PerHostnameAOPDetails struct {
 	ExpiresOn      time.Time `json:"expires_on"`
 }
 
-// PerHostnameAOPDetailsResponse represents Per Hostname AOP configuration metadata for a single hostname.
-type PerHostnameAOPDetailsResponse struct {
+// PerHostnameAuthenticatedOriginPullsDetailsResponse represents Per Hostname AuthenticatedOriginPulls configuration metadata for a single hostname.
+type PerHostnameAuthenticatedOriginPullsDetailsResponse struct {
 	Response
-	Result PerHostnameAOPDetails `json:"result"`
+	Result PerHostnameAuthenticatedOriginPullsDetails `json:"result"`
 }
 
-// PerHostnamesAOPDetailsResponse represents Per Hostname AOP configuration metadata for multiple hostnames.
-type PerHostnamesAOPDetailsResponse struct {
+// PerHostnamesAuthenticatedOriginPullsDetailsResponse represents Per Hostname AuthenticatedOriginPulls configuration metadata for multiple hostnames.
+type PerHostnamesAuthenticatedOriginPullsDetailsResponse struct {
 	Response
-	Result []PerHostnameAOPDetails `json:"result"`
+	Result []PerHostnameAuthenticatedOriginPullsDetails `json:"result"`
 }
 
-// PerHostnameAOPCertificateParams represents the required data related to the client certificate being uploaded to be used in Per Hostname AOP.
-type PerHostnameAOPCertificateParams struct {
+// PerHostnameAuthenticatedOriginPullsCertificateParams represents the required data related to the client certificate being uploaded to be used in Per Hostname AuthenticatedOriginPulls.
+type PerHostnameAuthenticatedOriginPullsCertificateParams struct {
 	Certificate string `json:"certificate"`
 	PrivateKey  string `json:"private_key"`
 }
 
-// PerHostnameAOPConfig represents the config state for Per Hostname AOP applied on a hostname.
-type PerHostnameAOPConfig struct {
+// PerHostnameAuthenticatedOriginPullsConfig represents the config state for Per Hostname AuthenticatedOriginPulls applied on a hostname.
+type PerHostnameAuthenticatedOriginPullsConfig struct {
 	Hostname string `json:"hostname"`
 	CertID   string `json:"cert_id"`
 	Enabled  bool   `json:"enabled"`
 }
 
-// UploadPerHostnameAOPCertificate will upload the provided certificate and private key to the edge under Per Hostname AOP.
+// UploadPerHostnameAuthenticatedOriginPullsCertificate will upload the provided certificate and private key to the edge under Per Hostname AuthenticatedOriginPulls.
 //
 // API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-upload-a-hostname-client-certificate
-func (api *API) UploadPerHostnameAOPCertificate(zoneID string, params PerHostnameAOPCertificateParams) (PerHostnameAOPCertificateDetails, error) {
+func (api *API) UploadPerHostnameAuthenticatedOriginPullsCertificate(zoneID string, params PerHostnameAuthenticatedOriginPullsCertificateParams) (PerHostnameAuthenticatedOriginPullsCertificateDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/certificates"
 	res, err := api.makeRequest("POST", uri, params)
 	if err != nil {
-		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+		return PerHostnameAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerHostnameAOPCertificateResponse
+	var r PerHostnameAuthenticatedOriginPullsCertificateResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+		return PerHostnameAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// GetPerHostnameAOPCertificate retrieves certificate metadata about the requested Per Hostname certificate.
+// GetPerHostnameAuthenticatedOriginPullsCertificate retrieves certificate metadata about the requested Per Hostname certificate.
 //
 // API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-get-the-hostname-client-certificate
-func (api *API) GetPerHostnameAOPCertificate(zoneID, certificateID string) (PerHostnameAOPCertificateDetails, error) {
+func (api *API) GetPerHostnameAuthenticatedOriginPullsCertificate(zoneID, certificateID string) (PerHostnameAuthenticatedOriginPullsCertificateDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/certificates/" + certificateID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+		return PerHostnameAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerHostnameAOPCertificateResponse
+	var r PerHostnameAuthenticatedOriginPullsCertificateResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+		return PerHostnameAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// DeletePerHostnameAOPCertificate will remove the requested Per Hostname certificate from the edge.
+// DeletePerHostnameAuthenticatedOriginPullsCertificate will remove the requested Per Hostname certificate from the edge.
 //
 // API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-delete-hostname-client-certificate
-func (api *API) DeletePerHostnameAOPCertificate(zoneID, certificateID string) (PerHostnameAOPCertificateDetails, error) {
+func (api *API) DeletePerHostnameAuthenticatedOriginPullsCertificate(zoneID, certificateID string) (PerHostnameAuthenticatedOriginPullsCertificateDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/certificates/" + certificateID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+		return PerHostnameAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerHostnameAOPCertificateResponse
+	var r PerHostnameAuthenticatedOriginPullsCertificateResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+		return PerHostnameAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// EditPerHostnameAOPConfig applies the supplied Per Hostname AOP config onto a hostname(s) in the edge.
+// EditPerHostnameAuthenticatedOriginPullsConfig applies the supplied Per Hostname AuthenticatedOriginPulls config onto a hostname(s) in the edge.
 //
 // API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-enable-or-disable-a-hostname-for-client-authentication
-func (api *API) EditPerHostnameAOPConfig(zoneID string, config []PerHostnameAOPConfig) ([]PerHostnameAOPDetails, error) {
+func (api *API) EditPerHostnameAuthenticatedOriginPullsConfig(zoneID string, config []PerHostnameAuthenticatedOriginPullsConfig) ([]PerHostnameAuthenticatedOriginPullsDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames"
 	res, err := api.makeRequest("PUT", uri, nil)
 	if err != nil {
-		return []PerHostnameAOPDetails{}, errors.Wrap(err, errMakeRequestError)
+		return []PerHostnameAuthenticatedOriginPullsDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerHostnamesAOPDetailsResponse
+	var r PerHostnamesAuthenticatedOriginPullsDetailsResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return []PerHostnameAOPDetails{}, errors.Wrap(err, errUnmarshalError)
+		return []PerHostnameAuthenticatedOriginPullsDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// GetPerHostnameAOPConfig returns the config state of Per Hostname AOP of the provided hostname within a zone.
+// GetPerHostnameAuthenticatedOriginPullsConfig returns the config state of Per Hostname AuthenticatedOriginPulls of the provided hostname within a zone.
 //
 // API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-get-the-hostname-status-for-client-authentication
-func (api *API) GetPerHostnameAOPConfig(zoneID, hostname string) (PerHostnameAOPDetails, error) {
+func (api *API) GetPerHostnameAuthenticatedOriginPullsConfig(zoneID, hostname string) (PerHostnameAuthenticatedOriginPullsDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/" + hostname
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return PerHostnameAOPDetails{}, errors.Wrap(err, errMakeRequestError)
+		return PerHostnameAuthenticatedOriginPullsDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerHostnameAOPDetailsResponse
+	var r PerHostnameAuthenticatedOriginPullsDetailsResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerHostnameAOPDetails{}, errors.Wrap(err, errUnmarshalError)
+		return PerHostnameAuthenticatedOriginPullsDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/authenticated_origin_pulls_per_hostname.go
+++ b/authenticated_origin_pulls_per_hostname.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// PerHostnameAOPCertificateDetails represents the metadata for a Per Hostname AOP certificate.
+type PerHostnameAOPCertificateDetails struct {
+	ID           string    `json:"id"`
+	Certificate  string    `json:"certificate"`
+	Issuer       string    `json:"issuer"`
+	Signature    string    `json:"signature"`
+	SerialNumber string    `json:"serial_number"`
+	ExpiresOn    time.Time `json:"expires_on"`
+	Status       string    `json:"status"`
+	UploadedOn   time.Time `json:"uploaded_on"`
+}
+
+// PerHostnameAOPCertificateResponse represents the response from endpoints relating to creating and deleting a Per Hostname AOP certificate.
+type PerHostnameAOPCertificateResponse struct {
+	Response
+	Result PerHostnameAOPCertificateDetails `json:"result"`
+}
+
+// PerHostnameAOPDetails contains metadata about the Per Hostname AOP configuration on a hostname.
+type PerHostnameAOPDetails struct {
+	Hostname       string    `json:"hostname"`
+	CertID         string    `json:"cert_id"`
+	Enabled        bool      `json:"enabled"`
+	Status         string    `json:"status"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	CertStatus     string    `json:"cert_status"`
+	Issuer         string    `json:"issuer"`
+	Signature      string    `json:"signature"`
+	SerialNumber   string    `json:"serial_number"`
+	Certificate    string    `json:"certificate"`
+	CertUploadedOn time.Time `json:"cert_uploaded_on"`
+	CertUpdatedAt  time.Time `json:"cert_updated_at"`
+	ExpiresOn      time.Time `json:"expires_on"`
+}
+
+// PerHostnamesAOPDetailsResponse represents Per Hostname AOP configuration metadata for a single hostname.
+type PerHostnameAOPDetailsResponse struct {
+	Response
+	Result PerHostnameAOPDetails `json:"result"`
+}
+
+// PerHostnamesAOPDetailsResponse represents Per Hostname AOP configuration metadata for multiple hostnames.
+type PerHostnamesAOPDetailsResponse struct {
+	Response
+	Result []PerHostnameAOPDetails `json:"result"`
+}
+
+// PerHostnameAOPCertificateParams represents the required data related to the client certificate being uploaded to be used in Per Hostname AOP.
+type PerHostnameAOPCertificateParams struct {
+	Certificate string `json:"certificate"`
+	PrivateKey  string `json:"private_key"`
+}
+
+// PerHostnameAOPConfig represents the config state for Per Hostname AOP applied on a hostname.
+type PerHostnameAOPConfig struct {
+	Hostname string `json:"hostname"`
+	CertID   string `json:"cert_id"`
+	Enabled  bool   `json:"enabled"`
+}
+
+// UploadPerHostnameAOPCertificate will upload the provided certificate and private key to the edge under Per Hostname AOP.
+//
+// API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-upload-a-hostname-client-certificate
+func (api *API) UploadPerHostnameAOPCertificate(zoneID string, params PerHostnameAOPCertificateParams) (PerHostnameAOPCertificateDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/certificates"
+	res, err := api.makeRequest("POST", uri, params)
+	if err != nil {
+		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerHostnameAOPCertificateResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// GetPerHostnameAOPCertificate retrieves certificate metadata about the requested Per Hostname certificate.
+//
+// API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-get-the-hostname-client-certificate
+func (api *API) GetPerHostnameAOPCertificate(zoneID, certificateID string) (PerHostnameAOPCertificateDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/certificates/" + certificateID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerHostnameAOPCertificateResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeletePerHostnameAOPCertificate will remove the requested Per Hostname certificate from the edge.
+//
+// API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-delete-hostname-client-certificate
+func (api *API) DeletePerHostnameAOPCertificate(zoneID, certificateID string) (PerHostnameAOPCertificateDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/certificates/" + certificateID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerHostnameAOPCertificateResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerHostnameAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// EditPerHostnameAOPConfig applies the supplied Per Hostname AOP config onto a hostname(s) in the edge.
+//
+// API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-enable-or-disable-a-hostname-for-client-authentication
+func (api *API) EditPerHostnameAOPConfig(zoneID string, config []PerHostnameAOPConfig) ([]PerHostnameAOPDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames"
+	res, err := api.makeRequest("PUT", uri, nil)
+	if err != nil {
+		return []PerHostnameAOPDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerHostnamesAOPDetailsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return []PerHostnameAOPDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// GetPerHostnameAOPConfig returns the config state of Per Hostname AOP of the provided hostname within a zone.
+//
+// API reference: https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-get-the-hostname-status-for-client-authentication
+func (api *API) GetPerHostnameAOPConfig(zoneID, hostname string) (PerHostnameAOPDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/hostnames/" + hostname
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return PerHostnameAOPDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerHostnameAOPDetailsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerHostnameAOPDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/authenticated_origin_pulls_per_hostname.go
+++ b/authenticated_origin_pulls_per_hostname.go
@@ -43,7 +43,7 @@ type PerHostnameAOPDetails struct {
 	ExpiresOn      time.Time `json:"expires_on"`
 }
 
-// PerHostnamesAOPDetailsResponse represents Per Hostname AOP configuration metadata for a single hostname.
+// PerHostnameAOPDetailsResponse represents Per Hostname AOP configuration metadata for a single hostname.
 type PerHostnameAOPDetailsResponse struct {
 	Response
 	Result PerHostnameAOPDetails `json:"result"`

--- a/authenticated_origin_pulls_per_hostname_test.go
+++ b/authenticated_origin_pulls_per_hostname_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUploadPerHostnameAOPCertificate(t *testing.T) {
+func TestUploadPerHostnameAuthenticatedOriginPullsCertificate(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -35,7 +35,7 @@ func TestUploadPerHostnameAOPCertificate(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/hostnames/certificates", handler)
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
-	want := PerHostnameAOPCertificateDetails{
+	want := PerHostnameAuthenticatedOriginPullsCertificateDetails{
 		ID:           "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 		Certificate:  "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		Issuer:       "GlobalSign",
@@ -46,17 +46,17 @@ func TestUploadPerHostnameAOPCertificate(t *testing.T) {
 		UploadedOn:   uploadedOn,
 	}
 
-	clientCert := PerHostnameAOPCertificateParams{
+	clientCert := PerHostnameAuthenticatedOriginPullsCertificateParams{
 		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		PrivateKey:  "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmG\ndtcGbg/1CGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKn\nabIRuGvBKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpid\ntnKX/a+50GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+py\nFxIXjbEIdZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pE\newooaeO2izNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABAoIBACbhTYXBZYKmYPCb\nHBR1IBlCQA2nLGf0qRuJNJZg5iEzXows/6tc8YymZkQE7nolapWsQ+upk2y5Xdp/\naxiuprIs9JzkYK8Ox0r+dlwCG1kSW+UAbX0bQ/qUqlsTvU6muVuMP8vZYHxJ3wmb\n+ufRBKztPTQ/rYWaYQcgC0RWI20HTFBMxlTAyNxYNWzX7RKFkGVVyB9RsAtmcc8g\n+j4OdosbfNoJPS0HeIfNpAznDfHKdxDk2Yc1tV6RHBrC1ynyLE9+TaflIAdo2MVv\nKLMLq51GqYKtgJFIlBRPQqKoyXdz3fGvXrTkf/WY9QNq0J1Vk5ERePZ54mN8iZB7\n9lwy/AkCgYEA6FXzosxswaJ2wQLeoYc7ceaweX/SwTvxHgXzRyJIIT0eJWgx13Wo\n/WA3Iziimsjf6qE+SI/8laxPp2A86VMaIt3Z3mJN/CqSVGw8LK2AQst+OwdPyDMu\niacE8lj/IFGC8mwNUAb9CzGU3JpU4PxxGFjS/eMtGeRXCWkK4NE+G08CgYEA1Kp9\nN2JrVlqUz+gAX+LPmE9OEMAS9WQSQsfCHGogIFDGGcNf7+uwBM7GAaSJIP01zcoe\nVAgWdzXCv3FLhsaZoJ6RyLOLay5phbu1iaTr4UNYm5WtYTzMzqh8l1+MFFDl9xDB\nvULuCIIrglM5MeS/qnSg1uMoH2oVPj9TVst/ir8CgYEAxrI7Ws9Zc4Bt70N1As+U\nlySjaEVZCMkqvHJ6TCuVZFfQoE0r0whdLdRLU2PsLFP+q7qaeZQqgBaNSKeVcDYR\n9B+nY/jOmQoPewPVsp/vQTCnE/R81spu0mp0YI6cIheT1Z9zAy322svcc43JaWB7\nmEbeqyLOP4Z4qSOcmghZBSECgYACvR9Xs0DGn+wCsW4vze/2ei77MD4OQvepPIFX\ndFZtlBy5ADcgE9z0cuVB6CiL8DbdK5kwY9pGNr8HUCI03iHkW6Zs+0L0YmihfEVe\nPG19PSzK9CaDdhD9KFZSbLyVFmWfxOt50H7YRTTiPMgjyFpfi5j2q348yVT0tEQS\nfhRqaQKBgAcWPokmJ7EbYQGeMbS7HC8eWO/RyamlnSffdCdSc7ue3zdVJxpAkQ8W\nqu80pEIF6raIQfAf8MXiiZ7auFOSnHQTXUbhCpvDLKi0Mwq3G8Pl07l+2s6dQG6T\nlv6XTQaMyf6n1yjzL+fzDrH3qXMxHMO/b13EePXpDMpY7HQpoLDi\n-----END RSA PRIVATE KEY-----\n",
 	}
-	actual, err := client.UploadPerHostnameAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", clientCert)
+	actual, err := client.UploadPerHostnameAuthenticatedOriginPullsCertificate("023e105f4ecef8ad9ca31a8372d0c353", clientCert)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestGetPerHostnameAOPCertificate(t *testing.T) {
+func TestGetPerHostnameAuthenticatedOriginPullsCertificate(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -83,7 +83,7 @@ func TestGetPerHostnameAOPCertificate(t *testing.T) {
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
 
-	want := PerHostnameAOPCertificateDetails{
+	want := PerHostnameAuthenticatedOriginPullsCertificateDetails{
 		ID:           "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 		Certificate:  "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		Issuer:       "GlobalSign",
@@ -93,12 +93,12 @@ func TestGetPerHostnameAOPCertificate(t *testing.T) {
 		Status:       "active",
 		UploadedOn:   uploadedOn,
 	}
-	actual, err := client.GetPerHostnameAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	actual, err := client.GetPerHostnameAuthenticatedOriginPullsCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
-func TestDeletePerHostnameAOPCertificate(t *testing.T) {
+func TestDeletePerHostnameAuthenticatedOriginPullsCertificate(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -125,7 +125,7 @@ func TestDeletePerHostnameAOPCertificate(t *testing.T) {
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
 
-	want := PerHostnameAOPCertificateDetails{
+	want := PerHostnameAuthenticatedOriginPullsCertificateDetails{
 		ID:           "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 		Certificate:  "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		Issuer:       "GlobalSign",
@@ -135,13 +135,13 @@ func TestDeletePerHostnameAOPCertificate(t *testing.T) {
 		Status:       "active",
 		UploadedOn:   uploadedOn,
 	}
-	actual, err := client.DeletePerHostnameAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	actual, err := client.DeletePerHostnameAuthenticatedOriginPullsCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestEditPerHostnameAOPConfig(t *testing.T) {
+func TestEditPerHostnameAuthenticatedOriginPullsConfig(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -178,7 +178,7 @@ func TestEditPerHostnameAOPConfig(t *testing.T) {
 	certUpdatedAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 
-	want := []PerHostnameAOPDetails{
+	want := []PerHostnameAuthenticatedOriginPullsDetails{
 		{
 			Hostname:       "app.example.com",
 			CertID:         "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
@@ -197,20 +197,20 @@ func TestEditPerHostnameAOPConfig(t *testing.T) {
 		},
 	}
 
-	config := []PerHostnameAOPConfig{
+	config := []PerHostnameAuthenticatedOriginPullsConfig{
 		{
 			Hostname: "app.example.com",
 			CertID:   "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 			Enabled:  true,
 		},
 	}
-	actual, err := client.EditPerHostnameAOPConfig("023e105f4ecef8ad9ca31a8372d0c353", config)
+	actual, err := client.EditPerHostnameAuthenticatedOriginPullsConfig("023e105f4ecef8ad9ca31a8372d0c353", config)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestGetPerHostnameAOPConfig(t *testing.T) {
+func TestGetPerHostnameAuthenticatedOriginPullsConfig(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -245,7 +245,7 @@ func TestGetPerHostnameAOPConfig(t *testing.T) {
 	certUpdatedAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 
-	want := PerHostnameAOPDetails{
+	want := PerHostnameAuthenticatedOriginPullsDetails{
 		Hostname:       "app.example.com",
 		CertID:         "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 		Enabled:        true,
@@ -261,7 +261,7 @@ func TestGetPerHostnameAOPConfig(t *testing.T) {
 		CertUpdatedAt:  certUpdatedAt,
 		ExpiresOn:      expiresOn,
 	}
-	actual, err := client.GetPerHostnameAOPConfig("023e105f4ecef8ad9ca31a8372d0c353", "app.example.com")
+	actual, err := client.GetPerHostnameAuthenticatedOriginPullsConfig("023e105f4ecef8ad9ca31a8372d0c353", "app.example.com")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}

--- a/authenticated_origin_pulls_per_hostname_test.go
+++ b/authenticated_origin_pulls_per_hostname_test.go
@@ -1,0 +1,268 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUploadPerHostnameAOPCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			  "certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			  "issuer": "GlobalSign",
+			  "signature": "SHA256WithRSA",
+			  "serial_number": "6743787633689793699141714808227354901",
+			  "expires_on": "2100-01-01T05:20:00Z",
+			  "status": "active",
+			  "uploaded_on": "2019-10-28T18:11:23.37411Z"
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/hostnames/certificates", handler)
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+	want := PerHostnameAOPCertificateDetails{
+		ID:           "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+		Certificate:  "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		Issuer:       "GlobalSign",
+		Signature:    "SHA256WithRSA",
+		SerialNumber: "6743787633689793699141714808227354901",
+		ExpiresOn:    expiresOn,
+		Status:       "active",
+		UploadedOn:   uploadedOn,
+	}
+
+	clientCert := PerHostnameAOPCertificateParams{
+		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		PrivateKey:  "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmG\ndtcGbg/1CGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKn\nabIRuGvBKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpid\ntnKX/a+50GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+py\nFxIXjbEIdZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pE\newooaeO2izNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABAoIBACbhTYXBZYKmYPCb\nHBR1IBlCQA2nLGf0qRuJNJZg5iEzXows/6tc8YymZkQE7nolapWsQ+upk2y5Xdp/\naxiuprIs9JzkYK8Ox0r+dlwCG1kSW+UAbX0bQ/qUqlsTvU6muVuMP8vZYHxJ3wmb\n+ufRBKztPTQ/rYWaYQcgC0RWI20HTFBMxlTAyNxYNWzX7RKFkGVVyB9RsAtmcc8g\n+j4OdosbfNoJPS0HeIfNpAznDfHKdxDk2Yc1tV6RHBrC1ynyLE9+TaflIAdo2MVv\nKLMLq51GqYKtgJFIlBRPQqKoyXdz3fGvXrTkf/WY9QNq0J1Vk5ERePZ54mN8iZB7\n9lwy/AkCgYEA6FXzosxswaJ2wQLeoYc7ceaweX/SwTvxHgXzRyJIIT0eJWgx13Wo\n/WA3Iziimsjf6qE+SI/8laxPp2A86VMaIt3Z3mJN/CqSVGw8LK2AQst+OwdPyDMu\niacE8lj/IFGC8mwNUAb9CzGU3JpU4PxxGFjS/eMtGeRXCWkK4NE+G08CgYEA1Kp9\nN2JrVlqUz+gAX+LPmE9OEMAS9WQSQsfCHGogIFDGGcNf7+uwBM7GAaSJIP01zcoe\nVAgWdzXCv3FLhsaZoJ6RyLOLay5phbu1iaTr4UNYm5WtYTzMzqh8l1+MFFDl9xDB\nvULuCIIrglM5MeS/qnSg1uMoH2oVPj9TVst/ir8CgYEAxrI7Ws9Zc4Bt70N1As+U\nlySjaEVZCMkqvHJ6TCuVZFfQoE0r0whdLdRLU2PsLFP+q7qaeZQqgBaNSKeVcDYR\n9B+nY/jOmQoPewPVsp/vQTCnE/R81spu0mp0YI6cIheT1Z9zAy322svcc43JaWB7\nmEbeqyLOP4Z4qSOcmghZBSECgYACvR9Xs0DGn+wCsW4vze/2ei77MD4OQvepPIFX\ndFZtlBy5ADcgE9z0cuVB6CiL8DbdK5kwY9pGNr8HUCI03iHkW6Zs+0L0YmihfEVe\nPG19PSzK9CaDdhD9KFZSbLyVFmWfxOt50H7YRTTiPMgjyFpfi5j2q348yVT0tEQS\nfhRqaQKBgAcWPokmJ7EbYQGeMbS7HC8eWO/RyamlnSffdCdSc7ue3zdVJxpAkQ8W\nqu80pEIF6raIQfAf8MXiiZ7auFOSnHQTXUbhCpvDLKi0Mwq3G8Pl07l+2s6dQG6T\nlv6XTQaMyf6n1yjzL+fzDrH3qXMxHMO/b13EePXpDMpY7HQpoLDi\n-----END RSA PRIVATE KEY-----\n",
+	}
+	actual, err := client.UploadPerHostnameAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", clientCert)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetPerHostnameAOPCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			  "certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			  "issuer": "GlobalSign",
+			  "signature": "SHA256WithRSA",
+			  "serial_number": "6743787633689793699141714808227354901",
+			  "expires_on": "2100-01-01T05:20:00Z",
+			  "status": "active",
+			  "uploaded_on": "2019-10-28T18:11:23.37411Z"
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/hostnames/certificates/2458ce5a-0c35-4c7f-82c7-8e9487d3ff60", handler)
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+
+	want := PerHostnameAOPCertificateDetails{
+		ID:           "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+		Certificate:  "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		Issuer:       "GlobalSign",
+		Signature:    "SHA256WithRSA",
+		SerialNumber: "6743787633689793699141714808227354901",
+		ExpiresOn:    expiresOn,
+		Status:       "active",
+		UploadedOn:   uploadedOn,
+	}
+	actual, err := client.GetPerHostnameAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+func TestDeletePerHostnameAOPCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			  "certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			  "issuer": "GlobalSign",
+			  "signature": "SHA256WithRSA",
+			  "serial_number": "6743787633689793699141714808227354901",
+			  "expires_on": "2100-01-01T05:20:00Z",
+			  "status": "active",
+			  "uploaded_on": "2019-10-28T18:11:23.37411Z"
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/hostnames/certificates/2458ce5a-0c35-4c7f-82c7-8e9487d3ff60", handler)
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+
+	want := PerHostnameAOPCertificateDetails{
+		ID:           "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+		Certificate:  "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		Issuer:       "GlobalSign",
+		Signature:    "SHA256WithRSA",
+		SerialNumber: "6743787633689793699141714808227354901",
+		ExpiresOn:    expiresOn,
+		Status:       "active",
+		UploadedOn:   uploadedOn,
+	}
+	actual, err := client.DeletePerHostnameAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestEditPerHostnameAOPConfig(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+			  {
+				"hostname": "app.example.com",
+				"cert_id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+				"enabled": true,
+				"status": "active",
+				"created_at": "2100-01-01T05:20:00Z",
+				"updated_at": "2100-01-01T05:20:00Z",
+				"cert_status": "active",
+				"issuer": "GlobalSign",
+				"signature": "SHA256WithRSA",
+				"serial_number": "6743787633689793699141714808227354901",
+				"certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+				"cert_uploaded_on": "2019-10-28T18:11:23.37411Z",
+				"cert_updated_at": "2100-01-01T05:20:00Z",
+				"expires_on": "2100-01-01T05:20:00Z"
+			  }
+			]
+		  }`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/hostnames", handler)
+	createdAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	certUploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+	certUpdatedAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+
+	want := []PerHostnameAOPDetails{
+		{
+			Hostname:       "app.example.com",
+			CertID:         "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			Enabled:        true,
+			Status:         "active",
+			CreatedAt:      createdAt,
+			UpdatedAt:      updatedAt,
+			CertStatus:     "active",
+			Issuer:         "GlobalSign",
+			Signature:      "SHA256WithRSA",
+			SerialNumber:   "6743787633689793699141714808227354901",
+			Certificate:    "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			CertUploadedOn: certUploadedOn,
+			CertUpdatedAt:  certUpdatedAt,
+			ExpiresOn:      expiresOn,
+		},
+	}
+
+	config := []PerHostnameAOPConfig{
+		{
+			Hostname: "app.example.com",
+			CertID:   "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			Enabled:  true,
+		},
+	}
+	actual, err := client.EditPerHostnameAOPConfig("023e105f4ecef8ad9ca31a8372d0c353", config)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetPerHostnameAOPConfig(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "hostname": "app.example.com",
+			  "cert_id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			  "enabled": true,
+			  "status": "active",
+			  "created_at": "2100-01-01T05:20:00Z",
+			  "updated_at": "2100-01-01T05:20:00Z",
+			  "cert_status": "active",
+			  "issuer": "GlobalSign",
+			  "signature": "SHA256WithRSA",
+			  "serial_number": "6743787633689793699141714808227354901",
+			  "certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			  "cert_uploaded_on": "2019-10-28T18:11:23.37411Z",
+			  "cert_updated_at": "2100-01-01T05:20:00Z",
+			  "expires_on": "2100-01-01T05:20:00Z"
+			}
+		  }`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/hostnames/app.example.com", handler)
+	createdAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	certUploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+	certUpdatedAt, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+
+	want := PerHostnameAOPDetails{
+		Hostname:       "app.example.com",
+		CertID:         "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+		Enabled:        true,
+		Status:         "active",
+		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
+		CertStatus:     "active",
+		Issuer:         "GlobalSign",
+		Signature:      "SHA256WithRSA",
+		SerialNumber:   "6743787633689793699141714808227354901",
+		Certificate:    "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		CertUploadedOn: certUploadedOn,
+		CertUpdatedAt:  certUpdatedAt,
+		ExpiresOn:      expiresOn,
+	}
+	actual, err := client.GetPerHostnameAOPConfig("023e105f4ecef8ad9ca31a8372d0c353", "app.example.com")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}

--- a/authenticated_origin_pulls_per_zone.go
+++ b/authenticated_origin_pulls_per_zone.go
@@ -7,19 +7,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PerZoneAOPSettings represents the settings for Per Zone AOP.
-type PerZoneAOPSettings struct {
+// PerZoneAuthenticatedOriginPullsSettings represents the settings for Per Zone AuthenticatedOriginPulls.
+type PerZoneAuthenticatedOriginPullsSettings struct {
 	Enabled bool `json:"enabled"`
 }
 
-// PerZoneAOPSettingsResponse represents the response from the Per Zone AOP settings endpoint.
-type PerZoneAOPSettingsResponse struct {
+// PerZoneAuthenticatedOriginPullsSettingsResponse represents the response from the Per Zone AuthenticatedOriginPulls settings endpoint.
+type PerZoneAuthenticatedOriginPullsSettingsResponse struct {
 	Response
-	Result PerZoneAOPSettings `json:"result"`
+	Result PerZoneAuthenticatedOriginPullsSettings `json:"result"`
 }
 
-// PerZoneAOPCertificateDetails represents the metadata for a Per Zone AOP client certificate.
-type PerZoneAOPCertificateDetails struct {
+// PerZoneAuthenticatedOriginPullsCertificateDetails represents the metadata for a Per Zone AuthenticatedOriginPulls client certificate.
+type PerZoneAuthenticatedOriginPullsCertificateDetails struct {
 	ID          string    `json:"id"`
 	Certificate string    `json:"certificate"`
 	Issuer      string    `json:"issuer"`
@@ -29,44 +29,44 @@ type PerZoneAOPCertificateDetails struct {
 	UploadedOn  time.Time `json:"uploaded_on"`
 }
 
-// PerZoneAOPCertificateResponse represents the response from endpoints relating to creating and deleting a per zone AOP certificate.
-type PerZoneAOPCertificateResponse struct {
+// PerZoneAuthenticatedOriginPullsCertificateResponse represents the response from endpoints relating to creating and deleting a per zone AuthenticatedOriginPulls certificate.
+type PerZoneAuthenticatedOriginPullsCertificateResponse struct {
 	Response
-	Result PerZoneAOPCertificateDetails `json:"result"`
+	Result PerZoneAuthenticatedOriginPullsCertificateDetails `json:"result"`
 }
 
-// PerZoneAOPCertificatesResponse represents the response from the per zone AOP certificate list endpoint.
-type PerZoneAOPCertificatesResponse struct {
+// PerZoneAuthenticatedOriginPullsCertificatesResponse represents the response from the per zone AuthenticatedOriginPulls certificate list endpoint.
+type PerZoneAuthenticatedOriginPullsCertificatesResponse struct {
 	Response
-	Result []PerZoneAOPCertificateDetails `json:"result"`
+	Result []PerZoneAuthenticatedOriginPullsCertificateDetails `json:"result"`
 }
 
-// PerZoneAOPCertificateParams represents the required data related to the client certificate being uploaded to be used in Per Zone AOP.
-type PerZoneAOPCertificateParams struct {
+// PerZoneAuthenticatedOriginPullsCertificateParams represents the required data related to the client certificate being uploaded to be used in Per Zone AuthenticatedOriginPulls.
+type PerZoneAuthenticatedOriginPullsCertificateParams struct {
 	Certificate string `json:"certificate"`
 	PrivateKey  string `json:"private_key"`
 }
 
-// GetPerZoneAOPStatus returns whether per zone AOP is enabled or not. It is false by default.
+// GetPerZoneAuthenticatedOriginPullsStatus returns whether per zone AuthenticatedOriginPulls is enabled or not. It is false by default.
 //
 // API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-get-enablement-setting-for-zone
-func (api *API) GetPerZoneAOPStatus(zoneID string) (PerZoneAOPSettings, error) {
+func (api *API) GetPerZoneAuthenticatedOriginPullsStatus(zoneID string) (PerZoneAuthenticatedOriginPullsSettings, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/settings"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return PerZoneAOPSettings{}, errors.Wrap(err, errMakeRequestError)
+		return PerZoneAuthenticatedOriginPullsSettings{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerZoneAOPSettingsResponse
+	var r PerZoneAuthenticatedOriginPullsSettingsResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerZoneAOPSettings{}, errors.Wrap(err, errUnmarshalError)
+		return PerZoneAuthenticatedOriginPullsSettings{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// SetPerZoneAOPStatus will update whether Per Zone AOP is enabled for the zone.
+// SetPerZoneAuthenticatedOriginPullsStatus will update whether Per Zone AuthenticatedOriginPulls is enabled for the zone.
 //
 // API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-set-enablement-for-zone
-func (api *API) SetPerZoneAOPStatus(zoneID string, enable bool) (PerZoneAOPSettings, error) {
+func (api *API) SetPerZoneAuthenticatedOriginPullsStatus(zoneID string, enable bool) (PerZoneAuthenticatedOriginPullsSettings, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/settings"
 	params := struct {
 		Enabled bool `json:"enabled"`
@@ -75,75 +75,75 @@ func (api *API) SetPerZoneAOPStatus(zoneID string, enable bool) (PerZoneAOPSetti
 	}
 	res, err := api.makeRequest("PUT", uri, params)
 	if err != nil {
-		return PerZoneAOPSettings{}, errors.Wrap(err, errMakeRequestError)
+		return PerZoneAuthenticatedOriginPullsSettings{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerZoneAOPSettingsResponse
+	var r PerZoneAuthenticatedOriginPullsSettingsResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerZoneAOPSettings{}, errors.Wrap(err, errUnmarshalError)
+		return PerZoneAuthenticatedOriginPullsSettings{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// UploadPerZoneAOPCertificate will upload a provided client certificate and enable it to be used in all AOP requests for the zone.
+// UploadPerZoneAuthenticatedOriginPullsCertificate will upload a provided client certificate and enable it to be used in all AuthenticatedOriginPulls requests for the zone.
 //
 // API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-upload-certificate
-func (api *API) UploadPerZoneAOPCertificate(zoneID string, params PerZoneAOPCertificateParams) (PerZoneAOPCertificateDetails, error) {
+func (api *API) UploadPerZoneAuthenticatedOriginPullsCertificate(zoneID string, params PerZoneAuthenticatedOriginPullsCertificateParams) (PerZoneAuthenticatedOriginPullsCertificateDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth"
 	res, err := api.makeRequest("POST", uri, params)
 	if err != nil {
-		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+		return PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerZoneAOPCertificateResponse
+	var r PerZoneAuthenticatedOriginPullsCertificateResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+		return PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// ListPerZoneAOPCertificates returns a list of all user uploaded client certificates to Per Zone AOP.
+// ListPerZoneAuthenticatedOriginPullsCertificates returns a list of all user uploaded client certificates to Per Zone AuthenticatedOriginPulls.
 //
 // API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-list-certificates
-func (api *API) ListPerZoneAOPCertificates(zoneID string) ([]PerZoneAOPCertificateDetails, error) {
+func (api *API) ListPerZoneAuthenticatedOriginPullsCertificates(zoneID string) ([]PerZoneAuthenticatedOriginPullsCertificateDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth"
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return []PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+		return []PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerZoneAOPCertificatesResponse
+	var r PerZoneAuthenticatedOriginPullsCertificatesResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return []PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+		return []PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// GetPerZoneAOPCertificateDetails returns the metadata associated with a user uploaded client certificate to Per Zone AOP.
+// GetPerZoneAuthenticatedOriginPullsCertificateDetails returns the metadata associated with a user uploaded client certificate to Per Zone AuthenticatedOriginPulls.
 //
 // API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-get-certificate-details
-func (api *API) GetPerZoneAOPCertificateDetails(zoneID, certificateID string) (PerZoneAOPCertificateDetails, error) {
+func (api *API) GetPerZoneAuthenticatedOriginPullsCertificateDetails(zoneID, certificateID string) (PerZoneAuthenticatedOriginPullsCertificateDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/" + certificateID
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
-		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+		return PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerZoneAOPCertificateResponse
+	var r PerZoneAuthenticatedOriginPullsCertificateResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+		return PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }
 
-// DeletePerZoneAOPCertificate removes the specified client certificate from the edge.
+// DeletePerZoneAuthenticatedOriginPullsCertificate removes the specified client certificate from the edge.
 //
 // API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-delete-certificate
-func (api *API) DeletePerZoneAOPCertificate(zoneID, certificateID string) (PerZoneAOPCertificateDetails, error) {
+func (api *API) DeletePerZoneAuthenticatedOriginPullsCertificate(zoneID, certificateID string) (PerZoneAuthenticatedOriginPullsCertificateDetails, error) {
 	uri := "/zones/" + zoneID + "/origin_tls_client_auth/" + certificateID
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {
-		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+		return PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
 	}
-	var r PerZoneAOPCertificateResponse
+	var r PerZoneAuthenticatedOriginPullsCertificateResponse
 	if err := json.Unmarshal(res, &r); err != nil {
-		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+		return PerZoneAuthenticatedOriginPullsCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/authenticated_origin_pulls_per_zone.go
+++ b/authenticated_origin_pulls_per_zone.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// PerZoneAOPSettingsResponse represents the settings for Per Zone AOP.
+// PerZoneAOPSettings represents the settings for Per Zone AOP.
 type PerZoneAOPSettings struct {
 	Enabled bool `json:"enabled"`
 }

--- a/authenticated_origin_pulls_per_zone.go
+++ b/authenticated_origin_pulls_per_zone.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// PerZoneAOPSettingsResponse represents the settings for Per Zone AOP.
+type PerZoneAOPSettings struct {
+	Enabled bool `json:"enabled"`
+}
+
+// PerZoneAOPSettingsResponse represents the response from the Per Zone AOP settings endpoint.
+type PerZoneAOPSettingsResponse struct {
+	Response
+	Result PerZoneAOPSettings `json:"result"`
+}
+
+// PerZoneAOPCertificateDetails represents the metadata for a Per Zone AOP client certificate.
+type PerZoneAOPCertificateDetails struct {
+	ID          string    `json:"id"`
+	Certificate string    `json:"certificate"`
+	Issuer      string    `json:"issuer"`
+	Signature   string    `json:"signature"`
+	ExpiresOn   time.Time `json:"expires_on"`
+	Status      string    `json:"status"`
+	UploadedOn  time.Time `json:"uploaded_on"`
+}
+
+// PerZoneAOPCertificateResponse represents the response from endpoints relating to creating and deleting a per zone AOP certificate.
+type PerZoneAOPCertificateResponse struct {
+	Response
+	Result PerZoneAOPCertificateDetails `json:"result"`
+}
+
+// PerZoneAOPCertificatesResponse represents the response from the per zone AOP certificate list endpoint.
+type PerZoneAOPCertificatesResponse struct {
+	Response
+	Result []PerZoneAOPCertificateDetails `json:"result"`
+}
+
+// PerZoneAOPCertificateParams represents the required data related to the client certificate being uploaded to be used in Per Zone AOP.
+type PerZoneAOPCertificateParams struct {
+	Certificate string `json:"certificate"`
+	PrivateKey  string `json:"private_key"`
+}
+
+// GetPerZoneAOPStatus returns whether per zone AOP is enabled or not. It is false by default.
+//
+// API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-get-enablement-setting-for-zone
+func (api *API) GetPerZoneAOPStatus(zoneID string) (PerZoneAOPSettings, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/settings"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return PerZoneAOPSettings{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerZoneAOPSettingsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerZoneAOPSettings{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// SetPerZoneAOPStatus will update whether Per Zone AOP is enabled for the zone.
+//
+// API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-set-enablement-for-zone
+func (api *API) SetPerZoneAOPStatus(zoneID string, enable bool) (PerZoneAOPSettings, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/settings"
+	params := struct {
+		Enabled bool `json:"enabled"`
+	}{
+		Enabled: enable,
+	}
+	res, err := api.makeRequest("PUT", uri, params)
+	if err != nil {
+		return PerZoneAOPSettings{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerZoneAOPSettingsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerZoneAOPSettings{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// UploadPerZoneAOPCertificate will upload a provided client certificate and enable it to be used in all AOP requests for the zone.
+//
+// API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-upload-certificate
+func (api *API) UploadPerZoneAOPCertificate(zoneID string, params PerZoneAOPCertificateParams) (PerZoneAOPCertificateDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth"
+	res, err := api.makeRequest("POST", uri, params)
+	if err != nil {
+		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerZoneAOPCertificateResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListPerZoneAOPCertificates returns a list of all user uploaded client certificates to Per Zone AOP.
+//
+// API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-list-certificates
+func (api *API) ListPerZoneAOPCertificates(zoneID string) ([]PerZoneAOPCertificateDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerZoneAOPCertificatesResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return []PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// GetPerZoneAOPCertificateDetails returns the metadata associated with a user uploaded client certificate to Per Zone AOP.
+//
+// API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-get-certificate-details
+func (api *API) GetPerZoneAOPCertificateDetails(zoneID, certificateID string) (PerZoneAOPCertificateDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/" + certificateID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerZoneAOPCertificateResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeletePerZoneAOPCertificate removes the specified client certificate from the edge.
+//
+// API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-delete-certificate
+func (api *API) DeletePerZoneAOPCertificate(zoneID, certificateID string) (PerZoneAOPCertificateDetails, error) {
+	uri := "/zones/" + zoneID + "/origin_tls_client_auth/" + certificateID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PerZoneAOPCertificateResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return PerZoneAOPCertificateDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/authenticated_origin_pulls_per_zone_test.go
+++ b/authenticated_origin_pulls_per_zone_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetPerZoneAOPStatus(t *testing.T) {
+func TestGetPerZoneAuthenticatedOriginPullsStatus(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -25,16 +25,16 @@ func TestGetPerZoneAOPStatus(t *testing.T) {
 		  }`)
 	}
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/settings", handler)
-	want := PerZoneAOPSettings{
+	want := PerZoneAuthenticatedOriginPullsSettings{
 		Enabled: true,
 	}
-	actual, err := client.GetPerZoneAOPStatus("023e105f4ecef8ad9ca31a8372d0c353")
+	actual, err := client.GetPerZoneAuthenticatedOriginPullsStatus("023e105f4ecef8ad9ca31a8372d0c353")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestSetPerZoneAOPStatus(t *testing.T) {
+func TestSetPerZoneAuthenticatedOriginPullsStatus(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -50,16 +50,16 @@ func TestSetPerZoneAOPStatus(t *testing.T) {
 		}`)
 	}
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/settings", handler)
-	want := PerZoneAOPSettings{
+	want := PerZoneAuthenticatedOriginPullsSettings{
 		Enabled: true,
 	}
-	actual, err := client.SetPerZoneAOPStatus("023e105f4ecef8ad9ca31a8372d0c353", true)
+	actual, err := client.SetPerZoneAuthenticatedOriginPullsStatus("023e105f4ecef8ad9ca31a8372d0c353", true)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestUploadPerZoneAOPCertificate(t *testing.T) {
+func TestUploadPerZoneAuthenticatedOriginPullsCertificate(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -84,7 +84,7 @@ func TestUploadPerZoneAOPCertificate(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth", handler)
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
-	want := PerZoneAOPCertificateDetails{
+	want := PerZoneAuthenticatedOriginPullsCertificateDetails{
 		ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		Issuer:      "GlobalSign",
@@ -94,17 +94,17 @@ func TestUploadPerZoneAOPCertificate(t *testing.T) {
 		UploadedOn:  uploadedOn,
 	}
 
-	clientCert := PerZoneAOPCertificateParams{
+	clientCert := PerZoneAuthenticatedOriginPullsCertificateParams{
 		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		PrivateKey:  "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmG\ndtcGbg/1CGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKn\nabIRuGvBKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpid\ntnKX/a+50GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+py\nFxIXjbEIdZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pE\newooaeO2izNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABAoIBACbhTYXBZYKmYPCb\nHBR1IBlCQA2nLGf0qRuJNJZg5iEzXows/6tc8YymZkQE7nolapWsQ+upk2y5Xdp/\naxiuprIs9JzkYK8Ox0r+dlwCG1kSW+UAbX0bQ/qUqlsTvU6muVuMP8vZYHxJ3wmb\n+ufRBKztPTQ/rYWaYQcgC0RWI20HTFBMxlTAyNxYNWzX7RKFkGVVyB9RsAtmcc8g\n+j4OdosbfNoJPS0HeIfNpAznDfHKdxDk2Yc1tV6RHBrC1ynyLE9+TaflIAdo2MVv\nKLMLq51GqYKtgJFIlBRPQqKoyXdz3fGvXrTkf/WY9QNq0J1Vk5ERePZ54mN8iZB7\n9lwy/AkCgYEA6FXzosxswaJ2wQLeoYc7ceaweX/SwTvxHgXzRyJIIT0eJWgx13Wo\n/WA3Iziimsjf6qE+SI/8laxPp2A86VMaIt3Z3mJN/CqSVGw8LK2AQst+OwdPyDMu\niacE8lj/IFGC8mwNUAb9CzGU3JpU4PxxGFjS/eMtGeRXCWkK4NE+G08CgYEA1Kp9\nN2JrVlqUz+gAX+LPmE9OEMAS9WQSQsfCHGogIFDGGcNf7+uwBM7GAaSJIP01zcoe\nVAgWdzXCv3FLhsaZoJ6RyLOLay5phbu1iaTr4UNYm5WtYTzMzqh8l1+MFFDl9xDB\nvULuCIIrglM5MeS/qnSg1uMoH2oVPj9TVst/ir8CgYEAxrI7Ws9Zc4Bt70N1As+U\nlySjaEVZCMkqvHJ6TCuVZFfQoE0r0whdLdRLU2PsLFP+q7qaeZQqgBaNSKeVcDYR\n9B+nY/jOmQoPewPVsp/vQTCnE/R81spu0mp0YI6cIheT1Z9zAy322svcc43JaWB7\nmEbeqyLOP4Z4qSOcmghZBSECgYACvR9Xs0DGn+wCsW4vze/2ei77MD4OQvepPIFX\ndFZtlBy5ADcgE9z0cuVB6CiL8DbdK5kwY9pGNr8HUCI03iHkW6Zs+0L0YmihfEVe\nPG19PSzK9CaDdhD9KFZSbLyVFmWfxOt50H7YRTTiPMgjyFpfi5j2q348yVT0tEQS\nfhRqaQKBgAcWPokmJ7EbYQGeMbS7HC8eWO/RyamlnSffdCdSc7ue3zdVJxpAkQ8W\nqu80pEIF6raIQfAf8MXiiZ7auFOSnHQTXUbhCpvDLKi0Mwq3G8Pl07l+2s6dQG6T\nlv6XTQaMyf6n1yjzL+fzDrH3qXMxHMO/b13EePXpDMpY7HQpoLDi\n-----END RSA PRIVATE KEY-----\n",
 	}
-	actual, err := client.UploadPerZoneAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", clientCert)
+	actual, err := client.UploadPerZoneAuthenticatedOriginPullsCertificate("023e105f4ecef8ad9ca31a8372d0c353", clientCert)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestListPerZoneAOPCertificates(t *testing.T) {
+func TestListPerZoneAuthenticatedOriginPullsCertificates(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -131,7 +131,7 @@ func TestListPerZoneAOPCertificates(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth", handler)
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
-	want := []PerZoneAOPCertificateDetails{
+	want := []PerZoneAuthenticatedOriginPullsCertificateDetails{
 		{
 			ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 			Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
@@ -142,13 +142,13 @@ func TestListPerZoneAOPCertificates(t *testing.T) {
 			UploadedOn:  uploadedOn,
 		},
 	}
-	actual, err := client.ListPerZoneAOPCertificates("023e105f4ecef8ad9ca31a8372d0c353")
+	actual, err := client.ListPerZoneAuthenticatedOriginPullsCertificates("023e105f4ecef8ad9ca31a8372d0c353")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestGetPerZoneAOPCertificateDetails(t *testing.T) {
+func TestGetPerZoneAuthenticatedOriginPullsCertificateDetails(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -173,7 +173,7 @@ func TestGetPerZoneAOPCertificateDetails(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/2458ce5a-0c35-4c7f-82c7-8e9487d3ff60", handler)
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
-	want := PerZoneAOPCertificateDetails{
+	want := PerZoneAuthenticatedOriginPullsCertificateDetails{
 		ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		Issuer:      "GlobalSign",
@@ -182,13 +182,13 @@ func TestGetPerZoneAOPCertificateDetails(t *testing.T) {
 		Status:      "active",
 		UploadedOn:  uploadedOn,
 	}
-	actual, err := client.GetPerZoneAOPCertificateDetails("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	actual, err := client.GetPerZoneAuthenticatedOriginPullsCertificateDetails("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestDeletePerZoneAOPCertificate(t *testing.T) {
+func TestDeletePerZoneAuthenticatedOriginPullsCertificate(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -213,7 +213,7 @@ func TestDeletePerZoneAOPCertificate(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/2458ce5a-0c35-4c7f-82c7-8e9487d3ff60", handler)
 	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
 	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
-	want := PerZoneAOPCertificateDetails{
+	want := PerZoneAuthenticatedOriginPullsCertificateDetails{
 		ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
 		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
 		Issuer:      "GlobalSign",
@@ -222,7 +222,7 @@ func TestDeletePerZoneAOPCertificate(t *testing.T) {
 		Status:      "active",
 		UploadedOn:  uploadedOn,
 	}
-	actual, err := client.DeletePerZoneAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	actual, err := client.DeletePerZoneAuthenticatedOriginPullsCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}

--- a/authenticated_origin_pulls_per_zone_test.go
+++ b/authenticated_origin_pulls_per_zone_test.go
@@ -1,0 +1,229 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPerZoneAOPStatus(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "enabled": true
+			}
+		  }`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/settings", handler)
+	want := PerZoneAOPSettings{
+		Enabled: true,
+	}
+	actual, err := client.GetPerZoneAOPStatus("023e105f4ecef8ad9ca31a8372d0c353")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestSetPerZoneAOPStatus(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "enabled": true
+			}
+		}`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/settings", handler)
+	want := PerZoneAOPSettings{
+		Enabled: true,
+	}
+	actual, err := client.SetPerZoneAOPStatus("023e105f4ecef8ad9ca31a8372d0c353", true)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUploadPerZoneAOPCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			  "certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			  "issuer": "GlobalSign",
+			  "signature": "SHA256WithRSA",
+			  "expires_on": "2100-01-01T05:20:00Z",
+			  "status": "active",
+			  "uploaded_on": "2019-10-28T18:11:23.37411Z"
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth", handler)
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+	want := PerZoneAOPCertificateDetails{
+		ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		Issuer:      "GlobalSign",
+		Signature:   "SHA256WithRSA",
+		ExpiresOn:   expiresOn,
+		Status:      "active",
+		UploadedOn:  uploadedOn,
+	}
+
+	clientCert := PerZoneAOPCertificateParams{
+		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		PrivateKey:  "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmG\ndtcGbg/1CGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKn\nabIRuGvBKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpid\ntnKX/a+50GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+py\nFxIXjbEIdZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pE\newooaeO2izNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABAoIBACbhTYXBZYKmYPCb\nHBR1IBlCQA2nLGf0qRuJNJZg5iEzXows/6tc8YymZkQE7nolapWsQ+upk2y5Xdp/\naxiuprIs9JzkYK8Ox0r+dlwCG1kSW+UAbX0bQ/qUqlsTvU6muVuMP8vZYHxJ3wmb\n+ufRBKztPTQ/rYWaYQcgC0RWI20HTFBMxlTAyNxYNWzX7RKFkGVVyB9RsAtmcc8g\n+j4OdosbfNoJPS0HeIfNpAznDfHKdxDk2Yc1tV6RHBrC1ynyLE9+TaflIAdo2MVv\nKLMLq51GqYKtgJFIlBRPQqKoyXdz3fGvXrTkf/WY9QNq0J1Vk5ERePZ54mN8iZB7\n9lwy/AkCgYEA6FXzosxswaJ2wQLeoYc7ceaweX/SwTvxHgXzRyJIIT0eJWgx13Wo\n/WA3Iziimsjf6qE+SI/8laxPp2A86VMaIt3Z3mJN/CqSVGw8LK2AQst+OwdPyDMu\niacE8lj/IFGC8mwNUAb9CzGU3JpU4PxxGFjS/eMtGeRXCWkK4NE+G08CgYEA1Kp9\nN2JrVlqUz+gAX+LPmE9OEMAS9WQSQsfCHGogIFDGGcNf7+uwBM7GAaSJIP01zcoe\nVAgWdzXCv3FLhsaZoJ6RyLOLay5phbu1iaTr4UNYm5WtYTzMzqh8l1+MFFDl9xDB\nvULuCIIrglM5MeS/qnSg1uMoH2oVPj9TVst/ir8CgYEAxrI7Ws9Zc4Bt70N1As+U\nlySjaEVZCMkqvHJ6TCuVZFfQoE0r0whdLdRLU2PsLFP+q7qaeZQqgBaNSKeVcDYR\n9B+nY/jOmQoPewPVsp/vQTCnE/R81spu0mp0YI6cIheT1Z9zAy322svcc43JaWB7\nmEbeqyLOP4Z4qSOcmghZBSECgYACvR9Xs0DGn+wCsW4vze/2ei77MD4OQvepPIFX\ndFZtlBy5ADcgE9z0cuVB6CiL8DbdK5kwY9pGNr8HUCI03iHkW6Zs+0L0YmihfEVe\nPG19PSzK9CaDdhD9KFZSbLyVFmWfxOt50H7YRTTiPMgjyFpfi5j2q348yVT0tEQS\nfhRqaQKBgAcWPokmJ7EbYQGeMbS7HC8eWO/RyamlnSffdCdSc7ue3zdVJxpAkQ8W\nqu80pEIF6raIQfAf8MXiiZ7auFOSnHQTXUbhCpvDLKi0Mwq3G8Pl07l+2s6dQG6T\nlv6XTQaMyf6n1yjzL+fzDrH3qXMxHMO/b13EePXpDMpY7HQpoLDi\n-----END RSA PRIVATE KEY-----\n",
+	}
+	actual, err := client.UploadPerZoneAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", clientCert)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestListPerZoneAOPCertificates(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+			  {
+				"id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+				"certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+				"issuer": "GlobalSign",
+				"signature": "SHA256WithRSA",
+				"expires_on": "2100-01-01T05:20:00Z",
+				"status": "active",
+				"uploaded_on": "2019-10-28T18:11:23.37411Z"
+			  }
+			]
+		  }
+		`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth", handler)
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+	want := []PerZoneAOPCertificateDetails{
+		{
+			ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			Issuer:      "GlobalSign",
+			Signature:   "SHA256WithRSA",
+			ExpiresOn:   expiresOn,
+			Status:      "active",
+			UploadedOn:  uploadedOn,
+		},
+	}
+	actual, err := client.ListPerZoneAOPCertificates("023e105f4ecef8ad9ca31a8372d0c353")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetPerZoneAOPCertificateDetails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			  "certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			  "issuer": "GlobalSign",
+			  "signature": "SHA256WithRSA",
+			  "expires_on": "2100-01-01T05:20:00Z",
+			  "status": "active",
+			  "uploaded_on": "2019-10-28T18:11:23.37411Z"
+			}
+		  }		  
+		`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/2458ce5a-0c35-4c7f-82c7-8e9487d3ff60", handler)
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+	want := PerZoneAOPCertificateDetails{
+		ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		Issuer:      "GlobalSign",
+		Signature:   "SHA256WithRSA",
+		ExpiresOn:   expiresOn,
+		Status:      "active",
+		UploadedOn:  uploadedOn,
+	}
+	actual, err := client.GetPerZoneAOPCertificateDetails("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeletePerZoneAOPCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+			  "certificate": "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+			  "issuer": "GlobalSign",
+			  "signature": "SHA256WithRSA",
+			  "expires_on": "2100-01-01T05:20:00Z",
+			  "status": "active",
+			  "uploaded_on": "2019-10-28T18:11:23.37411Z"
+			}
+		  }		  
+		`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/origin_tls_client_auth/2458ce5a-0c35-4c7f-82c7-8e9487d3ff60", handler)
+	expiresOn, _ := time.Parse(time.RFC3339, "2100-01-01T05:20:00Z")
+	uploadedOn, _ := time.Parse(time.RFC3339, "2019-10-28T18:11:23.37411Z")
+	want := PerZoneAOPCertificateDetails{
+		ID:          "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
+		Certificate: "-----BEGIN CERTIFICATE-----\nMIIDtTCCAp2gAwIBAgIJAMHAwfXZ5/PWMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMTYwODI0MTY0MzAxWhcNMTYxMTIyMTY0MzAxWjBF\nMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAwQHoetcl9+5ikGzV6cMzWtWPJHqXT3wpbEkRU9Yz7lgvddmGdtcGbg/1\nCGZu0jJGkMoppoUo4c3dts3iwqRYmBikUP77wwY2QGmDZw2FvkJCJlKnabIRuGvB\nKwzESIXgKk2016aTP6/dAjEHyo6SeoK8lkIySUvK0fyOVlsiEsCmOpidtnKX/a+5\n0GjB79CJH4ER2lLVZnhePFR/zUOyPxZQQ4naHf7yu/b5jhO0f8fwt+pyFxIXjbEI\ndZliWRkRMtzrHOJIhrmJ2A1J7iOrirbbwillwjjNVUWPf3IJ3M12S9pEewooaeO2\nizNTERcG9HzAacbVRn2Y2SWIyT/18QIDAQABo4GnMIGkMB0GA1UdDgQWBBT/LbE4\n9rWf288N6sJA5BRb6FJIGDB1BgNVHSMEbjBsgBT/LbE49rWf288N6sJA5BRb6FJI\nGKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV\nBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAMHAwfXZ5/PWMAwGA1UdEwQF\nMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAHHFwl0tH0quUYZYO0dZYt4R7SJ0pCm2\n2satiyzHl4OnXcHDpekAo7/a09c6Lz6AU83cKy/+x3/djYHXWba7HpEu0dR3ugQP\nMlr4zrhd9xKZ0KZKiYmtJH+ak4OM4L3FbT0owUZPyjLSlhMtJVcoRp5CJsjAMBUG\nSvD8RX+T01wzox/Qb+lnnNnOlaWpqu8eoOenybxKp1a9ULzIVvN/LAcc+14vioFq\n2swRWtmocBAs8QR9n4uvbpiYvS8eYueDCWMM4fvFfBhaDZ3N9IbtySh3SpFdQDhw\nYbjM2rxXiyLGxB4Bol7QTv4zHif7Zt89FReT/NBy4rzaskDJY5L6xmY=\n-----END CERTIFICATE-----\n",
+		Issuer:      "GlobalSign",
+		Signature:   "SHA256WithRSA",
+		ExpiresOn:   expiresOn,
+		Status:      "active",
+		UploadedOn:  uploadedOn,
+	}
+	actual, err := client.DeletePerZoneAOPCertificate("023e105f4ecef8ad9ca31a8372d0c353", "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}

--- a/authenticated_origin_pulls_test.go
+++ b/authenticated_origin_pulls_test.go
@@ -1,0 +1,110 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAOPDetails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+		    "id": "tls_client_auth",
+		    "value": "on",
+		    "editable": true,
+		    "modified_on": "2014-01-01T05:20:00.12345Z"
+		  }
+		}`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/settings/tls_client_auth", handler)
+
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	want := AOP{
+		ID:         "tls_client_auth",
+		Value:      "on",
+		Editable:   true,
+		ModifiedOn: modifiedOn,
+	}
+
+	actual, err := client.GetAOPStatus("023e105f4ecef8ad9ca31a8372d0c353")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestSetAOPStatusEnabled(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "tls_client_auth",
+			  "value": "on",
+			  "editable": true,
+			  "modified_on": "2014-01-01T05:20:00.12345Z"
+			}
+		  }`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/settings/tls_client_auth", handler)
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	want := AOP{
+		ID:         "tls_client_auth",
+		Value:      "on",
+		Editable:   true,
+		ModifiedOn: modifiedOn,
+	}
+
+	actual, err := client.SetAOPStatus("023e105f4ecef8ad9ca31a8372d0c353", true)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestSetAOPStatusDisabled(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+			  "id": "tls_client_auth",
+			  "value": "off",
+			  "editable": true,
+			  "modified_on": "2014-01-01T05:20:00.12345Z"
+			}
+		  }`)
+	}
+	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/settings/tls_client_auth", handler)
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	want := AOP{
+		ID:         "tls_client_auth",
+		Value:      "off",
+		Editable:   true,
+		ModifiedOn: modifiedOn,
+	}
+
+	actual, err := client.SetAOPStatus("023e105f4ecef8ad9ca31a8372d0c353", false)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}

--- a/authenticated_origin_pulls_test.go
+++ b/authenticated_origin_pulls_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAOPDetails(t *testing.T) {
+func TestAuthenticatedOriginPullsDetails(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -30,20 +30,20 @@ func TestAOPDetails(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/settings/tls_client_auth", handler)
 
 	modifiedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
-	want := AOP{
+	want := AuthenticatedOriginPulls{
 		ID:         "tls_client_auth",
 		Value:      "on",
 		Editable:   true,
 		ModifiedOn: modifiedOn,
 	}
 
-	actual, err := client.GetAOPStatus("023e105f4ecef8ad9ca31a8372d0c353")
+	actual, err := client.GetAuthenticatedOriginPullsStatus("023e105f4ecef8ad9ca31a8372d0c353")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestSetAOPStatusEnabled(t *testing.T) {
+func TestSetAuthenticatedOriginPullsStatusEnabled(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -63,20 +63,20 @@ func TestSetAOPStatusEnabled(t *testing.T) {
 	}
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/settings/tls_client_auth", handler)
 	modifiedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
-	want := AOP{
+	want := AuthenticatedOriginPulls{
 		ID:         "tls_client_auth",
 		Value:      "on",
 		Editable:   true,
 		ModifiedOn: modifiedOn,
 	}
 
-	actual, err := client.SetAOPStatus("023e105f4ecef8ad9ca31a8372d0c353", true)
+	actual, err := client.SetAuthenticatedOriginPullsStatus("023e105f4ecef8ad9ca31a8372d0c353", true)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
-func TestSetAOPStatusDisabled(t *testing.T) {
+func TestSetAuthenticatedOriginPullsStatusDisabled(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -96,14 +96,14 @@ func TestSetAOPStatusDisabled(t *testing.T) {
 	}
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/settings/tls_client_auth", handler)
 	modifiedOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
-	want := AOP{
+	want := AuthenticatedOriginPulls{
 		ID:         "tls_client_auth",
 		Value:      "off",
 		Editable:   true,
 		ModifiedOn: modifiedOn,
 	}
 
-	actual, err := client.SetAOPStatus("023e105f4ecef8ad9ca31a8372d0c353", false)
+	actual, err := client.SetAuthenticatedOriginPullsStatus("023e105f4ecef8ad9ca31a8372d0c353", false)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}


### PR DESCRIPTION
This PR adds support for:
* Global Authenticated Origin Pulls (tls_client_auth)
* Per Zone Authenticated Origin Pulls
* Per Hostname Authenticated Origin Pulls

## Description

Closes #498 

## Has your change been tested?

See tests:
```
⌘ ~/d/cloudflare-go (dhaynespls/498-add-aop-support)> go test
PASS
ok  	github.com/cloudflare/cloudflare-go	0.328s
```

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
