### PR TITLE
Expose optional team field for Access GitHub group

### DIFF
--- a/access_group.go
+++ b/access_group.go
@@ -109,6 +109,7 @@ type AccessGroupGSuite struct {
 type AccessGroupGitHub struct {
 	GitHubOrganization struct {
 		Name               string `json:"name"`
+		Team               string `json:"team,omitempty"`
 		IdentityProviderID string `json:"identity_provider_id"`
 	} `json:"github-organization"`
 }


### PR DESCRIPTION
## Description

This change will enable an optional `team` field that the API currently allows. This field is used as an additional access filter for GitHub IdP policy rules.

## Has your change been tested?

There doesn't appear to be a test explicitly testing a GitHub access group, but here is a cURL request displaying the field:
```
curl --request POST \
  --url https://api.cloudflare.com/client/v4/zones/<ZONE_ID>/access/apps/<APP_ID>/policies \
  --header 'authorization: Bearer ************************' \
  --header 'content-type: application/json' \
  --header 'x-auth-email: ***********************' \
  --header 'x-auth-key: ********************' \
  --cookie __cfduid=*************************** \
  --data '{
        "name": "Test Policy",
        "precedence": 3,
        "decision": "allow",
        "include": [
                {
                        "github-organization": {
                                "name": "asdf-fans",
                                "team": "GitHub Team Test",
                                "identity_provider_id": "5babdbc0-8e92-43f4-a9bc-e1ef9e65a8fb"
                        }
                }
        ]
}'
{
  "result": {
    "created_at": "2020-07-19T20:22:20Z",
    "decision": "allow",
    "exclude": [],
    "id": "298c442d-2932-40b3-b73b-785f7f9724be",
    "include": [
      {
        "github-organization": {
          "identity_provider_id": "5babdbc0-8e92-43f4-a9bc-e1ef9e65a8fb",
          "id": "68509257",
          "name": "asdf-fans",
          "team": "GitHub Team Test"
        }
      }
    ],
    "name": "Test Policy",
    "precedence": 3,
    "require": [],
    "uid": "298c442d-2932-40b3-b73b-785f7f9724be",
    "updated_at": "2020-07-19T20:22:20Z"
  },
  "success": true,
  "errors": [],
  "messages": []
}
```

## Types of changes

What sort of change does your code introduce/modify?

- [X] New feature (non-breaking change which adds functionality)
