### PR TITLE
Support Spectrum applications with port ranges

### DIFF
--- a/spectrum.go
+++ b/spectrum.go
@@ -38,13 +38,15 @@ func (p *ProxyProtocol) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// SpectrumApplicationOriginPort defines a union of a single port or range of ports
 type SpectrumApplicationOriginPort struct {
 	Port, Start, End uint16
 }
 
+// ErrOriginPortInvalid is a common error for failing to parse a single port or port range
 var ErrOriginPortInvalid = errors.New("invalid origin port")
 
-func (p *SpectrumApplicationOriginPort) Parse(s string) error {
+func (p *SpectrumApplicationOriginPort) parse(s string) error {
 	switch split := strings.Split(s, "-"); len(split) {
 	case 1:
 		i, err := strconv.ParseUint(split[0], 10, 16)
@@ -72,6 +74,7 @@ func (p *SpectrumApplicationOriginPort) Parse(s string) error {
 	return nil
 }
 
+// UnmarshalJSON converts a byte slice into a single port or port range
 func (p *SpectrumApplicationOriginPort) UnmarshalJSON(b []byte) error {
 	var port interface{}
 	if err := json.Unmarshal(b, &port); err != nil {
@@ -82,7 +85,7 @@ func (p *SpectrumApplicationOriginPort) UnmarshalJSON(b []byte) error {
 	case float64:
 		p.Port = uint16(i)
 	case string:
-		if err := p.Parse(i); err != nil {
+		if err := p.parse(i); err != nil {
 			return err
 		}
 	}
@@ -90,12 +93,12 @@ func (p *SpectrumApplicationOriginPort) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON converts a single port or port range to a suitable byte slice
 func (p *SpectrumApplicationOriginPort) MarshalJSON() ([]byte, error) {
 	if p.End > 0 {
 		return json.Marshal(fmt.Sprintf("%d-%d", p.Start, p.End))
-	} else {
-		return json.Marshal(p.Port)
 	}
+	return json.Marshal(p.Port)
 }
 
 // SpectrumApplication defines a single Spectrum Application.

--- a/spectrum.go
+++ b/spectrum.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,23 +38,83 @@ func (p *ProxyProtocol) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type SpectrumApplicationOriginPort struct {
+	Port, Start, End uint16
+}
+
+var ErrOriginPortInvalid = errors.New("invalid origin port")
+
+func (p *SpectrumApplicationOriginPort) Parse(s string) error {
+	switch split := strings.Split(s, "-"); len(split) {
+	case 1:
+		i, err := strconv.ParseUint(split[0], 10, 16)
+		if err != nil {
+			return err
+		}
+		p.Port = uint16(i)
+	case 2:
+		start, err := strconv.ParseUint(split[0], 10, 16)
+		if err != nil {
+			return err
+		}
+		end, err := strconv.ParseUint(split[1], 10, 16)
+		if err != nil {
+			return err
+		}
+		if start >= end {
+			return ErrOriginPortInvalid
+		}
+		p.Start = uint16(start)
+		p.End = uint16(end)
+	default:
+		return ErrOriginPortInvalid
+	}
+	return nil
+}
+
+func (p *SpectrumApplicationOriginPort) UnmarshalJSON(b []byte) error {
+	var port interface{}
+	if err := json.Unmarshal(b, &port); err != nil {
+		return err
+	}
+
+	switch i := port.(type) {
+	case float64:
+		p.Port = uint16(i)
+	case string:
+		if err := p.Parse(i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *SpectrumApplicationOriginPort) MarshalJSON() ([]byte, error) {
+	if p.End > 0 {
+		return json.Marshal(fmt.Sprintf("%d-%d", p.Start, p.End))
+	} else {
+		return json.Marshal(p.Port)
+	}
+}
+
 // SpectrumApplication defines a single Spectrum Application.
 type SpectrumApplication struct {
-	ID               string                        `json:"id,omitempty"`
-	Protocol         string                        `json:"protocol,omitempty"`
-	IPv4             bool                          `json:"ipv4,omitempty"`
-	DNS              SpectrumApplicationDNS        `json:"dns,omitempty"`
-	OriginDirect     []string                      `json:"origin_direct,omitempty"`
-	OriginPort       int                           `json:"origin_port,omitempty"`
-	OriginDNS        *SpectrumApplicationOriginDNS `json:"origin_dns,omitempty"`
-	IPFirewall       bool                          `json:"ip_firewall,omitempty"`
-	ProxyProtocol    ProxyProtocol                 `json:"proxy_protocol,omitempty"`
-	TLS              string                        `json:"tls,omitempty"`
-	TrafficType      string                        `json:"traffic_type,omitempty"`
-	EdgeIPs          *SpectrumApplicationEdgeIPs   `json:"edge_ips,omitempty"`
-	ArgoSmartRouting bool                          `json:"argo_smart_routing,omitempty"`
-	CreatedOn        *time.Time                    `json:"created_on,omitempty"`
-	ModifiedOn       *time.Time                    `json:"modified_on,omitempty"`
+	ID               string                         `json:"id,omitempty"`
+	Protocol         string                         `json:"protocol,omitempty"`
+	IPv4             bool                           `json:"ipv4,omitempty"`
+	DNS              SpectrumApplicationDNS         `json:"dns,omitempty"`
+	OriginDirect     []string                       `json:"origin_direct,omitempty"`
+	OriginPort       *SpectrumApplicationOriginPort `json:"origin_port,omitempty"`
+	OriginDNS        *SpectrumApplicationOriginDNS  `json:"origin_dns,omitempty"`
+	IPFirewall       bool                           `json:"ip_firewall,omitempty"`
+	ProxyProtocol    ProxyProtocol                  `json:"proxy_protocol,omitempty"`
+	TLS              string                         `json:"tls,omitempty"`
+	TrafficType      string                         `json:"traffic_type,omitempty"`
+	EdgeIPs          *SpectrumApplicationEdgeIPs    `json:"edge_ips,omitempty"`
+	ArgoSmartRouting bool                           `json:"argo_smart_routing,omitempty"`
+	CreatedOn        *time.Time                     `json:"created_on,omitempty"`
+	ModifiedOn       *time.Time                     `json:"modified_on,omitempty"`
 }
 
 // UnmarshalJSON handles setting the `ProxyProtocol` field based on the value of the deprecated `spp` field.

--- a/spectrum_test.go
+++ b/spectrum_test.go
@@ -259,6 +259,7 @@ func TestCreateSpectrumApplication_OriginDNS(t *testing.T) {
 				"origin_dns": {
 					"name" : "spectrum.origin.example.com"
 				},
+				"origin_port": 2022,
 				"ip_firewall": true,
 				"proxy_protocol": "off",
 				"tls": "full",
@@ -285,6 +286,9 @@ func TestCreateSpectrumApplication_OriginDNS(t *testing.T) {
 		},
 		OriginDNS: &SpectrumApplicationOriginDNS{
 			Name: "spectrum.origin.example.com",
+		},
+		OriginPort: &SpectrumApplicationOriginPort{
+			Port: 2022,
 		},
 		IPFirewall:    true,
 		ProxyProtocol: "off",
@@ -454,6 +458,80 @@ func TestSpectrumApplicationEdgeIPs(t *testing.T) {
 			Type: "CNAME",
 		},
 		OriginDirect:  []string{"tcp://192.0.2.1:22"},
+		IPFirewall:    true,
+		ProxyProtocol: "off",
+		TLS:           "off",
+		EdgeIPs: &SpectrumApplicationEdgeIPs{
+			Type: SpectrumEdgeTypeStatic,
+			IPs:  []net.IP{net.ParseIP("192.0.2.1"), net.ParseIP("2001:db8::1")},
+		},
+	}
+
+	actual, err := client.SpectrumApplication("01a7362d577a6c3019a474fd6f485823", "f68579455bd947efb65ffa1bcf33b52c")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestSpectrumApplicationPortRange(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"id": "f68579455bd947efb65ffa1bcf33b52c",
+				"protocol": "tcp/22-23",
+				"ipv4": true,
+				"dns": {
+					"type": "CNAME",
+					"name": "spectrum.example.com"
+				},
+				"origin_dns": {
+				  "name": "cloudflare.com"
+				},
+				"origin_port": "2022-2023",
+				"ip_firewall": true,
+				"proxy_protocol": "off",
+				"tls": "off",
+				"edge_ips": {
+					"type": "static",
+					"ips": [
+						"192.0.2.1",
+						"2001:db8::1"
+					]
+				},
+				"created_on": "2018-03-28T21:25:55.643771Z",
+				"modified_on": "2018-03-28T21:25:55.643771Z"
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/zones/01a7362d577a6c3019a474fd6f485823/spectrum/apps/f68579455bd947efb65ffa1bcf33b52c", handler)
+	createdOn, _ := time.Parse(time.RFC3339, "2018-03-28T21:25:55.643771Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2018-03-28T21:25:55.643771Z")
+	want := SpectrumApplication{
+		ID:         "f68579455bd947efb65ffa1bcf33b52c",
+		CreatedOn:  &createdOn,
+		ModifiedOn: &modifiedOn,
+		Protocol:   "tcp/22-23",
+		IPv4:       true,
+		DNS: SpectrumApplicationDNS{
+			Name: "spectrum.example.com",
+			Type: "CNAME",
+		},
+		OriginDNS: &SpectrumApplicationOriginDNS{
+			Name: "cloudflare.com",
+		},
+		OriginPort: &SpectrumApplicationOriginPort{
+			Start: 2022,
+			End:   2023,
+		},
 		IPFirewall:    true,
 		ProxyProtocol: "off",
 		TLS:           "off",


### PR DESCRIPTION
See the Port Ranges section of https://developers.cloudflare.com/spectrum/getting-started/configuration-options/
The API docs should be updated at some point today.

## Description

Instead of having to create n spectrum applications to proxy an origin app that listens on n ports, you can now create a single spectrum application for the whole range.

## Has your change been tested?

The change was tested via the automated tests below and as part of the terraform plugin.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
