### PR TITLE
Add support for deleting CustomHostname Fallback Origins

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -258,6 +258,24 @@ func (api *API) UpdateCustomHostnameFallbackOrigin(zoneID string, chfo CustomHos
 	return response, nil
 }
 
+// DeleteCustomHostnameFallbackOrigin deletes the Custom Hostname Fallback origin in the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-fallback-origin-for-a-zone-delete-fallback-origin-for-custom-hostnames
+func (api *API) DeleteCustomHostnameFallbackOrigin(zoneID string) error {
+	uri := "/zones/" + zoneID + "/custom_hostnames/fallback_origin"
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response *CustomHostnameFallbackOriginResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}
+
 // CustomHostnameFallbackOrigin inspects the Custom Hostname Fallback origin in the given zone.
 //
 // API reference: https://api.cloudflare.com/#custom-hostname-fallback-origin-for-a-zone-properties

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -468,6 +468,26 @@ func TestCustomHostname_CustomHostnameFallbackOrigin(t *testing.T) {
 	}
 }
 
+func TestCustomHostname_DeleteCustomHostnameFallbackOrigin(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/zones/foo/custom_hostnames/fallback_origin", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "DELETE", r.Method, "Expected method 'DELETE', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `
+{
+  "id": "bar"
+}`)
+	})
+
+	err := client.DeleteCustomHostnameFallbackOrigin("foo")
+
+	assert.NoError(t, err)
+}
+
+
 func TestCustomHostname_UpdateCustomHostnameFallbackOrigin(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description

Adds support for deleting CustomHostname fallback origins.

Adding so it can be used within the Terraform Provider.

## Has your change been tested?

Added test code 

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
