### PR TITLE
Allow Specification of certificate_authority for Custom Hostnames

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -39,15 +39,16 @@ type CustomHostnameOwnershipVerification struct {
 
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
 type CustomHostnameSSL struct {
-	Status            string                    `json:"status,omitempty"`
-	Method            string                    `json:"method,omitempty"`
-	Type              string                    `json:"type,omitempty"`
-	CnameTarget       string                    `json:"cname_target,omitempty"`
-	CnameName         string                    `json:"cname,omitempty"`
-	Wildcard          bool                      `json:"wildcard,omitempty"`
-	CustomCertificate string                    `json:"custom_certificate,omitempty"`
-	CustomKey         string                    `json:"custom_key,omitempty"`
-	Settings          CustomHostnameSSLSettings `json:"settings,omitempty"`
+	Status               string                    `json:"status,omitempty"`
+	Method               string                    `json:"method,omitempty"`
+	Type                 string                    `json:"type,omitempty"`
+	CnameTarget          string                    `json:"cname_target,omitempty"`
+	CnameName            string                    `json:"cname,omitempty"`
+	Wildcard             bool                      `json:"wildcard,omitempty"`
+	CustomCertificate    string                    `json:"custom_certificate,omitempty"`
+	CustomKey            string                    `json:"custom_key,omitempty"`
+	CertificateAuthority string                    `json:"certificate_authority,omitempty"`
+	Settings             CustomHostnameSSLSettings `json:"settings,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudflare/cloudflare-go
+module github.com/Shopify/cloudflare-go
 
 go 1.11
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Shopify/cloudflare-go
+module github.com/cloudflare/cloudflare-go
 
 go 1.11
 


### PR DESCRIPTION
## Description

Allow clients to specify the `certificate_authority` field of the `ssl` parameter to the [Create Custom Hostname](https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname) endpoint.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.