### PR TITLE
Add support for audit log value change details

### DIFF
--- a/auditlogs.go
+++ b/auditlogs.go
@@ -35,15 +35,17 @@ type AuditLogResource struct {
 
 // AuditLog is an resource that represents an update in the cloudflare dash
 type AuditLog struct {
-	Action   AuditLogAction         `json:"action"`
-	Actor    AuditLogActor          `json:"actor"`
-	ID       string                 `json:"id"`
-	Metadata map[string]interface{} `json:"metadata"`
-	NewValue string                 `json:"newValue"`
-	OldValue string                 `json:"oldValue"`
-	Owner    AuditLogOwner          `json:"owner"`
-	Resource AuditLogResource       `json:"resource"`
-	When     time.Time              `json:"when"`
+	Action       AuditLogAction         `json:"action"`
+	Actor        AuditLogActor          `json:"actor"`
+	ID           string                 `json:"id"`
+	Metadata     map[string]interface{} `json:"metadata"`
+	NewValue     string                 `json:"newValue"`
+	NewValueJSON map[string]interface{} `json:"newValueJson"`
+	OldValue     string                 `json:"oldValue"`
+	OldValueJSON map[string]interface{} `json:"oldValueJson"`
+	Owner        AuditLogOwner          `json:"owner"`
+	Resource     AuditLogResource       `json:"resource"`
+	When         time.Time              `json:"when"`
 }
 
 // AuditLogResponse is the response returned from the cloudflare v4 api


### PR DESCRIPTION
## Description

This PR closes #513 (details and context are in the linked issue).

## Has your change been tested?

I tested my changes locally against my own zone. Output from using the library with the added struct fields:

```
	},
	"newValue": "",
	"newValueJson": {
		"content": "jamesejr.com",
		"id": "{{id}}",
		"name": "hello.jamesejr.com",
		"proxied": true,
		"ttl": 1,
		"type": "CNAME",
		"zone_id": "{{zone_id}}",
		"zone_name": "jamesejr.com"
	},
	"oldValue": "",
	"oldValueJson": null,
	"owner": {
```

I'm not sure if `newValue` and `oldValue` should be left there for backward compatibility.

I also ran `go test` to verify current tests pass:

```
PASS
ok  	github.com/cloudflare/cloudflare-go	0.349s
```

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
