### PR TITLE
Add missing fields to CustomHostname API model

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -37,18 +38,24 @@ type CustomHostnameOwnershipVerification struct {
 	Value string `json:"value,omitempty"`
 }
 
+//CustomHostnameSSLValidationErrors represents errors that occurred during SSL validation.
+type CustomHostnameSSLValidationErrors struct {
+	Message string `json:"message,omitempty"`
+}
+
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
 type CustomHostnameSSL struct {
-	Status               string                    `json:"status,omitempty"`
-	Method               string                    `json:"method,omitempty"`
-	Type                 string                    `json:"type,omitempty"`
-	CnameTarget          string                    `json:"cname_target,omitempty"`
-	CnameName            string                    `json:"cname,omitempty"`
-	Wildcard             bool                      `json:"wildcard,omitempty"`
-	CustomCertificate    string                    `json:"custom_certificate,omitempty"`
-	CustomKey            string                    `json:"custom_key,omitempty"`
-	CertificateAuthority string                    `json:"certificate_authority,omitempty"`
-	Settings             CustomHostnameSSLSettings `json:"settings,omitempty"`
+	Status               string                            `json:"status,omitempty"`
+	Method               string                            `json:"method,omitempty"`
+	Type                 string                            `json:"type,omitempty"`
+	CnameTarget          string                            `json:"cname_target,omitempty"`
+	CnameName            string                            `json:"cname,omitempty"`
+	Wildcard             bool                              `json:"wildcard,omitempty"`
+	CustomCertificate    string                            `json:"custom_certificate,omitempty"`
+	CustomKey            string                            `json:"custom_key,omitempty"`
+	CertificateAuthority string                            `json:"certificate_authority,omitempty"`
+	Settings             CustomHostnameSSLSettings         `json:"settings,omitempty"`
+	ValidationErrors     CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.
@@ -65,6 +72,7 @@ type CustomHostname struct {
 	VerificationErrors        []string                                `json:"verification_errors,omitempty"`
 	OwnershipVerification     CustomHostnameOwnershipVerification     `json:"ownership_verification,omitempty"`
 	OwnershipVerificationHTTP CustomHostnameOwnershipVerificationHTTP `json:"ownership_verification_http,omitempty"`
+	CreatedAt                 *time.Time                              `json:"created_at,omitempty"`
 }
 
 // CustomHostnameOwnershipVerificationHTTP represents a response from the Custom Hostnames endpoints.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -328,15 +328,15 @@ func TestCustomHostname_CustomHostname_WithSSLError(t *testing.T) {
 "success": true,
 "result": {
 	"id": "bar",
-	"hostname": "foo.bar.com",
+	"hostname": "example.com",
 	"ssl": {
 		"type": "dv",
 		"method": "cname",
 		"status": "pending_validation",
 		"cname_target": "dcv.digicert.com",
-		"cname": "810b7d5f01154524b961ba0cd578acc2.foo.bar.com",
+		"cname": "810b7d5f01154524b961ba0cd578acc2.example.com",
 		"validation_errors": {
-			"message": "SERVFAIL looking up CAA for foo.bar.com"
+			"message": "SERVFAIL looking up CAA for example.com"
 		}
 	},
 	"status": "pending",
@@ -344,7 +344,7 @@ func TestCustomHostname_CustomHostname_WithSSLError(t *testing.T) {
 		"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
 	],
 	"ownership_verification_http": {
-		"http_url": "http://custom.test.com/.well-known/cf-custom-hostname-challenge/0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+		"http_url": "http://example.com/.well-known/cf-custom-hostname-challenge/0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 		"http_body": "5cc07c04-ea62-4a5a-95f0-419334a875a4"
 	}
 }
@@ -355,15 +355,15 @@ func TestCustomHostname_CustomHostname_WithSSLError(t *testing.T) {
 
 	want := CustomHostname{
 		ID:       "bar",
-		Hostname: "foo.bar.com",
+		Hostname: "example.com",
 		SSL: CustomHostnameSSL{
 			Type:        "dv",
 			Method:      "cname",
 			Status:      "pending_validation",
-			CnameName:   "810b7d5f01154524b961ba0cd578acc2.foo.bar.com",
+			CnameName:   "810b7d5f01154524b961ba0cd578acc2.example.com",
 			CnameTarget: "dcv.digicert.com",
 			ValidationErrors: CustomHostnameSSLValidationErrors{
-				Message: "SERVFAIL looking up CAA for foo.bar.com",
+				Message: "SERVFAIL looking up CAA for example.com",
 			},
 		},
 		Status: PENDING,
@@ -371,7 +371,7 @@ func TestCustomHostname_CustomHostname_WithSSLError(t *testing.T) {
 			"by this account and the pre-generated ownership verification token was not found."},
 		OwnershipVerificationHTTP: CustomHostnameOwnershipVerificationHTTP{
 			HTTPBody: "5cc07c04-ea62-4a5a-95f0-419334a875a4",
-			HTTPUrl:  "http://custom.test.com/.well-known/cf-custom-hostname-challenge/0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+			HTTPUrl:  "http://example.com/.well-known/cf-custom-hostname-challenge/0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 		},
 	}
 


### PR DESCRIPTION
## Description

Our team will be using this API to manage and provision custom hostnames created through Cloudflare. The API models exposed in this package are missing a few fields that we need and that are mentioned in the [docs]([API](https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname))

## Has your change been tested?

Yes. I included a new test case for the new field in the SSL object and added appropriate changes to other tests to reflect the new `created_at` introduction.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
