### PR TITLE
diagnostics: Add support for traceroute

### DIFF
--- a/diagnostics.go
+++ b/diagnostics.go
@@ -1,0 +1,101 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// DiagnosticsTracerouteConfiguration is the overarching structure of the
+// diagnostics traceroute requests.
+type DiagnosticsTracerouteConfiguration struct {
+	Targets []string                                  `json:"targets"`
+	Colos   []string                                  `json:"colos"`
+	Options DiagnosticsTracerouteConfigurationOptions `json:"options,omitempty"`
+}
+
+// DiagnosticsTracerouteConfigurationOptions contains the options for performing
+// traceroutes.
+type DiagnosticsTracerouteConfigurationOptions struct {
+	PacketsPerTTL int    `json:"packets_per_ttl"`
+	PacketType    string `json:"packet_type"`
+	MaxTTL        int    `json:"max_ttl"`
+	WaitTime      int    `json:"wait_time"`
+}
+
+// DiagnosticsTracerouteResponse is the outer response of the API response.
+type DiagnosticsTracerouteResponse struct {
+	Response
+	Result []DiagnosticsTracerouteResponseResult `json:"result"`
+}
+
+// DiagnosticsTracerouteResponseResult is the inner API response for the
+// traceroute request.
+type DiagnosticsTracerouteResponseResult struct {
+	Target string                               `json:"target"`
+	Colos  []DiagnosticsTracerouteResponseColos `json:"colos"`
+}
+
+// DiagnosticsTracerouteResponseColo contains the Name and City of a colocation.
+type DiagnosticsTracerouteResponseColo struct {
+	Name string `json:"name"`
+	City string `json:"city"`
+}
+
+// DiagnosticsTracerouteResponseNodes holds a summary of nodes contacted in the
+// traceroute.
+type DiagnosticsTracerouteResponseNodes struct {
+	Asn             string  `json:"asn"`
+	IP              string  `json:"ip"`
+	Name            string  `json:"name"`
+	PacketCount     int     `json:"packet_count"`
+	MeanLatencyMs   float64 `json:"mean_latency_ms"`
+	StdDevLatencyMs float64 `json:"std_dev_latency_ms"`
+	MinLatencyMs    float64 `json:"min_latency_ms"`
+	MaxLatencyMs    float64 `json:"max_latency_ms"`
+}
+
+// DiagnosticsTracerouteResponseHops holds packet and node information of the
+// hops.
+type DiagnosticsTracerouteResponseHops struct {
+	PacketsTTL  int                                  `json:"packets_ttl"`
+	PacketsSent int                                  `json:"packets_sent"`
+	PacketsLost int                                  `json:"packets_lost"`
+	Nodes       []DiagnosticsTracerouteResponseNodes `json:"nodes"`
+}
+
+// DiagnosticsTracerouteResponseColos is the summary struct of a colocation test.
+type DiagnosticsTracerouteResponseColos struct {
+	Error            string                              `json:"error"`
+	Colo             DiagnosticsTracerouteResponseColo   `json:"colo"`
+	TracerouteTimeMs int                                 `json:"traceroute_time_ms"`
+	TargetSummary    DiagnosticsTracerouteResponseNodes  `json:"target_summary"`
+	Hops             []DiagnosticsTracerouteResponseHops `json:"hops"`
+}
+
+// PerformTraceroute initiates a traceroute from the Cloudflare network to the
+// requested targets.
+//
+// API documentation: https://api.cloudflare.com/#diagnostics-traceroute
+func (api *API) PerformTraceroute(accountID string, targets, colos []string, tracerouteOptions DiagnosticsTracerouteConfigurationOptions) ([]DiagnosticsTracerouteResponseResult, error) {
+	uri := "/accounts/" + accountID + "/diagnostics/traceroute"
+	diagnosticsPayload := DiagnosticsTracerouteConfiguration{
+		Targets: targets,
+		Colos:   colos,
+		Options: tracerouteOptions,
+	}
+
+	res, err := api.makeRequest(http.MethodPost, uri, diagnosticsPayload)
+	if err != nil {
+		return []DiagnosticsTracerouteResponseResult{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var diagnosticsResponse DiagnosticsTracerouteResponse
+	err = json.Unmarshal(res, &diagnosticsResponse)
+	if err != nil {
+		return []DiagnosticsTracerouteResponseResult{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return diagnosticsResponse.Result, nil
+}

--- a/diagnostics_test.go
+++ b/diagnostics_test.go
@@ -1,0 +1,116 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiagnosticsPerformTraceroute(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `
+		{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+    {
+      "target": "1.1.1.1",
+      "colos": [
+        {
+          "error": "",
+          "colo": {
+            "name": "den01",
+            "city": "Denver, CO, US"
+          },
+          "traceroute_time_ms": 969,
+          "target_summary": {
+            "asn": "",
+            "ip": "1.1.1.1",
+            "name": "1.1.1.1",
+            "packet_count": 3,
+            "mean_latency_ms": 0.021,
+            "std_dev_latency_ms": 0.011269427669584647,
+            "min_latency_ms": 0.014,
+            "max_latency_ms": 0.034
+          },
+          "hops": [
+            {
+              "packets_ttl": 1,
+              "packets_sent": 3,
+              "packets_lost": 0,
+              "nodes": [
+                {
+                  "asn": "AS13335",
+                  "ip": "1.1.1.1",
+                  "name": "one.one.one.one",
+                  "packet_count": 3,
+                  "mean_latency_ms": 0.021,
+                  "std_dev_latency_ms": 0.011269427669584647,
+                  "min_latency_ms": 0.014,
+                  "max_latency_ms": 0.034
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/diagnostics/traceroute", handler)
+
+	want := []DiagnosticsTracerouteResponseResult{{
+		Target: "1.1.1.1",
+		Colos: []DiagnosticsTracerouteResponseColos{{
+			Error: "",
+			Colo: DiagnosticsTracerouteResponseColo{
+				Name: "den01", City: "Denver, CO, US",
+			},
+			TracerouteTimeMs: 969,
+			TargetSummary: DiagnosticsTracerouteResponseNodes{
+				Asn:             "",
+				IP:              "1.1.1.1",
+				Name:            "1.1.1.1",
+				PacketCount:     3,
+				MeanLatencyMs:   0.021,
+				StdDevLatencyMs: 0.011269427669584647,
+				MinLatencyMs:    0.014,
+				MaxLatencyMs:    0.034,
+			},
+			Hops: []DiagnosticsTracerouteResponseHops{{
+				PacketsTTL:  1,
+				PacketsSent: 3,
+				PacketsLost: 0,
+				Nodes: []DiagnosticsTracerouteResponseNodes{{
+					Asn:             "AS13335",
+					IP:              "1.1.1.1",
+					Name:            "one.one.one.one",
+					PacketCount:     3,
+					MeanLatencyMs:   0.021,
+					StdDevLatencyMs: 0.011269427669584647,
+					MinLatencyMs:    0.014,
+					MaxLatencyMs:    0.034,
+				}},
+			}},
+		}},
+	},
+	}
+
+	opts := DiagnosticsTracerouteConfigurationOptions{PacketsPerTTL: 1, PacketType: "imcp", MaxTTL: 1, WaitTime: 1}
+	trace, err := client.PerformTraceroute("01a7362d577a6c3019a474fd6f485823", []string{"1.1.1.1"}, []string{"den01"}, opts)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, trace)
+	}
+}


### PR DESCRIPTION
Adds support for initiating a traceroute using the Cloudflare network to
the specified targets.

API documentation: https://api.cloudflare.com/#diagnostics-traceroute