### PR TITLE
diagnostics: `s/latency/rtt`

### DIFF
--- a/diagnostics.go
+++ b/diagnostics.go
@@ -46,14 +46,14 @@ type DiagnosticsTracerouteResponseColo struct {
 // DiagnosticsTracerouteResponseNodes holds a summary of nodes contacted in the
 // traceroute.
 type DiagnosticsTracerouteResponseNodes struct {
-	Asn             string  `json:"asn"`
-	IP              string  `json:"ip"`
-	Name            string  `json:"name"`
-	PacketCount     int     `json:"packet_count"`
-	MeanLatencyMs   float64 `json:"mean_latency_ms"`
-	StdDevLatencyMs float64 `json:"std_dev_latency_ms"`
-	MinLatencyMs    float64 `json:"min_latency_ms"`
-	MaxLatencyMs    float64 `json:"max_latency_ms"`
+	Asn         string  `json:"asn"`
+	IP          string  `json:"ip"`
+	Name        string  `json:"name"`
+	PacketCount int     `json:"packet_count"`
+	MeanRttMs   float64 `json:"mean_rtt_ms"`
+	StdDevRttMs float64 `json:"std_dev_rtt_ms"`
+	MinRttMs    float64 `json:"min_rtt_ms"`
+	MaxRttMs    float64 `json:"max_rtt_ms"`
 }
 
 // DiagnosticsTracerouteResponseHops holds packet and node information of the

--- a/diagnostics_test.go
+++ b/diagnostics_test.go
@@ -36,10 +36,10 @@ func TestDiagnosticsPerformTraceroute(t *testing.T) {
             "ip": "1.1.1.1",
             "name": "1.1.1.1",
             "packet_count": 3,
-            "mean_latency_ms": 0.021,
-            "std_dev_latency_ms": 0.011269427669584647,
-            "min_latency_ms": 0.014,
-            "max_latency_ms": 0.034
+            "mean_rtt_ms": 0.021,
+            "std_dev_rtt_ms": 0.011269427669584647,
+            "min_rtt_ms": 0.014,
+            "max_rtt_ms": 0.034
           },
           "hops": [
             {
@@ -52,10 +52,10 @@ func TestDiagnosticsPerformTraceroute(t *testing.T) {
                   "ip": "1.1.1.1",
                   "name": "one.one.one.one",
                   "packet_count": 3,
-                  "mean_latency_ms": 0.021,
-                  "std_dev_latency_ms": 0.011269427669584647,
-                  "min_latency_ms": 0.014,
-                  "max_latency_ms": 0.034
+                  "mean_rtt_ms": 0.021,
+                  "std_dev_rtt_ms": 0.011269427669584647,
+                  "min_rtt_ms": 0.014,
+                  "max_rtt_ms": 0.034
                 }
               ]
             }
@@ -79,28 +79,28 @@ func TestDiagnosticsPerformTraceroute(t *testing.T) {
 			},
 			TracerouteTimeMs: 969,
 			TargetSummary: DiagnosticsTracerouteResponseNodes{
-				Asn:             "",
-				IP:              "1.1.1.1",
-				Name:            "1.1.1.1",
-				PacketCount:     3,
-				MeanLatencyMs:   0.021,
-				StdDevLatencyMs: 0.011269427669584647,
-				MinLatencyMs:    0.014,
-				MaxLatencyMs:    0.034,
+				Asn:         "",
+				IP:          "1.1.1.1",
+				Name:        "1.1.1.1",
+				PacketCount: 3,
+				MeanRttMs:   0.021,
+				StdDevRttMs: 0.011269427669584647,
+				MinRttMs:    0.014,
+				MaxRttMs:    0.034,
 			},
 			Hops: []DiagnosticsTracerouteResponseHops{{
 				PacketsTTL:  1,
 				PacketsSent: 3,
 				PacketsLost: 0,
 				Nodes: []DiagnosticsTracerouteResponseNodes{{
-					Asn:             "AS13335",
-					IP:              "1.1.1.1",
-					Name:            "one.one.one.one",
-					PacketCount:     3,
-					MeanLatencyMs:   0.021,
-					StdDevLatencyMs: 0.011269427669584647,
-					MinLatencyMs:    0.014,
-					MaxLatencyMs:    0.034,
+					Asn:         "AS13335",
+					IP:          "1.1.1.1",
+					Name:        "one.one.one.one",
+					PacketCount: 3,
+					MeanRttMs:   0.021,
+					StdDevRttMs: 0.011269427669584647,
+					MinRttMs:    0.014,
+					MaxRttMs:    0.034,
 				}},
 			}},
 		}},


### PR DESCRIPTION
The documentation for this endpoint mentions "latency" in place of "rtt"
however the actual responses use the latter.

I've raised 1961060 to get the public documentation updated to reflect
the actual responses.