### PR TITLE
Add `ID` to `CertificatePackAdvancedCertificate`

### DIFF
--- a/certificate_packs.go
+++ b/certificate_packs.go
@@ -50,6 +50,7 @@ type CertificatePackRequest struct {
 // CertificatePackAdvancedCertificate is the structure of the advanced
 // certificate pack certificate.
 type CertificatePackAdvancedCertificate struct {
+	ID                   string   `json:"id"`
 	Type                 string   `json:"type"`
 	Hosts                []string `json:"hosts"`
 	ValidationMethod     string   `json:"validation_method"`

--- a/certificate_packs_test.go
+++ b/certificate_packs_test.go
@@ -232,6 +232,7 @@ func TestCreateAdvancedCertificatePack(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs/order", handler)
 
 	certificate := CertificatePackAdvancedCertificate{
+		ID:                   "3822ff90-ea29-44df-9e55-21300bb9419b",
 		Type:                 "advanced",
 		Hosts:                []string{"example.com", "*.example.com", "www.example.com"},
 		ValidityDays:         365,
@@ -278,6 +279,7 @@ func TestRestartAdvancedCertificateValidation(t *testing.T) {
 	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b", handler)
 
 	certificate := CertificatePackAdvancedCertificate{
+		ID:                   "3822ff90-ea29-44df-9e55-21300bb9419b",
 		Type:                 "advanced",
 		Hosts:                []string{"example.com", "*.example.com", "www.example.com"},
 		ValidityDays:         365,


### PR DESCRIPTION
This wasn't intentionally required however for
cloudflare/terraform-provider-cloudflare#778 to work , this is now.