### PR TITLE
Swap `Response` for custom fields

### DIFF
--- a/diagnostics.go
+++ b/diagnostics.go
@@ -26,8 +26,10 @@ type DiagnosticsTracerouteConfigurationOptions struct {
 
 // DiagnosticsTracerouteResponse is the outer response of the API response.
 type DiagnosticsTracerouteResponse struct {
-	Response
-	Result []DiagnosticsTracerouteResponseResult `json:"result"`
+	Success  bool                                  `json:"success"`
+	Errors   []string                              `json:"errors"`
+	Messages []string                              `json:"messages"`
+	Result   []DiagnosticsTracerouteResponseResult `json:"result"`
 }
 
 // DiagnosticsTracerouteResponseResult is the inner API response for the


### PR DESCRIPTION
While building out a tool to implement traceroutes via CLI
([cf-traceroute](https://github.com/jacobbednarz/cf-traceroute) if you're interested), I was getting misleading output
when trying to perform a trace on a domain which doesn't resolve. After
a bit of a debugging session, I found the smoking gun.

```
(*json.UnmarshalTypeError)(0xc00010e3c0)(json: cannot unmarshal string into Go struct field DiagnosticsTracerouteResponse.messages of type cloudflare.ResponseInfo)
```

Diving further again, `DiagnosticsTracerouteResponse` is using the
`Response` struct which has a `Messages` field however the API response
from the diagnostics endpoints *don't* have the `code` field and it's
failing to unmarshal the response causing a failure.

```
{
  "result": [
    // snip
  ],
  "success": true,
  "errors": [],
  "messages": [
    "Some traceroute results were unsuccessful. See error message in traceroute results"
  ]
}
```

The diagnostics endpoint only has a string for the error, no code
associated with it.

To address this, I've duplicated the fields out of the `Response` struct
to reflect the actual values we're seeing and unmarshalling no longer
chokes on it.