### PR TITLE
fix: Set context for requests properly

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -293,7 +293,7 @@ func (api *API) request(ctx context.Context, method, uri string, reqBody io.Read
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request creation failed")
 	}
-	req.WithContext(ctx)
+	req = req.WithContext(ctx)
 
 	combinedHeaders := make(http.Header)
 	copyHeader(combinedHeaders, api.headers)

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -289,11 +289,10 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, u
 // *http.Response, or an error if one occurred. The caller is responsible for
 // closing the response body.
 func (api *API) request(ctx context.Context, method, uri string, reqBody io.Reader, authType int, headers http.Header) (*http.Response, error) {
-	req, err := http.NewRequest(method, api.BaseURL+uri, reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, api.BaseURL+uri, reqBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "HTTP request creation failed")
 	}
-	req = req.WithContext(ctx)
 
 	combinedHeaders := make(http.Header)
 	copyHeader(combinedHeaders, api.headers)


### PR DESCRIPTION
## Description

`WithContext` does not mutate the request, and the returned `Request` value is ignored, so context for requests is never actually being set.

## Has your change been tested?

A regression test was added that ensure the context is properly passed. It failed prior to changes to the implementation.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.