### PR TITLE
Add enable_binding_cookie field to Access application

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -20,6 +20,7 @@ type AccessApplication struct {
 	Domain                 string                        `json:"domain"`
 	SessionDuration        string                        `json:"session_duration,omitempty"`
 	AutoRedirectToIdentity bool                          `json:"auto_redirect_to_identity,omitempty"`
+	EnableBindingCookie    bool                          `json:"enable_binding_cookie,omitempty"`
 	AllowedIdps            []string                      `json:"allowed_idps,omitempty"`
 	CorsHeaders            *AccessApplicationCorsHeaders `json:"cors_headers,omitempty"`
 }

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -30,7 +30,8 @@ func TestAccessApplications(t *testing.T) {
 					"domain": "test.example.com/admin",
 					"session_duration": "24h",
 					"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
-					"auto_redirect_to_identity": false
+					"auto_redirect_to_identity": false,
+					"enable_binding_cookie": false
 				}
 			],
 			"result_info": {
@@ -47,7 +48,7 @@ func TestAccessApplications(t *testing.T) {
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
-	want := []AccessApplication{AccessApplication{
+	want := []AccessApplication{{
 		ID:                     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
 		CreatedAt:              &createdAt,
 		UpdatedAt:              &updatedAt,
@@ -57,6 +58,7 @@ func TestAccessApplications(t *testing.T) {
 		SessionDuration:        "24h",
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
+		EnableBindingCookie:    false,
 	}}
 
 	actual, _, err := client.AccessApplications("01a7362d577a6c3019a474fd6f485823", PaginationOptions{})
@@ -86,7 +88,8 @@ func TestAccessApplication(t *testing.T) {
 				"domain": "test.example.com/admin",
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
-				"auto_redirect_to_identity": false
+				"auto_redirect_to_identity": false,
+				"enable_binding_cookie": false
 			}
 		}
 		`)
@@ -107,6 +110,7 @@ func TestAccessApplication(t *testing.T) {
 		SessionDuration:        "24h",
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
+		EnableBindingCookie:    false,
 	}
 
 	actual, err := client.AccessApplication("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
@@ -136,7 +140,8 @@ func TestCreateAccessApplications(t *testing.T) {
 				"domain": "test.example.com/admin",
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
-				"auto_redirect_to_identity": false
+				"auto_redirect_to_identity": false,
+				"enable_binding_cookie": false
 			}
 		}
 		`)
@@ -163,6 +168,7 @@ func TestCreateAccessApplications(t *testing.T) {
 		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
+		EnableBindingCookie:    false,
 		CreatedAt:              &createdAt,
 		UpdatedAt:              &updatedAt,
 	}
@@ -192,7 +198,8 @@ func TestUpdateAccessApplication(t *testing.T) {
 				"domain": "test.example.com/admin",
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
-				"auto_redirect_to_identity": false
+				"auto_redirect_to_identity": false,
+				"enable_binding_cookie": false
 			}
 		}
 		`)
@@ -210,6 +217,7 @@ func TestUpdateAccessApplication(t *testing.T) {
 		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
+		EnableBindingCookie:    false,
 		CreatedAt:              &createdAt,
 		UpdatedAt:              &updatedAt,
 	}


### PR DESCRIPTION
## Description

Adds the `enable_binding_cookie` field to Access applications. This optional field when enabled will provide increased security against compromised authorization tokens and CSRF attacks. Cloudflare's API documentation should be updated soon with the added changes as well. 

Related PR: https://github.com/cloudflare/terraform-provider-cloudflare/pull/802.

## Has your change been tested?

Here is a cURL request with the new field:
```
curl --request PUT \
  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/access/apps/<APP_ID> \
  --header 'authorization: Bearer <TOKEN>' \
  --header 'content-type: application/json' \
  --header 'x-auth-email: <EMAIL>' \
  --header 'x-auth-key: <KEY>' \
  --data '{
        "aud": REDACTED,
        "domain": "asdf.fans",
        "id": REDACTED,
        "name": "asdf-fans",
        "policies": [],
        "allowed_idps": [],
        "session_duration": "24h",
        "uid": REDACTED,
        "auto_redirect_to_identity": false,
        "enable_binding_cookie": true
}'
{
  "result": {
    "aud": REDACTED,
    "created_at": "2020-09-03T20:27:02Z",
    "domain": "asdf.fans",
    "id": REDACTED,
    "name": "asdf-fans",
    "policies": [],
    "allowed_idps": [],
    "auto_redirect_to_identity": false,
    "session_duration": "24h",
    "uid": REDACTED,
    "updated_at": "2020-09-17T17:46:02Z",
    "enable_binding_cookie": true
  },
  "success": true,
  "errors": [],
  "messages": []
}
```

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)