### PR TITLE
Add http_url and http_body ssl properties on CustomHostname when available from API response

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -56,6 +56,8 @@ type CustomHostnameSSL struct {
 	CertificateAuthority string                            `json:"certificate_authority,omitempty"`
 	Settings             CustomHostnameSSLSettings         `json:"settings,omitempty"`
 	ValidationErrors     CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
+	HTTPUrl              string                            `json:"http_url,omitempty"`
+	HTTPBody             string                            `json:"http_body,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -191,7 +191,9 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 				"method": "cname",
 				"status": "pending_validation",
 				"cname_target": "dcv.digicert.com",
-				"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com"
+				"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				"http_url": "http://app.example.com/.well-known/pki-validation/ca3-da12a1c25e7b48cf80408c6c1763b8a2.txt",
+      			"http_body": "ca3-574923932a82475cb8592200f1a2a23d"
 			},
 			"custom_metadata": {
 				"a_random_field": "random field value"
@@ -228,6 +230,8 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 				Status:      "pending_validation",
 				CnameTarget: "dcv.digicert.com",
 				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				HTTPUrl:     "http://app.example.com/.well-known/pki-validation/ca3-da12a1c25e7b48cf80408c6c1763b8a2.txt",
+				HTTPBody:    "ca3-574923932a82475cb8592200f1a2a23d",
 			},
 			CustomMetadata: CustomMetadata{"a_random_field": "random field value"},
 			Status:         PENDING,


### PR DESCRIPTION
## Description

This PR adds the `ssl.http_url` and `ssl.http_body` to deserialization of `CustomHostname` when they are available from the API.
These values are already returned by the API on the [`zones/:zone_identifier/custom_hostnames/:identifier` endpoint](https://api.cloudflare.com/#custom-hostname-for-a-zone-custom-hostname-details) on some conditions.

## Has your change been tested?

I've tested these changes with my fork and they work well.
Since they are only additional and optional properties during JSON de/serialization, they will not alter the overall code.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
