### PR TITLE
zone: allow `ListZonesContext` to automatically handle pagination

### DIFF
--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -333,7 +333,8 @@ func TestZoneIDByNameWithNonUniqueZonesWithoutOrgID(t *testing.T) {
 				"page": 1,
 				"per_page": 20,
 				"count": 1,
-				"total_count": 2000
+				"total_count": 2000,
+				"total_pages": 1
 			}
 		}
 		`)
@@ -470,7 +471,8 @@ func TestZoneIDByNameWithNonUniqueZonesWithOrgId(t *testing.T) {
 				"page": 1,
 				"per_page": 20,
 				"count": 1,
-				"total_count": 2000
+				"total_count": 2000,
+				"total_pages": 1
 			}
 		}
 		`)
@@ -609,7 +611,8 @@ func TestZoneIDByNameWithIDN(t *testing.T) {
 				"page": 1,
 				"per_page": 20,
 				"count": 1,
-				"total_count": 2000
+				"total_count": 2000,
+				"total_pages": 1
 			}
 		}
 		`)


### PR DESCRIPTION
Updates the `ListZonesContext` method to automatically handle the
pagination provided by the API response to return all zones regardless
of the number of entries.

This will fix cloudflare/terraform-provider-cloudflare#790 which uses
this functionality for filtering the data resource.

Fixes cloudflare/terraform-provider-cloudflare#790