### PR TITLE
ips: Add support for China colos

### DIFF
--- a/ips.go
+++ b/ips.go
@@ -10,8 +10,9 @@ import (
 
 // IPRanges contains lists of IPv4 and IPv6 CIDRs.
 type IPRanges struct {
-	IPv4CIDRs []string `json:"ipv4_cidrs"`
-	IPv6CIDRs []string `json:"ipv6_cidrs"`
+	IPv4CIDRs      []string `json:"ipv4_cidrs"`
+	IPv6CIDRs      []string `json:"ipv6_cidrs"`
+	ChinaColoCIDRs []string `json:"china_colos"`
 }
 
 // IPsResponse is the API response containing a list of IPs.
@@ -26,7 +27,7 @@ type IPsResponse struct {
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ips
 func IPs() (IPRanges, error) {
-	resp, err := http.Get(apiURL + "/ips")
+	resp, err := http.Get(apiURL + "/ips?china_colo=1")
 	if err != nil {
 		return IPRanges{}, errors.Wrap(err, "HTTP request failed")
 	}

--- a/ips_test.go
+++ b/ips_test.go
@@ -51,7 +51,8 @@ func Test_IPs(t *testing.T) {
   "messages": [],
   "result": {
     "ipv4_cidrs": ["199.27.128.0/21"],
-    "ipv6_cidrs": ["ffff:ffff::/32"]
+    "ipv6_cidrs": ["ffff:ffff::/32"],
+    "china_colos": ["42.81.6.0/25"]
   }
 }`)
 	})
@@ -64,4 +65,6 @@ func Test_IPs(t *testing.T) {
 	assert.Equal(t, "199.27.128.0/21", ipRanges.IPv4CIDRs[0])
 	assert.Len(t, ipRanges.IPv6CIDRs, 1)
 	assert.Equal(t, "ffff:ffff::/32", ipRanges.IPv6CIDRs[0])
+	assert.Len(t, ipRanges.ChinaColoCIDRs, 1)
+	assert.Equal(t, "42.81.6.0/25", ipRanges.ChinaColoCIDRs[0])
 }

--- a/ips_test.go
+++ b/ips_test.go
@@ -52,7 +52,7 @@ func Test_IPs(t *testing.T) {
   "result": {
     "ipv4_cidrs": ["199.27.128.0/21"],
     "ipv6_cidrs": ["ffff:ffff::/32"],
-    "china_colos": ["42.81.6.0/25"]
+    "china_colos": ["42.81.6.0/25", "2408:871a:1801:7::/72"]
   }
 }`)
 	})
@@ -65,6 +65,8 @@ func Test_IPs(t *testing.T) {
 	assert.Equal(t, "199.27.128.0/21", ipRanges.IPv4CIDRs[0])
 	assert.Len(t, ipRanges.IPv6CIDRs, 1)
 	assert.Equal(t, "ffff:ffff::/32", ipRanges.IPv6CIDRs[0])
-	assert.Len(t, ipRanges.ChinaColoCIDRs, 1)
-	assert.Equal(t, "42.81.6.0/25", ipRanges.ChinaColoCIDRs[0])
+	assert.Len(t, ipRanges.ChinaIPv4CIDRs, 1)
+	assert.Equal(t, "42.81.6.0/25", ipRanges.ChinaIPv4CIDRs[0])
+	assert.Len(t, ipRanges.ChinaIPv6CIDRs, 1)
+	assert.Equal(t, "2408:871a:1801:7::/72", ipRanges.ChinaIPv6CIDRs[0])
 }


### PR DESCRIPTION
Updates the methods to fetch the China colo CIDRs when querying the IPs.

Will unblock cloudflare/terraform-provider-cloudflare#809

Support ticket (1989094) has been raised to get the API documentation
updated to reflect this.