### PR TITLE
Match CustomHostname.SSL.VerificationErrors struct to actual API response

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -56,6 +56,8 @@ type CustomHostnameSSL struct {
 	CertificateAuthority string                            `json:"certificate_authority,omitempty"`
 	Settings             CustomHostnameSSLSettings         `json:"settings,omitempty"`
 	ValidationErrors     CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
+	HTTPUrl              string                            `json:"http_url,omitempty"`
+	HTTPBody             string                            `json:"http_body,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -45,19 +45,19 @@ type CustomHostnameSSLValidationErrors struct {
 
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
 type CustomHostnameSSL struct {
-	Status               string                            `json:"status,omitempty"`
-	Method               string                            `json:"method,omitempty"`
-	Type                 string                            `json:"type,omitempty"`
-	CnameTarget          string                            `json:"cname_target,omitempty"`
-	CnameName            string                            `json:"cname,omitempty"`
-	Wildcard             bool                              `json:"wildcard,omitempty"`
-	CustomCertificate    string                            `json:"custom_certificate,omitempty"`
-	CustomKey            string                            `json:"custom_key,omitempty"`
-	CertificateAuthority string                            `json:"certificate_authority,omitempty"`
-	Settings             CustomHostnameSSLSettings         `json:"settings,omitempty"`
-	ValidationErrors     CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
-	HTTPUrl              string                            `json:"http_url,omitempty"`
-	HTTPBody             string                            `json:"http_body,omitempty"`
+	Status               string                              `json:"status,omitempty"`
+	Method               string                              `json:"method,omitempty"`
+	Type                 string                              `json:"type,omitempty"`
+	CnameTarget          string                              `json:"cname_target,omitempty"`
+	CnameName            string                              `json:"cname,omitempty"`
+	Wildcard             bool                                `json:"wildcard,omitempty"`
+	CustomCertificate    string                              `json:"custom_certificate,omitempty"`
+	CustomKey            string                              `json:"custom_key,omitempty"`
+	CertificateAuthority string                              `json:"certificate_authority,omitempty"`
+	Settings             CustomHostnameSSLSettings           `json:"settings,omitempty"`
+	ValidationErrors     []CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
+	HTTPUrl              string                              `json:"http_url,omitempty"`
+	HTTPBody             string                              `json:"http_body,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -191,7 +191,9 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 				"method": "cname",
 				"status": "pending_validation",
 				"cname_target": "dcv.digicert.com",
-				"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com"
+				"cname": "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				"http_url": "http://app.example.com/.well-known/pki-validation/ca3-da12a1c25e7b48cf80408c6c1763b8a2.txt",
+      			"http_body": "ca3-574923932a82475cb8592200f1a2a23d"
 			},
 			"custom_metadata": {
 				"a_random_field": "random field value"
@@ -228,6 +230,8 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 				Status:      "pending_validation",
 				CnameTarget: "dcv.digicert.com",
 				CnameName:   "810b7d5f01154524b961ba0cd578acc2.app.example.com",
+				HTTPUrl:     "http://app.example.com/.well-known/pki-validation/ca3-da12a1c25e7b48cf80408c6c1763b8a2.txt",
+				HTTPBody:    "ca3-574923932a82475cb8592200f1a2a23d",
 			},
 			CustomMetadata: CustomMetadata{"a_random_field": "random field value"},
 			Status:         PENDING,

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -366,8 +366,10 @@ func TestCustomHostname_CustomHostname_WithSSLError(t *testing.T) {
 			Status:      "pending_validation",
 			CnameName:   "810b7d5f01154524b961ba0cd578acc2.example.com",
 			CnameTarget: "dcv.digicert.com",
-			ValidationErrors: CustomHostnameSSLValidationErrors{
-				Message: "SERVFAIL looking up CAA for example.com",
+			ValidationErrors: []CustomHostnameSSLValidationErrors{
+				CustomHostnameSSLValidationErrors{
+					Message: "SERVFAIL looking up CAA for example.com",
+				},
 			},
 		},
 		Status: PENDING,

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -339,9 +339,9 @@ func TestCustomHostname_CustomHostname_WithSSLError(t *testing.T) {
 		"status": "pending_validation",
 		"cname_target": "dcv.digicert.com",
 		"cname": "810b7d5f01154524b961ba0cd578acc2.example.com",
-		"validation_errors": {
+		"validation_errors": [{
 			"message": "SERVFAIL looking up CAA for example.com"
-		}
+		}]
 	},
 	"status": "pending",
 	"verification_errors": [

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200927032502-5d4f70055728 h1:5wtQIAulKU5AbLQOkjxl32UufnIOqgBX72pS0AV14H0=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
## Description

The [current API documentation for custom hostnames](https://api.cloudflare.com/#custom-hostname-for-a-zone-custom-hostname-details) in a zone states that the custom hostname `ssl.verification_errors` is an object with the type:

```ts
interface VerificationError {
  message: string;
}

interface CustomHostname {
  // ...
  ssl: {
    // ...
    verification_errors: VerificationError;
  }
}
```

However, after testing it in real conditions, the API actually returns an array of such objects:

```ts
interface CustomHostname {
  // ...
  ssl: {
    // ...
    verification_errors: VerificationError[];
  }
}
```

I encountered this error using cloudflare-go, which led to the following error:
```
error unmarshalling the JSON response: json: cannot unmarshal array into Go struct field
CustomHostnameSSL.result.ssl.validation_errors of type cloudflare.CustomHostnameSSLValidationErrors
```

This PR fixes the struct definition to properly deserialize the JSON response in this library.
I've also sent a support request to Cloudflare to ask for updating the documentation regarding this issue.

## Has your change been tested?

I've updated the existing test to match the actual response from the API.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
