### PR TITLE
Add support for zone-level Access routes

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -59,6 +59,17 @@ type AccessApplicationDetailResponse struct {
 //
 // API reference: https://api.cloudflare.com/#access-applications-list-access-applications
 func (api *API) AccessApplications(accountID string, pageOpts PaginationOptions) ([]AccessApplication, ResultInfo, error) {
+	return api.accessApplications(accountID, pageOpts, AccountRouteRoot)
+}
+
+// ZoneLevelAccessApplications returns all applications within an account.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-applications-list-access-applications
+func (api *API) ZoneLevelAccessApplications(zoneID string, pageOpts PaginationOptions) ([]AccessApplication, ResultInfo, error) {
+	return api.accessApplications(zoneID, pageOpts, ZoneRouteRoot)
+}
+
+func (api *API) accessApplications(id string, pageOpts PaginationOptions, routeRoot RouteRoot) ([]AccessApplication, ResultInfo, error) {
 	v := url.Values{}
 	if pageOpts.PerPage > 0 {
 		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
@@ -67,7 +78,7 @@ func (api *API) AccessApplications(accountID string, pageOpts PaginationOptions)
 		v.Set("page", strconv.Itoa(pageOpts.Page))
 	}
 
-	uri := "/accounts/" + accountID + "/access/apps"
+	uri := fmt.Sprintf("/%s/", routeRoot) + id + "/access/apps"
 	if len(v) > 0 {
 		uri = uri + "?" + v.Encode()
 	}
@@ -91,9 +102,22 @@ func (api *API) AccessApplications(accountID string, pageOpts PaginationOptions)
 //
 // API reference: https://api.cloudflare.com/#access-applications-access-applications-details
 func (api *API) AccessApplication(accountID, applicationID string) (AccessApplication, error) {
+	return api.accessApplication(accountID, applicationID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessApplication returns a single application based on the
+// application ID.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-applications-access-applications-details
+func (api *API) ZoneLevelAccessApplication(zoneID, applicationID string) (AccessApplication, error) {
+	return api.accessApplication(zoneID, applicationID, ZoneRouteRoot)
+}
+
+func (api *API) accessApplication(id, applicationID string, routeRoot RouteRoot) (AccessApplication, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s",
-		accountID,
+		"/%s/%s/access/apps/%s",
+		routeRoot,
+		id,
 		applicationID,
 	)
 
@@ -115,7 +139,18 @@ func (api *API) AccessApplication(accountID, applicationID string) (AccessApplic
 //
 // API reference: https://api.cloudflare.com/#access-applications-create-access-application
 func (api *API) CreateAccessApplication(accountID string, accessApplication AccessApplication) (AccessApplication, error) {
-	uri := "/accounts/" + accountID + "/access/apps"
+	return api.createAccessApplication(accountID, accessApplication, AccountRouteRoot)
+}
+
+// CreateZoneLevelAccessApplication creates a new access application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-applications-create-access-application
+func (api *API) CreateZoneLevelAccessApplication(zoneID string, accessApplication AccessApplication) (AccessApplication, error) {
+	return api.createAccessApplication(zoneID, accessApplication, ZoneRouteRoot)
+}
+
+func (api *API) createAccessApplication(id string, accessApplication AccessApplication, routeRoot RouteRoot) (AccessApplication, error) {
+	uri := fmt.Sprintf("/%s/%s/access/apps", routeRoot, id)
 
 	res, err := api.makeRequest("POST", uri, accessApplication)
 	if err != nil {
@@ -135,13 +170,25 @@ func (api *API) CreateAccessApplication(accountID string, accessApplication Acce
 //
 // API reference: https://api.cloudflare.com/#access-applications-update-access-application
 func (api *API) UpdateAccessApplication(accountID string, accessApplication AccessApplication) (AccessApplication, error) {
+	return api.updateAccessApplication(accountID, accessApplication, AccountRouteRoot)
+}
+
+// UpdateZoneLevelAccessApplication updates an existing access application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-applications-update-access-application
+func (api *API) UpdateZoneLevelAccessApplication(zoneID string, accessApplication AccessApplication) (AccessApplication, error) {
+	return api.updateAccessApplication(zoneID, accessApplication, ZoneRouteRoot)
+}
+
+func (api *API) updateAccessApplication(id string, accessApplication AccessApplication, routeRoot RouteRoot) (AccessApplication, error) {
 	if accessApplication.ID == "" {
 		return AccessApplication{}, errors.Errorf("access application ID cannot be empty")
 	}
 
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s",
-		accountID,
+		"/%s/%s/access/apps/%s",
+		routeRoot,
+		id,
 		accessApplication.ID,
 	)
 
@@ -163,9 +210,21 @@ func (api *API) UpdateAccessApplication(accountID string, accessApplication Acce
 //
 // API reference: https://api.cloudflare.com/#access-applications-delete-access-application
 func (api *API) DeleteAccessApplication(accountID, applicationID string) error {
+	return api.deleteAccessApplication(accountID, applicationID, AccountRouteRoot)
+}
+
+// DeleteZoneLevelAccessApplication deletes an access application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-applications-delete-access-application
+func (api *API) DeleteZoneLevelAccessApplication(zoneID, applicationID string) error {
+	return api.deleteAccessApplication(zoneID, applicationID, ZoneRouteRoot)
+}
+
+func (api *API) deleteAccessApplication(id, applicationID string, routeRoot RouteRoot) error {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s",
-		accountID,
+		"/%s/%s/access/apps/%s",
+		routeRoot,
+		id,
 		applicationID,
 	)
 
@@ -182,9 +241,22 @@ func (api *API) DeleteAccessApplication(accountID, applicationID string) error {
 //
 // API reference: https://api.cloudflare.com/#access-applications-revoke-access-tokens
 func (api *API) RevokeAccessApplicationTokens(accountID, applicationID string) error {
+	return api.revokeAccessApplicationTokens(accountID, applicationID, AccountRouteRoot)
+}
+
+// RevokeZoneLevelAccessApplicationTokens revokes tokens associated with an
+// access application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-applications-revoke-access-tokens
+func (api *API) RevokeZoneLevelAccessApplicationTokens(zoneID, applicationID string) error {
+	return api.revokeAccessApplicationTokens(zoneID, applicationID, ZoneRouteRoot)
+}
+
+func (api *API) revokeAccessApplicationTokens(id string, applicationID string, routeRoot RouteRoot) error {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/revoke-tokens",
-		accountID,
+		"/%s/%s/access/apps/%s/revoke-tokens",
+		routeRoot,
+		id,
 		applicationID,
 	)
 

--- a/access_application.go
+++ b/access_application.go
@@ -62,7 +62,7 @@ func (api *API) AccessApplications(accountID string, pageOpts PaginationOptions)
 	return api.accessApplications(accountID, pageOpts, AccountRouteRoot)
 }
 
-// ZoneLevelAccessApplications returns all applications within an account.
+// ZoneLevelAccessApplications returns all applications within a zone.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-applications-list-access-applications
 func (api *API) ZoneLevelAccessApplications(zoneID string, pageOpts PaginationOptions) ([]AccessApplication, ResultInfo, error) {
@@ -78,7 +78,7 @@ func (api *API) accessApplications(id string, pageOpts PaginationOptions, routeR
 		v.Set("page", strconv.Itoa(pageOpts.Page))
 	}
 
-	uri := fmt.Sprintf("/%s/", routeRoot) + id + "/access/apps"
+	uri := fmt.Sprintf("/%s/%s/access/apps", routeRoot, id)
 	if len(v) > 0 {
 		uri = uri + "?" + v.Encode()
 	}
@@ -105,7 +105,7 @@ func (api *API) AccessApplication(accountID, applicationID string) (AccessApplic
 	return api.accessApplication(accountID, applicationID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessApplication returns a single application based on the
+// ZoneLevelAccessApplication returns a single zone level application based on the
 // application ID.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-applications-access-applications-details
@@ -142,7 +142,7 @@ func (api *API) CreateAccessApplication(accountID string, accessApplication Acce
 	return api.createAccessApplication(accountID, accessApplication, AccountRouteRoot)
 }
 
-// CreateZoneLevelAccessApplication creates a new access application.
+// CreateZoneLevelAccessApplication creates a new zone level access application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-applications-create-access-application
 func (api *API) CreateZoneLevelAccessApplication(zoneID string, accessApplication AccessApplication) (AccessApplication, error) {
@@ -173,7 +173,7 @@ func (api *API) UpdateAccessApplication(accountID string, accessApplication Acce
 	return api.updateAccessApplication(accountID, accessApplication, AccountRouteRoot)
 }
 
-// UpdateZoneLevelAccessApplication updates an existing access application.
+// UpdateZoneLevelAccessApplication updates an existing zone level access application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-applications-update-access-application
 func (api *API) UpdateZoneLevelAccessApplication(zoneID string, accessApplication AccessApplication) (AccessApplication, error) {
@@ -213,7 +213,7 @@ func (api *API) DeleteAccessApplication(accountID, applicationID string) error {
 	return api.deleteAccessApplication(accountID, applicationID, AccountRouteRoot)
 }
 
-// DeleteZoneLevelAccessApplication deletes an access application.
+// DeleteZoneLevelAccessApplication deletes a zone level access application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-applications-delete-access-application
 func (api *API) DeleteZoneLevelAccessApplication(zoneID, applicationID string) error {
@@ -244,7 +244,7 @@ func (api *API) RevokeAccessApplicationTokens(accountID, applicationID string) e
 	return api.revokeAccessApplicationTokens(accountID, applicationID, AccountRouteRoot)
 }
 
-// RevokeZoneLevelAccessApplicationTokens revokes tokens associated with an
+// RevokeZoneLevelAccessApplicationTokens revokes tokens associated with a zone level
 // access application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-applications-revoke-access-tokens

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -44,7 +44,6 @@ func TestAccessApplications(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
@@ -61,7 +60,17 @@ func TestAccessApplications(t *testing.T) {
 		EnableBindingCookie:    false,
 	}}
 
-	actual, _, err := client.AccessApplications("01a7362d577a6c3019a474fd6f485823", PaginationOptions{})
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps", handler)
+
+	actual, _, err := client.AccessApplications(accountID, PaginationOptions{})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps", handler)
+
+	actual, _, err = client.ZoneLevelAccessApplications(zoneID, PaginationOptions{})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -95,8 +104,6 @@ func TestAccessApplication(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
-
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
@@ -113,7 +120,17 @@ func TestAccessApplication(t *testing.T) {
 		EnableBindingCookie:    false,
 	}
 
-	actual, err := client.AccessApplication("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err := client.AccessApplication(accountID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err = client.ZoneLevelAccessApplication(zoneID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -147,17 +164,6 @@ func TestCreateAccessApplications(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps", handler)
-
-	actual, err := client.CreateAccessApplication(
-		"01a7362d577a6c3019a474fd6f485823",
-		AccessApplication{
-			Name:            "Admin Site",
-			Domain:          "test.example.com/admin",
-			SessionDuration: "24h",
-		},
-	)
-
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	fullAccessApplication := AccessApplication{
@@ -172,6 +178,32 @@ func TestCreateAccessApplications(t *testing.T) {
 		CreatedAt:              &createdAt,
 		UpdatedAt:              &updatedAt,
 	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps", handler)
+
+	actual, err := client.CreateAccessApplication(
+		accountID,
+		AccessApplication{
+			Name:            "Admin Site",
+			Domain:          "test.example.com/admin",
+			SessionDuration: "24h",
+		},
+	)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fullAccessApplication, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps", handler)
+
+	actual, err = client.CreateZoneLevelAccessApplication(
+		zoneID,
+		AccessApplication{
+			Name:            "Admin Site",
+			Domain:          "test.example.com/admin",
+			SessionDuration: "24h",
+		},
+	)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, fullAccessApplication, actual)
@@ -205,8 +237,6 @@ func TestUpdateAccessApplication(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
-
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	fullAccessApplication := AccessApplication{
@@ -222,8 +252,21 @@ func TestUpdateAccessApplication(t *testing.T) {
 		UpdatedAt:              &updatedAt,
 	}
 
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
 	actual, err := client.UpdateAccessApplication(
-		"01a7362d577a6c3019a474fd6f485823",
+		accountID,
+		fullAccessApplication,
+	)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fullAccessApplication, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err = client.UpdateZoneLevelAccessApplication(
+		zoneID,
 		fullAccessApplication,
 	)
 
@@ -236,7 +279,10 @@ func TestUpdateAccessApplicationWithMissingID(t *testing.T) {
 	setup()
 	defer teardown()
 
-	_, err := client.UpdateAccessApplication("d56084adb405e0b7e32c52321bf07be6", AccessApplication{})
+	_, err := client.UpdateAccessApplication(zoneID, AccessApplication{})
+	assert.EqualError(t, err, "access application ID cannot be empty")
+
+	_, err = client.UpdateZoneLevelAccessApplication(zoneID, AccessApplication{})
 	assert.EqualError(t, err, "access application ID cannot be empty")
 }
 
@@ -258,8 +304,13 @@ func TestDeleteAccessApplication(t *testing.T) {
     `)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
-	err := client.DeleteAccessApplication("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+	err := client.DeleteAccessApplication(accountID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	assert.NoError(t, err)
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+	err = client.DeleteZoneLevelAccessApplication(zoneID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
 
 	assert.NoError(t, err)
 }
@@ -279,8 +330,13 @@ func TestRevokeAccessApplicationTokens(t *testing.T) {
     `)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db/revoke-tokens", handler)
-	err := client.RevokeAccessApplicationTokens("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db/revoke-tokens", handler)
+	err := client.RevokeAccessApplicationTokens(accountID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	assert.NoError(t, err)
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db/revoke-tokens", handler)
+	err = client.RevokeZoneLevelAccessApplicationTokens(zoneID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
 
 	assert.NoError(t, err)
 }
@@ -321,8 +377,6 @@ func TestAccessApplicationWithCORS(t *testing.T) {
     `)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
-
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
@@ -342,7 +396,17 @@ func TestAccessApplicationWithCORS(t *testing.T) {
 		},
 	}
 
-	actual, err := client.AccessApplication("01a7362d577a6c3019a474fd6f485823", "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err := client.AccessApplication(accountID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err = client.ZoneLevelAccessApplication(zoneID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/access_ca_certificate.go
+++ b/access_ca_certificate.go
@@ -33,7 +33,18 @@ type AccessCACertificateResponse struct {
 //
 // API reference: https://api.cloudflare.com/#access-short-lived-certificates-list-short-lived-certificates
 func (api *API) AccessCACertificates(accountID string) ([]AccessCACertificate, error) {
-	uri := fmt.Sprintf("/accounts/%s/access/apps/ca", accountID)
+	return api.accessCACertificates(accountID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessCACertificates returns all CA certificates within Access.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-list-short-lived-certificates
+func (api *API) ZoneLevelAccessCACertificates(zoneID string) ([]AccessCACertificate, error) {
+	return api.accessCACertificates(zoneID, ZoneRouteRoot)
+}
+
+func (api *API) accessCACertificates(id string, routeRoot RouteRoot) ([]AccessCACertificate, error) {
+	uri := fmt.Sprintf("/%s/%s/access/apps/ca", routeRoot, id)
 
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
@@ -54,7 +65,19 @@ func (api *API) AccessCACertificates(accountID string) ([]AccessCACertificate, e
 //
 // API reference: https://api.cloudflare.com/#access-short-lived-certificates-short-lived-certificate-details
 func (api *API) AccessCACertificate(accountID, applicationID string) (AccessCACertificate, error) {
-	uri := fmt.Sprintf("/accounts/%s/access/apps/%s/ca", accountID, applicationID)
+	return api.accessCACertificate(accountID, applicationID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessCACertificate returns a single CA certificate associated with an Access
+// Application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-short-lived-certificate-details
+func (api *API) ZoneLevelAccessCACertificate(zoneID, applicationID string) (AccessCACertificate, error) {
+	return api.accessCACertificate(zoneID, applicationID, ZoneRouteRoot)
+}
+
+func (api *API) accessCACertificate(id string, applicationID string, routeRoot RouteRoot) (AccessCACertificate, error) {
+	uri := fmt.Sprintf("/%s/%s/access/apps/%s/ca", routeRoot, id, applicationID)
 
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
@@ -75,9 +98,22 @@ func (api *API) AccessCACertificate(accountID, applicationID string) (AccessCACe
 //
 // API reference: https://api.cloudflare.com/#access-short-lived-certificates-create-short-lived-certificate
 func (api *API) CreateAccessCACertificate(accountID, applicationID string) (AccessCACertificate, error) {
+	return api.createAccessCACertificate(accountID, applicationID, AccountRouteRoot)
+}
+
+// CreateZoneLevelAccessCACertificate creates a new CA certificate for an Access
+// Application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-create-short-lived-certificate
+func (api *API) CreateZoneLevelAccessCACertificate(zoneID string, applicationID string) (AccessCACertificate, error) {
+	return api.createAccessCACertificate(zoneID, applicationID, ZoneRouteRoot)
+}
+
+func (api *API) createAccessCACertificate(id string, applicationID string, routeRoot RouteRoot) (AccessCACertificate, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/ca",
-		accountID,
+		"/%s/%s/access/apps/%s/ca",
+		routeRoot,
+		id,
 		applicationID,
 	)
 
@@ -100,9 +136,22 @@ func (api *API) CreateAccessCACertificate(accountID, applicationID string) (Acce
 //
 // API reference: https://api.cloudflare.com/#access-short-lived-certificates-delete-access-certificate
 func (api *API) DeleteAccessCACertificate(accountID, applicationID string) error {
+	return api.deleteAccessCACertificate(accountID, applicationID, AccountRouteRoot)
+}
+
+// DeleteZoneLevelAccessCACertificate deletes an Access CA certificate on a defined
+// Access Application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-delete-access-certificate
+func (api *API) DeleteZoneLevelAccessCACertificate(zoneID, applicationID string) error {
+	return api.deleteAccessCACertificate(zoneID, applicationID, ZoneRouteRoot)
+}
+
+func (api *API) deleteAccessCACertificate(id string, applicationID string, routeRoot RouteRoot) error {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/ca",
-		accountID,
+		"/%s/%s/access/apps/%s/ca",
+		routeRoot,
+		id,
 		applicationID,
 	)
 

--- a/access_ca_certificate.go
+++ b/access_ca_certificate.go
@@ -36,7 +36,7 @@ func (api *API) AccessCACertificates(accountID string) ([]AccessCACertificate, e
 	return api.accessCACertificates(accountID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessCACertificates returns all CA certificates within Access.
+// ZoneLevelAccessCACertificates returns all zone level CA certificates within Access.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-list-short-lived-certificates
 func (api *API) ZoneLevelAccessCACertificates(zoneID string) ([]AccessCACertificate, error) {
@@ -68,7 +68,7 @@ func (api *API) AccessCACertificate(accountID, applicationID string) (AccessCACe
 	return api.accessCACertificate(accountID, applicationID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessCACertificate returns a single CA certificate associated with an Access
+// ZoneLevelAccessCACertificate returns a single zone level CA certificate associated with an Access
 // Application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-short-lived-certificate-details
@@ -101,7 +101,7 @@ func (api *API) CreateAccessCACertificate(accountID, applicationID string) (Acce
 	return api.createAccessCACertificate(accountID, applicationID, AccountRouteRoot)
 }
 
-// CreateZoneLevelAccessCACertificate creates a new CA certificate for an Access
+// CreateZoneLevelAccessCACertificate creates a new zone level CA certificate for an Access
 // Application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-create-short-lived-certificate
@@ -139,7 +139,7 @@ func (api *API) DeleteAccessCACertificate(accountID, applicationID string) error
 	return api.deleteAccessCACertificate(accountID, applicationID, AccountRouteRoot)
 }
 
-// DeleteZoneLevelAccessCACertificate deletes an Access CA certificate on a defined
+// DeleteZoneLevelAccessCACertificate deletes a zone level Access CA certificate on a defined
 // Access Application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-short-lived-certificates-delete-access-certificate

--- a/access_ca_certificate_test.go
+++ b/access_ca_certificate_test.go
@@ -28,15 +28,23 @@ func TestAcessCACertificate(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
-
 	want := AccessCACertificate{
 		ID:        "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
 		Aud:       "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
 		PublicKey: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org",
 	}
 
-	actual, err := client.AccessCACertificate("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	actual, err := client.AccessCACertificate(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	actual, err = client.ZoneLevelAccessCACertificate(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -63,15 +71,23 @@ func TestAcessCACertificates(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/ca", handler)
-
 	want := []AccessCACertificate{{
 		ID:        "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
 		Aud:       "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
 		PublicKey: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org",
 	}}
 
-	actual, err := client.AccessCACertificates("01a7362d577a6c3019a474fd6f485823")
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/ca", handler)
+
+	actual, err := client.AccessCACertificates(accountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/ca", handler)
+
+	actual, err = client.ZoneLevelAccessCACertificates(zoneID)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -98,15 +114,23 @@ func TestCreateAcessCACertificates(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
-
 	want := AccessCACertificate{
 		ID:        "4f74df465b2a53271d4219ac2ce2598e24b5e2c60c7924f4",
 		Aud:       "7d1996154eb606c19e31dd777fe6981f57a5ab66735c5c00fefd01b1200ba9d0",
 		PublicKey: "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTI...3urg/XpGMdgaSs5ZdptUPw= open-ssh-ca@cloudflareaccess.org",
 	}
 
-	actual, err := client.CreateAccessCACertificate("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	actual, err := client.CreateAccessCACertificate(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	actual, err = client.CreateZoneLevelAccessCACertificate(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -131,9 +155,15 @@ func TestDeleteAcessCACertificates(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+	mux.HandleFunc("/accounts/"+accountID+"/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
 
-	err := client.DeleteAccessCACertificate("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	err := client.DeleteAccessCACertificate(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	assert.NoError(t, err)
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/apps/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/ca", handler)
+
+	err = client.DeleteZoneLevelAccessCACertificate(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
 
 	assert.NoError(t, err)
 }

--- a/access_group.go
+++ b/access_group.go
@@ -183,7 +183,7 @@ func (api *API) AccessGroups(accountID string, pageOpts PaginationOptions) ([]Ac
 	return api.accessGroups(accountID, pageOpts, AccountRouteRoot)
 }
 
-// ZoneLevelAccessGroups returns all access groups for an access application.
+// ZoneLevelAccessGroups returns all zone level access groups for an access application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-groups-list-access-groups
 func (api *API) ZoneLevelAccessGroups(zoneID string, pageOpts PaginationOptions) ([]AccessGroup, ResultInfo, error) {
@@ -230,7 +230,7 @@ func (api *API) AccessGroup(accountID, groupID string) (AccessGroup, error) {
 	return api.accessGroup(accountID, groupID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessGroup returns a single group based on the group ID.
+// ZoneLevelAccessGroup returns a single zone level group based on the group ID.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-groups-access-group-details
 func (api *API) ZoneLevelAccessGroup(zoneID, groupID string) (AccessGroup, error) {
@@ -266,7 +266,7 @@ func (api *API) CreateAccessGroup(accountID string, accessGroup AccessGroup) (Ac
 	return api.createAccessGroup(accountID, accessGroup, AccountRouteRoot)
 }
 
-// CreateZoneLevelAccessGroup creates a new access group.
+// CreateZoneLevelAccessGroup creates a new zone level access group.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-groups-create-access-group
 func (api *API) CreateZoneLevelAccessGroup(zoneID string, accessGroup AccessGroup) (AccessGroup, error) {
@@ -301,7 +301,7 @@ func (api *API) UpdateAccessGroup(accountID string, accessGroup AccessGroup) (Ac
 	return api.updateAccessGroup(accountID, accessGroup, AccountRouteRoot)
 }
 
-// UpdateZoneLevelAccessGroup updates an existing access group.
+// UpdateZoneLevelAccessGroup updates an existing zone level access group.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-groups-update-access-group
 func (api *API) UpdateZoneLevelAccessGroup(zoneID string, accessGroup AccessGroup) (AccessGroup, error) {
@@ -340,7 +340,7 @@ func (api *API) DeleteAccessGroup(accountID, groupID string) error {
 	return api.deleteAccessGroup(accountID, groupID, AccountRouteRoot)
 }
 
-// DeleteZoneLevelAccessGroup deletes an access group.
+// DeleteZoneLevelAccessGroup deletes a zone level access group.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-groups-delete-access-group
 func (api *API) DeleteZoneLevelAccessGroup(zoneID, groupID string) error {

--- a/access_group.go
+++ b/access_group.go
@@ -180,6 +180,17 @@ type AccessGroupDetailResponse struct {
 //
 // API reference: https://api.cloudflare.com/#access-groups-list-access-groups
 func (api *API) AccessGroups(accountID string, pageOpts PaginationOptions) ([]AccessGroup, ResultInfo, error) {
+	return api.accessGroups(accountID, pageOpts, AccountRouteRoot)
+}
+
+// ZoneLevelAccessGroups returns all access groups for an access application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-groups-list-access-groups
+func (api *API) ZoneLevelAccessGroups(zoneID string, pageOpts PaginationOptions) ([]AccessGroup, ResultInfo, error) {
+	return api.accessGroups(zoneID, pageOpts, ZoneRouteRoot)
+}
+
+func (api *API) accessGroups(id string, pageOpts PaginationOptions, routeRoot RouteRoot) ([]AccessGroup, ResultInfo, error) {
 	v := url.Values{}
 	if pageOpts.PerPage > 0 {
 		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
@@ -189,8 +200,9 @@ func (api *API) AccessGroups(accountID string, pageOpts PaginationOptions) ([]Ac
 	}
 
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/groups",
-		accountID,
+		"/%s/%s/access/groups",
+		routeRoot,
+		id,
 	)
 
 	if len(v) > 0 {
@@ -215,9 +227,21 @@ func (api *API) AccessGroups(accountID string, pageOpts PaginationOptions) ([]Ac
 //
 // API reference: https://api.cloudflare.com/#access-groups-access-group-details
 func (api *API) AccessGroup(accountID, groupID string) (AccessGroup, error) {
+	return api.accessGroup(accountID, groupID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessGroup returns a single group based on the group ID.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-groups-access-group-details
+func (api *API) ZoneLevelAccessGroup(zoneID, groupID string) (AccessGroup, error) {
+	return api.accessGroup(zoneID, groupID, ZoneRouteRoot)
+}
+
+func (api *API) accessGroup(id string, groupID string, routeRoot RouteRoot) (AccessGroup, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/groups/%s",
-		accountID,
+		"/%s/%s/access/groups/%s",
+		routeRoot,
+		id,
 		groupID,
 	)
 
@@ -239,9 +263,21 @@ func (api *API) AccessGroup(accountID, groupID string) (AccessGroup, error) {
 //
 // API reference: https://api.cloudflare.com/#access-groups-create-access-group
 func (api *API) CreateAccessGroup(accountID string, accessGroup AccessGroup) (AccessGroup, error) {
+	return api.createAccessGroup(accountID, accessGroup, AccountRouteRoot)
+}
+
+// CreateZoneLevelAccessGroup creates a new access group.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-groups-create-access-group
+func (api *API) CreateZoneLevelAccessGroup(zoneID string, accessGroup AccessGroup) (AccessGroup, error) {
+	return api.createAccessGroup(zoneID, accessGroup, ZoneRouteRoot)
+}
+
+func (api *API) createAccessGroup(id string, accessGroup AccessGroup, routeRoot RouteRoot) (AccessGroup, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/groups",
-		accountID,
+		"/%s/%s/access/groups",
+		routeRoot,
+		id,
 	)
 
 	res, err := api.makeRequest("POST", uri, accessGroup)
@@ -262,12 +298,24 @@ func (api *API) CreateAccessGroup(accountID string, accessGroup AccessGroup) (Ac
 //
 // API reference: https://api.cloudflare.com/#access-groups-update-access-group
 func (api *API) UpdateAccessGroup(accountID string, accessGroup AccessGroup) (AccessGroup, error) {
+	return api.updateAccessGroup(accountID, accessGroup, AccountRouteRoot)
+}
+
+// UpdateZoneLevelAccessGroup updates an existing access group.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-groups-update-access-group
+func (api *API) UpdateZoneLevelAccessGroup(zoneID string, accessGroup AccessGroup) (AccessGroup, error) {
+	return api.updateAccessGroup(zoneID, accessGroup, ZoneRouteRoot)
+}
+
+func (api *API) updateAccessGroup(id string, accessGroup AccessGroup, routeRoot RouteRoot) (AccessGroup, error) {
 	if accessGroup.ID == "" {
 		return AccessGroup{}, errors.Errorf("access group ID cannot be empty")
 	}
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/groups/%s",
-		accountID,
+		"/%s/%s/access/groups/%s",
+		routeRoot,
+		id,
 		accessGroup.ID,
 	)
 
@@ -289,9 +337,21 @@ func (api *API) UpdateAccessGroup(accountID string, accessGroup AccessGroup) (Ac
 //
 // API reference: https://api.cloudflare.com/#access-groups-delete-access-group
 func (api *API) DeleteAccessGroup(accountID, groupID string) error {
+	return api.deleteAccessGroup(accountID, groupID, AccountRouteRoot)
+}
+
+// DeleteZoneLevelAccessGroup deletes an access group.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-groups-delete-access-group
+func (api *API) DeleteZoneLevelAccessGroup(zoneID, groupID string) error {
+	return api.deleteAccessGroup(zoneID, groupID, ZoneRouteRoot)
+}
+
+func (api *API) deleteAccessGroup(id string, groupID string, routeRoot RouteRoot) error {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/groups/%s",
-		accountID,
+		"/%s/%s/access/groups/%s",
+		routeRoot,
+		id,
 		groupID,
 	)
 

--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -46,14 +46,14 @@ type AccessIdentityProviderConfiguration struct {
 // Access Identity Providers.
 type AccessIdentityProvidersListResponse struct {
 	Response
-	Result   []AccessIdentityProvider         `json:"result"`
+	Result []AccessIdentityProvider `json:"result"`
 }
 
 // AccessIdentityProviderListResponse is the API response for a single
 // Access Identity Provider.
 type AccessIdentityProviderListResponse struct {
 	Response
-	Result   AccessIdentityProvider           `json:"result"`
+	Result AccessIdentityProvider `json:"result"`
 }
 
 // AccessIdentityProviders returns all Access Identity Providers for an
@@ -61,7 +61,19 @@ type AccessIdentityProviderListResponse struct {
 //
 // API reference: https://api.cloudflare.com/#access-identity-providers-list-access-identity-providers
 func (api *API) AccessIdentityProviders(accountID string) ([]AccessIdentityProvider, error) {
-	uri := "/accounts/" + accountID + "/access/identity_providers"
+	return api.accessIdentityProviders(accountID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessIdentityProviders returns all Access Identity Providers for an
+// account.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-list-access-identity-providers
+func (api *API) ZoneLevelAccessIdentityProviders(zoneID string) ([]AccessIdentityProvider, error) {
+	return api.accessIdentityProviders(zoneID, ZoneRouteRoot)
+}
+
+func (api *API) accessIdentityProviders(id string, routeRoot RouteRoot) ([]AccessIdentityProvider, error) {
+	uri := fmt.Sprintf("/%s/%s/access/identity_providers", routeRoot, id)
 
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
@@ -82,9 +94,22 @@ func (api *API) AccessIdentityProviders(accountID string) ([]AccessIdentityProvi
 //
 // API reference: https://api.cloudflare.com/#access-identity-providers-access-identity-providers-details
 func (api *API) AccessIdentityProviderDetails(accountID, identityProviderID string) (AccessIdentityProvider, error) {
+	return api.accessIdentityProviderDetails(accountID, identityProviderID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessIdentityProviderDetails returns a single Access Identity
+// Provider for an account.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-access-identity-providers-details
+func (api *API) ZoneLevelAccessIdentityProviderDetails(zoneID, identityProviderID string) (AccessIdentityProvider, error) {
+	return api.accessIdentityProviderDetails(zoneID, identityProviderID, ZoneRouteRoot)
+}
+
+func (api *API) accessIdentityProviderDetails(id string, identityProviderID string, routeRoot RouteRoot) (AccessIdentityProvider, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/identity_providers/%s",
-		accountID,
+		"/%s/%s/access/identity_providers/%s",
+		routeRoot,
+		id,
 		identityProviderID,
 	)
 
@@ -106,7 +131,18 @@ func (api *API) AccessIdentityProviderDetails(accountID, identityProviderID stri
 //
 // API reference: https://api.cloudflare.com/#access-identity-providers-create-access-identity-provider
 func (api *API) CreateAccessIdentityProvider(accountID string, identityProviderConfiguration AccessIdentityProvider) (AccessIdentityProvider, error) {
-	uri := "/accounts/" + accountID + "/access/identity_providers"
+	return api.createAccessIdentityProvider(accountID, identityProviderConfiguration, AccountRouteRoot)
+}
+
+// CreateZoneLevelAccessIdentityProvider creates a new Access Identity Provider.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-create-access-identity-provider
+func (api *API) CreateZoneLevelAccessIdentityProvider(zoneID string, identityProviderConfiguration AccessIdentityProvider) (AccessIdentityProvider, error) {
+	return api.createAccessIdentityProvider(zoneID, identityProviderConfiguration, ZoneRouteRoot)
+}
+
+func (api *API) createAccessIdentityProvider(id string, identityProviderConfiguration AccessIdentityProvider, routeRoot RouteRoot) (AccessIdentityProvider, error) {
+	uri := fmt.Sprintf("/%s/%s/access/identity_providers", routeRoot, id)
 
 	res, err := api.makeRequest("POST", uri, identityProviderConfiguration)
 	if err != nil {
@@ -127,9 +163,22 @@ func (api *API) CreateAccessIdentityProvider(accountID string, identityProviderC
 //
 // API reference: https://api.cloudflare.com/#access-identity-providers-create-access-identity-provider
 func (api *API) UpdateAccessIdentityProvider(accountID, identityProviderUUID string, identityProviderConfiguration AccessIdentityProvider) (AccessIdentityProvider, error) {
+	return api.updateAccessIdentityProvider(accountID, identityProviderUUID, identityProviderConfiguration, AccountRouteRoot)
+}
+
+// UpdateZoneLevelAccessIdentityProvider updates an existing Access Identity
+// Provider.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-update-access-identity-provider
+func (api *API) UpdateZoneLevelAccessIdentityProvider(zoneID, identityProviderUUID string, identityProviderConfiguration AccessIdentityProvider) (AccessIdentityProvider, error) {
+	return api.updateAccessIdentityProvider(zoneID, identityProviderUUID, identityProviderConfiguration, ZoneRouteRoot)
+}
+
+func (api *API) updateAccessIdentityProvider(id string, identityProviderUUID string, identityProviderConfiguration AccessIdentityProvider, routeRoot RouteRoot) (AccessIdentityProvider, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/identity_providers/%s",
-		accountID,
+		"/%s/%s/access/identity_providers/%s",
+		routeRoot,
+		id,
 		identityProviderUUID,
 	)
 
@@ -151,9 +200,21 @@ func (api *API) UpdateAccessIdentityProvider(accountID, identityProviderUUID str
 //
 // API reference: https://api.cloudflare.com/#access-identity-providers-create-access-identity-provider
 func (api *API) DeleteAccessIdentityProvider(accountID, identityProviderUUID string) (AccessIdentityProvider, error) {
+	return api.deleteAccessIdentityProvider(accountID, identityProviderUUID, AccountRouteRoot)
+}
+
+// DeleteZoneLevelAccessIdentityProvider deletes an Access Identity Provider.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-delete-access-identity-provider
+func (api *API) DeleteZoneLevelAccessIdentityProvider(zoneID, identityProviderUUID string) (AccessIdentityProvider, error) {
+	return api.deleteAccessIdentityProvider(zoneID, identityProviderUUID, ZoneRouteRoot)
+}
+
+func (api *API) deleteAccessIdentityProvider(id string, identityProviderUUID string, routeRoot RouteRoot) (AccessIdentityProvider, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/identity_providers/%s",
-		accountID,
+		"/%s/%s/access/identity_providers/%s",
+		routeRoot,
+		id,
 		identityProviderUUID,
 	)
 

--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -97,7 +97,7 @@ func (api *API) AccessIdentityProviderDetails(accountID, identityProviderID stri
 	return api.accessIdentityProviderDetails(accountID, identityProviderID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessIdentityProviderDetails returns a single Access Identity
+// ZoneLevelAccessIdentityProviderDetails returns a single zone level Access Identity
 // Provider for an account.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-access-identity-providers-details
@@ -134,7 +134,7 @@ func (api *API) CreateAccessIdentityProvider(accountID string, identityProviderC
 	return api.createAccessIdentityProvider(accountID, identityProviderConfiguration, AccountRouteRoot)
 }
 
-// CreateZoneLevelAccessIdentityProvider creates a new Access Identity Provider.
+// CreateZoneLevelAccessIdentityProvider creates a new zone level Access Identity Provider.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-create-access-identity-provider
 func (api *API) CreateZoneLevelAccessIdentityProvider(zoneID string, identityProviderConfiguration AccessIdentityProvider) (AccessIdentityProvider, error) {
@@ -166,7 +166,7 @@ func (api *API) UpdateAccessIdentityProvider(accountID, identityProviderUUID str
 	return api.updateAccessIdentityProvider(accountID, identityProviderUUID, identityProviderConfiguration, AccountRouteRoot)
 }
 
-// UpdateZoneLevelAccessIdentityProvider updates an existing Access Identity
+// UpdateZoneLevelAccessIdentityProvider updates an existing zone level Access Identity
 // Provider.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-update-access-identity-provider
@@ -203,7 +203,7 @@ func (api *API) DeleteAccessIdentityProvider(accountID, identityProviderUUID str
 	return api.deleteAccessIdentityProvider(accountID, identityProviderUUID, AccountRouteRoot)
 }
 
-// DeleteZoneLevelAccessIdentityProvider deletes an Access Identity Provider.
+// DeleteZoneLevelAccessIdentityProvider deletes a zone level Access Identity Provider.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-identity-providers-delete-access-identity-provider
 func (api *API) DeleteZoneLevelAccessIdentityProvider(zoneID, identityProviderUUID string) (AccessIdentityProvider, error) {

--- a/access_identity_provider_test.go
+++ b/access_identity_provider_test.go
@@ -34,19 +34,29 @@ func TestAccessIdentityProviders(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers", handler)
-
-	want := []AccessIdentityProvider{AccessIdentityProvider{
-		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
-		Name: "Widget Corps OTP",
-		Type: "github",
-		Config: AccessIdentityProviderConfiguration{
-			ClientID:     "example_id",
-			ClientSecret: "a-secret-key",
+	want := []AccessIdentityProvider{
+		{
+			ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+			Name: "Widget Corps OTP",
+			Type: "github",
+			Config: AccessIdentityProviderConfiguration{
+				ClientID:     "example_id",
+				ClientSecret: "a-secret-key",
+			},
 		},
-	}}
+	}
 
-	actual, err := client.AccessIdentityProviders("01a7362d577a6c3019a474fd6f485823")
+	mux.HandleFunc("/accounts/"+accountID+"/access/identity_providers", handler)
+
+	actual, err := client.AccessIdentityProviders(accountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/identity_providers", handler)
+
+	actual, err = client.ZoneLevelAccessIdentityProviders(zoneID)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -77,8 +87,6 @@ func TestAccessIdentityProviderDetails(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc841", handler)
-
 	want := AccessIdentityProvider{
 		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name: "Widget Corps OTP",
@@ -89,7 +97,17 @@ func TestAccessIdentityProviderDetails(t *testing.T) {
 		},
 	}
 
-	actual, err := client.AccessIdentityProviderDetails("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc841")
+	mux.HandleFunc("/accounts/"+accountID+"/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc841", handler)
+
+	actual, err := client.AccessIdentityProviderDetails(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc841")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc841", handler)
+
+	actual, err = client.ZoneLevelAccessIdentityProviderDetails(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc841")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -120,8 +138,6 @@ func TestCreateAccessIdentityProvider(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers", handler)
-
 	newIdentityProvider := AccessIdentityProvider{
 		Name: "Widget Corps OTP",
 		Type: "github",
@@ -141,7 +157,17 @@ func TestCreateAccessIdentityProvider(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateAccessIdentityProvider("01a7362d577a6c3019a474fd6f485823", newIdentityProvider)
+	mux.HandleFunc("/accounts/"+accountID+"/access/identity_providers", handler)
+
+	actual, err := client.CreateAccessIdentityProvider(accountID, newIdentityProvider)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/identity_providers", handler)
+
+	actual, err = client.CreateZoneLevelAccessIdentityProvider(zoneID, newIdentityProvider)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -171,8 +197,6 @@ func TestUpdateAccessIdentityProvider(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
-
 	updatedIdentityProvider := AccessIdentityProvider{
 		Name: "Widget Corps OTP",
 		Type: "github",
@@ -192,7 +216,17 @@ func TestUpdateAccessIdentityProvider(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateAccessIdentityProvider("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415", updatedIdentityProvider)
+	mux.HandleFunc("/accounts/"+accountID+"/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err := client.UpdateAccessIdentityProvider(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415", updatedIdentityProvider)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err = client.UpdateZoneLevelAccessIdentityProvider(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415", updatedIdentityProvider)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -223,8 +257,6 @@ func TestDeleteAccessIdentityProvider(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
-
 	want := AccessIdentityProvider{
 		ID:   "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name: "Widget Corps OTP",
@@ -235,7 +267,17 @@ func TestDeleteAccessIdentityProvider(t *testing.T) {
 		},
 	}
 
+	mux.HandleFunc("/accounts/"+accountID+"/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
 	actual, err := client.DeleteAccessIdentityProvider("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/identity_providers/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err = client.DeleteZoneLevelAccessIdentityProvider(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/access_organization.go
+++ b/access_organization.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -44,7 +45,18 @@ type AccessOrganizationDetailResponse struct {
 //
 // API reference: https://api.cloudflare.com/#access-organizations-access-organization-details
 func (api *API) AccessOrganization(accountID string) (AccessOrganization, ResultInfo, error) {
-	uri := "/accounts/" + accountID + "/access/organizations"
+	return api.accessOrganization(accountID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessOrganization returns the Access organisation details.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-organizations-access-organization-details
+func (api *API) ZoneLevelAccessOrganization(zoneID string) (AccessOrganization, ResultInfo, error) {
+	return api.accessOrganization(zoneID, ZoneRouteRoot)
+}
+
+func (api *API) accessOrganization(id string, routeRoot RouteRoot) (AccessOrganization, ResultInfo, error) {
+	uri := fmt.Sprintf("/%s/%s/access/organizations", routeRoot, id)
 
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
@@ -64,7 +76,18 @@ func (api *API) AccessOrganization(accountID string) (AccessOrganization, Result
 //
 // API reference: https://api.cloudflare.com/#access-organizations-create-access-organization
 func (api *API) CreateAccessOrganization(accountID string, accessOrganization AccessOrganization) (AccessOrganization, error) {
-	uri := "/accounts/" + accountID + "/access/organizations"
+	return api.createAccessOrganization(accountID, accessOrganization, AccountRouteRoot)
+}
+
+// CreateZoneLevelAccessOrganization creates the Access organisation details.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-organizations-create-access-organization
+func (api *API) CreateZoneLevelAccessOrganization(zoneID string, accessOrganization AccessOrganization) (AccessOrganization, error) {
+	return api.createAccessOrganization(zoneID, accessOrganization, ZoneRouteRoot)
+}
+
+func (api *API) createAccessOrganization(id string, accessOrganization AccessOrganization, routeRoot RouteRoot) (AccessOrganization, error) {
+	uri := fmt.Sprintf("/%s/%s/access/organizations", routeRoot, id)
 
 	res, err := api.makeRequest("POST", uri, accessOrganization)
 	if err != nil {
@@ -84,7 +107,18 @@ func (api *API) CreateAccessOrganization(accountID string, accessOrganization Ac
 //
 // API reference: https://api.cloudflare.com/#access-organizations-update-access-organization
 func (api *API) UpdateAccessOrganization(accountID string, accessOrganization AccessOrganization) (AccessOrganization, error) {
-	uri := "/accounts/" + accountID + "/access/organizations"
+	return api.updateAccessOrganization(accountID, accessOrganization, AccountRouteRoot)
+}
+
+// UpdateZoneLevelAccessOrganization creates the Access organisation details.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-organizations-update-access-organization
+func (api *API) UpdateZoneLevelAccessOrganization(zoneID string, accessOrganization AccessOrganization) (AccessOrganization, error) {
+	return api.updateAccessOrganization(zoneID, accessOrganization, ZoneRouteRoot)
+}
+
+func (api *API) updateAccessOrganization(id string, accessOrganization AccessOrganization, routeRoot RouteRoot) (AccessOrganization, error) {
+	uri := fmt.Sprintf("/%s/%s/access/organizations", routeRoot, id)
 
 	res, err := api.makeRequest("PUT", uri, accessOrganization)
 	if err != nil {

--- a/access_organization.go
+++ b/access_organization.go
@@ -48,7 +48,7 @@ func (api *API) AccessOrganization(accountID string) (AccessOrganization, Result
 	return api.accessOrganization(accountID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessOrganization returns the Access organisation details.
+// ZoneLevelAccessOrganization returns the zone level Access organisation details.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-organizations-access-organization-details
 func (api *API) ZoneLevelAccessOrganization(zoneID string) (AccessOrganization, ResultInfo, error) {
@@ -79,7 +79,7 @@ func (api *API) CreateAccessOrganization(accountID string, accessOrganization Ac
 	return api.createAccessOrganization(accountID, accessOrganization, AccountRouteRoot)
 }
 
-// CreateZoneLevelAccessOrganization creates the Access organisation details.
+// CreateZoneLevelAccessOrganization creates the zone level Access organisation details.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-organizations-create-access-organization
 func (api *API) CreateZoneLevelAccessOrganization(zoneID string, accessOrganization AccessOrganization) (AccessOrganization, error) {
@@ -103,14 +103,14 @@ func (api *API) createAccessOrganization(id string, accessOrganization AccessOrg
 	return accessOrganizationDetailResponse.Result, nil
 }
 
-// UpdateAccessOrganization creates the Access organisation details.
+// UpdateAccessOrganization updates the Access organisation details.
 //
 // API reference: https://api.cloudflare.com/#access-organizations-update-access-organization
 func (api *API) UpdateAccessOrganization(accountID string, accessOrganization AccessOrganization) (AccessOrganization, error) {
 	return api.updateAccessOrganization(accountID, accessOrganization, AccountRouteRoot)
 }
 
-// UpdateZoneLevelAccessOrganization creates the Access organisation details.
+// UpdateZoneLevelAccessOrganization updates the zone level Access organisation details.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-organizations-update-access-organization
 func (api *API) UpdateZoneLevelAccessOrganization(zoneID string, accessOrganization AccessOrganization) (AccessOrganization, error) {

--- a/access_organization_test.go
+++ b/access_organization_test.go
@@ -35,7 +35,6 @@ func TestAccessOrganization(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/organizations", handler)
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
@@ -51,7 +50,17 @@ func TestAccessOrganization(t *testing.T) {
 		},
 	}
 
-	actual, _, err := client.AccessOrganization("01a7362d577a6c3019a474fd6f485823")
+	mux.HandleFunc("/accounts/"+accountID+"/access/organizations", handler)
+
+	actual, _, err := client.AccessOrganization(accountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/organizations", handler)
+
+	actual, _, err = client.ZoneLevelAccessOrganization(zoneID)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -84,7 +93,6 @@ func TestCreateAccessOrganization(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/organizations", handler)
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
@@ -100,7 +108,17 @@ func TestCreateAccessOrganization(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateAccessOrganization("01a7362d577a6c3019a474fd6f485823", want)
+	mux.HandleFunc("/accounts/"+accountID+"/access/organizations", handler)
+
+	actual, err := client.CreateAccessOrganization(accountID, want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/organizations", handler)
+
+	actual, err = client.CreateZoneLevelAccessOrganization(zoneID, want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -133,7 +151,6 @@ func TestUpdateAccessOrganization(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/organizations", handler)
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
@@ -149,7 +166,17 @@ func TestUpdateAccessOrganization(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateAccessOrganization("01a7362d577a6c3019a474fd6f485823", want)
+	mux.HandleFunc("/accounts/"+accountID+"/access/organizations", handler)
+
+	actual, err := client.UpdateAccessOrganization(accountID, want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/organizations", handler)
+
+	actual, err = client.UpdateZoneLevelAccessOrganization(zoneID, want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/access_policy.go
+++ b/access_policy.go
@@ -54,6 +54,17 @@ type AccessPolicyDetailResponse struct {
 //
 // API reference: https://api.cloudflare.com/#access-policy-list-access-policies
 func (api *API) AccessPolicies(accountID, applicationID string, pageOpts PaginationOptions) ([]AccessPolicy, ResultInfo, error) {
+	return api.accessPolicies(accountID, applicationID, pageOpts, AccountRouteRoot)
+}
+
+// ZoneLevelAccessPolicies returns all access policies for an access application.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-policy-list-access-policies
+func (api *API) ZoneLevelAccessPolicies(zoneID, applicationID string, pageOpts PaginationOptions) ([]AccessPolicy, ResultInfo, error) {
+	return api.accessPolicies(zoneID, applicationID, pageOpts, ZoneRouteRoot)
+}
+
+func (api *API) accessPolicies(id string, applicationID string, pageOpts PaginationOptions, routeRoot RouteRoot) ([]AccessPolicy, ResultInfo, error) {
 	v := url.Values{}
 	if pageOpts.PerPage > 0 {
 		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
@@ -63,8 +74,9 @@ func (api *API) AccessPolicies(accountID, applicationID string, pageOpts Paginat
 	}
 
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/policies",
-		accountID,
+		"/%s/%s/access/apps/%s/policies",
+		routeRoot,
+		id,
 		applicationID,
 	)
 
@@ -90,9 +102,21 @@ func (api *API) AccessPolicies(accountID, applicationID string, pageOpts Paginat
 //
 // API reference: https://api.cloudflare.com/#access-policy-access-policy-details
 func (api *API) AccessPolicy(accountID, applicationID, policyID string) (AccessPolicy, error) {
+	return api.accessPolicy(accountID, applicationID, policyID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessPolicy returns a single policy based on the policy ID.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-policy-access-policy-details
+func (api *API) ZoneLevelAccessPolicy(zoneID, applicationID, policyID string) (AccessPolicy, error) {
+	return api.accessPolicy(zoneID, applicationID, policyID, ZoneRouteRoot)
+}
+
+func (api *API) accessPolicy(id string, applicationID string, policyID string, routeRoot RouteRoot) (AccessPolicy, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/policies/%s",
-		accountID,
+		"/%s/%s/access/apps/%s/policies/%s",
+		routeRoot,
+		id,
 		applicationID,
 		policyID,
 	)
@@ -115,9 +139,21 @@ func (api *API) AccessPolicy(accountID, applicationID, policyID string) (AccessP
 //
 // API reference: https://api.cloudflare.com/#access-policy-create-access-policy
 func (api *API) CreateAccessPolicy(accountID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
+	return api.createAccessPolicy(accountID, applicationID, accessPolicy, AccountRouteRoot)
+}
+
+// CreateZoneLevelAccessPolicy creates a new access policy.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-policy-create-access-policy
+func (api *API) CreateZoneLevelAccessPolicy(zoneID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
+	return api.createAccessPolicy(zoneID, applicationID, accessPolicy, ZoneRouteRoot)
+}
+
+func (api *API) createAccessPolicy(id, applicationID string, accessPolicy AccessPolicy, routeRoot RouteRoot) (AccessPolicy, error) {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/policies",
-		accountID,
+		"/%s/%s/access/apps/%s/policies",
+		routeRoot,
+		id,
 		applicationID,
 	)
 
@@ -139,12 +175,24 @@ func (api *API) CreateAccessPolicy(accountID, applicationID string, accessPolicy
 //
 // API reference: https://api.cloudflare.com/#access-policy-update-access-policy
 func (api *API) UpdateAccessPolicy(accountID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
+	return api.updateAccessPolicy(accountID, applicationID, accessPolicy, AccountRouteRoot)
+}
+
+// UpdateZoneLevelAccessPolicy updates an existing access policy.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-policy-update-access-policy
+func (api *API) UpdateZoneLevelAccessPolicy(zoneID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
+	return api.updateAccessPolicy(zoneID, applicationID, accessPolicy, ZoneRouteRoot)
+}
+
+func (api *API) updateAccessPolicy(id, applicationID string, accessPolicy AccessPolicy, routeRoot RouteRoot) (AccessPolicy, error) {
 	if accessPolicy.ID == "" {
 		return AccessPolicy{}, errors.Errorf("access policy ID cannot be empty")
 	}
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/policies/%s",
-		accountID,
+		"/%s/%s/access/apps/%s/policies/%s",
+		routeRoot,
+		id,
 		applicationID,
 		accessPolicy.ID,
 	)
@@ -167,9 +215,21 @@ func (api *API) UpdateAccessPolicy(accountID, applicationID string, accessPolicy
 //
 // API reference: https://api.cloudflare.com/#access-policy-update-access-policy
 func (api *API) DeleteAccessPolicy(accountID, applicationID, accessPolicyID string) error {
+	return api.deleteAccessPolicy(accountID, applicationID, accessPolicyID, AccountRouteRoot)
+}
+
+// DeleteZoneLevelAccessPolicy deletes an access policy.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-policy-delete-access-policy
+func (api *API) DeleteZoneLevelAccessPolicy(zoneID, applicationID, accessPolicyID string) error {
+	return api.deleteAccessPolicy(zoneID, applicationID, accessPolicyID, ZoneRouteRoot)
+}
+
+func (api *API) deleteAccessPolicy(id, applicationID, accessPolicyID string, routeRoot RouteRoot) error {
 	uri := fmt.Sprintf(
-		"/accounts/%s/access/apps/%s/policies/%s",
-		accountID,
+		"/%s/%s/access/apps/%s/policies/%s",
+		routeRoot,
+		id,
 		applicationID,
 		accessPolicyID,
 	)

--- a/access_policy.go
+++ b/access_policy.go
@@ -57,7 +57,7 @@ func (api *API) AccessPolicies(accountID, applicationID string, pageOpts Paginat
 	return api.accessPolicies(accountID, applicationID, pageOpts, AccountRouteRoot)
 }
 
-// ZoneLevelAccessPolicies returns all access policies for an access application.
+// ZoneLevelAccessPolicies returns all zone level access policies for an access application.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-policy-list-access-policies
 func (api *API) ZoneLevelAccessPolicies(zoneID, applicationID string, pageOpts PaginationOptions) ([]AccessPolicy, ResultInfo, error) {
@@ -105,7 +105,7 @@ func (api *API) AccessPolicy(accountID, applicationID, policyID string) (AccessP
 	return api.accessPolicy(accountID, applicationID, policyID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessPolicy returns a single policy based on the policy ID.
+// ZoneLevelAccessPolicy returns a single zone level policy based on the policy ID.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-policy-access-policy-details
 func (api *API) ZoneLevelAccessPolicy(zoneID, applicationID, policyID string) (AccessPolicy, error) {
@@ -135,7 +135,7 @@ func (api *API) accessPolicy(id string, applicationID string, policyID string, r
 	return accessPolicyDetailResponse.Result, nil
 }
 
-// CreateAccessPolicy creates a new access policy.
+// CreateAccessPolicy creates a new zone level access policy.
 //
 // API reference: https://api.cloudflare.com/#access-policy-create-access-policy
 func (api *API) CreateAccessPolicy(accountID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
@@ -178,7 +178,7 @@ func (api *API) UpdateAccessPolicy(accountID, applicationID string, accessPolicy
 	return api.updateAccessPolicy(accountID, applicationID, accessPolicy, AccountRouteRoot)
 }
 
-// UpdateZoneLevelAccessPolicy updates an existing access policy.
+// UpdateZoneLevelAccessPolicy updates an existing zone level access policy.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-policy-update-access-policy
 func (api *API) UpdateZoneLevelAccessPolicy(zoneID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
@@ -218,7 +218,7 @@ func (api *API) DeleteAccessPolicy(accountID, applicationID, accessPolicyID stri
 	return api.deleteAccessPolicy(accountID, applicationID, accessPolicyID, AccountRouteRoot)
 }
 
-// DeleteZoneLevelAccessPolicy deletes an access policy.
+// DeleteZoneLevelAccessPolicy deletes a zone level access policy.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-policy-delete-access-policy
 func (api *API) DeleteZoneLevelAccessPolicy(zoneID, applicationID, accessPolicyID string) error {

--- a/access_policy.go
+++ b/access_policy.go
@@ -135,14 +135,14 @@ func (api *API) accessPolicy(id string, applicationID string, policyID string, r
 	return accessPolicyDetailResponse.Result, nil
 }
 
-// CreateAccessPolicy creates a new zone level access policy.
+// CreateAccessPolicy creates a new access policy.
 //
 // API reference: https://api.cloudflare.com/#access-policy-create-access-policy
 func (api *API) CreateAccessPolicy(accountID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {
 	return api.createAccessPolicy(accountID, applicationID, accessPolicy, AccountRouteRoot)
 }
 
-// CreateZoneLevelAccessPolicy creates a new access policy.
+// CreateZoneLevelAccessPolicy creates a new zone level access policy.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-policy-create-access-policy
 func (api *API) CreateZoneLevelAccessPolicy(zoneID, applicationID string, accessPolicy AccessPolicy) (AccessPolicy, error) {

--- a/access_service_tokens.go
+++ b/access_service_tokens.go
@@ -83,7 +83,7 @@ func (api *API) AccessServiceTokens(accountID string) ([]AccessServiceToken, Res
 	return api.accessServiceTokens(accountID, AccountRouteRoot)
 }
 
-// ZoneLevelAccessServiceTokens returns all Access Service Tokens for an account.
+// ZoneLevelAccessServiceTokens returns all Access Service Tokens for a zone.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-list-access-service-tokens
 func (api *API) ZoneLevelAccessServiceTokens(zoneID string) ([]AccessServiceToken, ResultInfo, error) {
@@ -114,7 +114,7 @@ func (api *API) CreateAccessServiceToken(accountID, name string) (AccessServiceT
 	return api.createAccessServiceToken(accountID, name, AccountRouteRoot)
 }
 
-// CreateZoneLevelAccessServiceToken creates a new Access Service Token for an account.
+// CreateZoneLevelAccessServiceToken creates a new Access Service Token for a zone.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-create-access-service-token
 func (api *API) CreateZoneLevelAccessServiceToken(zoneID, name string) (AccessServiceTokenCreateResponse, error) {
@@ -150,8 +150,8 @@ func (api *API) UpdateAccessServiceToken(accountID, uuid, name string) (AccessSe
 	return api.updateAccessServiceToken(accountID, uuid, name, AccountRouteRoot)
 }
 
-// UpdateZoneLevelAccessServiceToken updates an existing Access Service Token for an
-// account.
+// UpdateZoneLevelAccessServiceToken updates an existing Access Service Token for a
+// zone.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-update-access-service-token
 func (api *API) UpdateZoneLevelAccessServiceToken(zoneID, uuid, name string) (AccessServiceTokenUpdateResponse, error) {
@@ -187,8 +187,8 @@ func (api *API) DeleteAccessServiceToken(accountID, uuid string) (AccessServiceT
 	return api.deleteAccessServiceToken(accountID, uuid, AccountRouteRoot)
 }
 
-// DeleteZoneLevelAccessServiceToken removes an existing Access Service Token for an
-// account.
+// DeleteZoneLevelAccessServiceToken removes an existing Access Service Token for a
+// zone.
 //
 // API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-delete-access-service-token
 func (api *API) DeleteZoneLevelAccessServiceToken(zoneID, uuid string) (AccessServiceTokenUpdateResponse, error) {

--- a/access_service_tokens.go
+++ b/access_service_tokens.go
@@ -80,7 +80,18 @@ type AccessServiceTokensUpdateDetailResponse struct {
 //
 // API reference: https://api.cloudflare.com/#access-service-tokens-list-access-service-tokens
 func (api *API) AccessServiceTokens(accountID string) ([]AccessServiceToken, ResultInfo, error) {
-	uri := "/accounts/" + accountID + "/access/service_tokens"
+	return api.accessServiceTokens(accountID, AccountRouteRoot)
+}
+
+// ZoneLevelAccessServiceTokens returns all Access Service Tokens for an account.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-list-access-service-tokens
+func (api *API) ZoneLevelAccessServiceTokens(zoneID string) ([]AccessServiceToken, ResultInfo, error) {
+	return api.accessServiceTokens(zoneID, ZoneRouteRoot)
+}
+
+func (api *API) accessServiceTokens(id string, routeRoot RouteRoot) ([]AccessServiceToken, ResultInfo, error) {
+	uri := fmt.Sprintf("/%s/%s/access/service_tokens", routeRoot, id)
 
 	res, err := api.makeRequest("GET", uri, nil)
 	if err != nil {
@@ -100,7 +111,18 @@ func (api *API) AccessServiceTokens(accountID string) ([]AccessServiceToken, Res
 //
 // API reference: https://api.cloudflare.com/#access-service-tokens-create-access-service-token
 func (api *API) CreateAccessServiceToken(accountID, name string) (AccessServiceTokenCreateResponse, error) {
-	uri := "/accounts/" + accountID + "/access/service_tokens"
+	return api.createAccessServiceToken(accountID, name, AccountRouteRoot)
+}
+
+// CreateZoneLevelAccessServiceToken creates a new Access Service Token for an account.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-create-access-service-token
+func (api *API) CreateZoneLevelAccessServiceToken(zoneID, name string) (AccessServiceTokenCreateResponse, error) {
+	return api.createAccessServiceToken(zoneID, name, ZoneRouteRoot)
+}
+
+func (api *API) createAccessServiceToken(id, name string, routeRoot RouteRoot) (AccessServiceTokenCreateResponse, error) {
+	uri := fmt.Sprintf("/%s/%s/access/service_tokens", routeRoot, id)
 	marshalledName, _ := json.Marshal(struct {
 		Name string `json:"name"`
 	}{name})
@@ -125,7 +147,19 @@ func (api *API) CreateAccessServiceToken(accountID, name string) (AccessServiceT
 //
 // API reference: https://api.cloudflare.com/#access-service-tokens-update-access-service-token
 func (api *API) UpdateAccessServiceToken(accountID, uuid, name string) (AccessServiceTokenUpdateResponse, error) {
-	uri := fmt.Sprintf("/accounts/%s/access/service_tokens/%s", accountID, uuid)
+	return api.updateAccessServiceToken(accountID, uuid, name, AccountRouteRoot)
+}
+
+// UpdateZoneLevelAccessServiceToken updates an existing Access Service Token for an
+// account.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-update-access-service-token
+func (api *API) UpdateZoneLevelAccessServiceToken(zoneID, uuid, name string) (AccessServiceTokenUpdateResponse, error) {
+	return api.updateAccessServiceToken(zoneID, uuid, name, ZoneRouteRoot)
+}
+
+func (api *API) updateAccessServiceToken(id, uuid, name string, routeRoot RouteRoot) (AccessServiceTokenUpdateResponse, error) {
+	uri := fmt.Sprintf("/%s/%s/access/service_tokens/%s", routeRoot, id, uuid)
 
 	marshalledName, _ := json.Marshal(struct {
 		Name string `json:"name"`
@@ -150,7 +184,19 @@ func (api *API) UpdateAccessServiceToken(accountID, uuid, name string) (AccessSe
 //
 // API reference: https://api.cloudflare.com/#access-service-tokens-delete-access-service-token
 func (api *API) DeleteAccessServiceToken(accountID, uuid string) (AccessServiceTokenUpdateResponse, error) {
-	uri := fmt.Sprintf("/accounts/%s/access/service_tokens/%s", accountID, uuid)
+	return api.deleteAccessServiceToken(accountID, uuid, AccountRouteRoot)
+}
+
+// DeleteZoneLevelAccessServiceToken removes an existing Access Service Token for an
+// account.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-service-tokens-delete-access-service-token
+func (api *API) DeleteZoneLevelAccessServiceToken(zoneID, uuid string) (AccessServiceTokenUpdateResponse, error) {
+	return api.deleteAccessServiceToken(zoneID, uuid, ZoneRouteRoot)
+}
+
+func (api *API) deleteAccessServiceToken(id, uuid string, routeRoot RouteRoot) (AccessServiceTokenUpdateResponse, error) {
+	uri := fmt.Sprintf("/%s/%s/access/service_tokens/%s", routeRoot, id, uuid)
 
 	res, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {

--- a/access_service_tokens_test.go
+++ b/access_service_tokens_test.go
@@ -33,19 +33,30 @@ func TestAccessServiceTokens(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/service_tokens", handler)
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
-	want := []AccessServiceToken{AccessServiceToken{
-		CreatedAt: &createdAt,
-		UpdatedAt: &updatedAt,
-		ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
-		Name:      "CI/CD token",
-		ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
-	}}
+	want := []AccessServiceToken{
+		{
+			CreatedAt: &createdAt,
+			UpdatedAt: &updatedAt,
+			ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+			Name:      "CI/CD token",
+			ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
+		},
+	}
 
-	actual, _, err := client.AccessServiceTokens("01a7362d577a6c3019a474fd6f485823")
+	mux.HandleFunc("/accounts/"+accountID+"/access/service_tokens", handler)
+
+	actual, _, err := client.AccessServiceTokens(accountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/service_tokens", handler)
+
+	actual, _, err = client.ZoneLevelAccessServiceTokens(zoneID)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -75,8 +86,6 @@ func TestCreateAccessServiceToken(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/service_tokens", handler)
-
 	expected := AccessServiceTokenCreateResponse{
 		CreatedAt:    &createdAt,
 		UpdatedAt:    &updatedAt,
@@ -86,7 +95,17 @@ func TestCreateAccessServiceToken(t *testing.T) {
 		ClientSecret: "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5",
 	}
 
-	actual, err := client.CreateAccessServiceToken("01a7362d577a6c3019a474fd6f485823", "CI/CD token")
+	mux.HandleFunc("/accounts/"+accountID+"/access/service_tokens", handler)
+
+	actual, err := client.CreateAccessServiceToken(accountID, "CI/CD token")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/service_tokens", handler)
+
+	actual, err = client.CreateZoneLevelAccessServiceToken(zoneID, "CI/CD token")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, expected, actual)
@@ -115,8 +134,6 @@ func TestUpdateAccessServiceToken(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
-
 	expected := AccessServiceTokenUpdateResponse{
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -125,8 +142,22 @@ func TestUpdateAccessServiceToken(t *testing.T) {
 		ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
 	}
 
+	mux.HandleFunc("/accounts/"+accountID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
 	actual, err := client.UpdateAccessServiceToken(
-		"01a7362d577a6c3019a474fd6f485823",
+		accountID,
+		"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		"CI/CD token",
+	)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err = client.UpdateZoneLevelAccessServiceToken(
+		zoneID,
 		"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		"CI/CD token",
 	)
@@ -158,8 +189,6 @@ func TestDeleteAccessServiceToken(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
-
 	expected := AccessServiceTokenUpdateResponse{
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -168,8 +197,21 @@ func TestDeleteAccessServiceToken(t *testing.T) {
 		ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
 	}
 
+	mux.HandleFunc("/accounts/"+accountID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
 	actual, err := client.DeleteAccessServiceToken(
-		"01a7362d577a6c3019a474fd6f485823",
+		accountID,
+		"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+	)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err = client.DeleteZoneLevelAccessServiceToken(
+		zoneID,
 		"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 	)
 

--- a/consts.go
+++ b/consts.go
@@ -1,0 +1,16 @@
+package cloudflare
+
+// RouteRoot represents the name of the route namespace
+type RouteRoot string
+
+const (
+	// AccountRouteRoot is the accounts route namespace
+	AccountRouteRoot RouteRoot = "accounts"
+
+	// ZoneRouteRoot is the zones route namespace
+	ZoneRouteRoot RouteRoot = "zones"
+
+	// Used for testing
+	accountID = "01a7362d577a6c3019a474fd6f485823"
+	zoneID    = "d56084adb405e0b7e32c52321bf07be6"
+)

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200927032502-5d4f70055728 h1:5wtQIAulKU5AbLQOkjxl32UufnIOqgBX72pS0AV14H0=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
## Description

Provides support for zone-level Access endpoints. The Access team reverted its decision to deprecate zone based routes because of users needing zone-scoped access tokens. Zone based routes have also been added back to the documentation: https://api.cloudflare.com/.

Related issue: https://github.com/cloudflare/terraform-provider-cloudflare/issues/812.

## Has your change been tested?

Tests were included for every added request. 

## Types of changes

What sort of change does your code introduce/modify?

- [X] New feature (non-breaking change which adds functionality)
