### PR TITLE
fix: properly report messages from an "error" field instead of "errors".

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -359,6 +359,7 @@ type ResponseInfo struct {
 type Response struct {
 	Success  bool           `json:"success"`
 	Errors   []ResponseInfo `json:"errors"`
+	Error    string         `json:"error"`
 	Messages []ResponseInfo `json:"messages"`
 }
 
@@ -465,5 +466,10 @@ func errorFromResponse(statusCode int, respBody []byte) error {
 	for _, v := range r.Errors {
 		errMsgs = append(errMsgs, v.Message)
 	}
+
+	if r.Error != "" {
+		errMsgs = append(errMsgs, r.Error)
+	}
+
 	return errors.Errorf("HTTP status %d: %s", statusCode, strings.Join(errMsgs, " "))
 }


### PR DESCRIPTION
## Description

I was trying to dynamically update a DNS record pointing to my home IP address, but got an error:

> `Error creating DNS record: error from makeRequest: HTTP status 401: `

(and a similar message with s/creating/updating/ when trying to update an existing record)

Clearly, something was missing at the end there.

After a bit of debugging it turns out that the API does not always report errors in an `errors` field, in this case it reported one in an `error` field instead.

This PR adds an `Error string` field to the `Response` type, and if it's not empty the message in it is reported just like the messages in `Errors`.

## Has your change been tested?

I re-ran my command and got

> `Error creating DNS record: error from makeRequest: HTTP status 401: You cannot use this API for domains with a .cf, .ga, .gq, .ml, or .tk TLD (top-level domain). To configure the DNS settings for this domain, use the Cloudflare Dashboard.`

Which as an aside could have been better documented (maybe a warning when I was creating the API token specifically scoped to editing this zone?), but I guess I'll figure something else out.

I also added a unit test.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
