### PR TITLE
Add API token support

### DIFF
--- a/api_token.go
+++ b/api_token.go
@@ -1,0 +1,211 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// APIToken is the full API token.
+type APIToken struct {
+	ID         string             `json:"id,omitempty"`
+	Name       string             `json:"name"`
+	Status     string             `json:"status,omitempty"`
+	IssuedOn   time.Time          `json:"issued_on,omitempty"`
+	ModifiedOn time.Time          `json:"modified_on,omitempty"`
+	NotBefore  time.Time          `json:"not_before"`
+	ExpiresOn  time.Time          `json:"expires_on"`
+	Policies   []APITokenPolicies `json:"policies"`
+	Condition  *APITokenCondition `json:"condition,omitempty"`
+	Value      string             `json:"value,omitempty"`
+}
+
+// APITokenPermissionGroups is the permission groups associated with API tokens.
+type APITokenPermissionGroups struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+}
+
+// APITokenPolicies are policies attached to an API token.
+type APITokenPolicies struct {
+	ID               string                     `json:"id,omitempty"`
+	Effect           string                     `json:"effect"`
+	Resources        map[string]interface{}     `json:"resources"`
+	PermissionGroups []APITokenPermissionGroups `json:"permission_groups"`
+}
+
+// APITokenRequestIPCondition is the struct for adding an IP restriction to an
+// API token.
+type APITokenRequestIPCondition struct {
+	In    []string `json:"in"`
+	NotIn []string `json:"not_in"`
+}
+
+// APITokenCondition is the outer structure for request conditions (currently
+// only IPs).
+type APITokenCondition struct {
+	RequestIP *APITokenRequestIPCondition `json:"request.ip,omitempty"`
+}
+
+// APITokenResponse is the API response for a single API token.
+type APITokenResponse struct {
+	Response
+	Result APIToken `json:"result"`
+}
+
+// APITokenListResponse is the API response for multiple API tokens.
+type APITokenListResponse struct {
+	Response
+	Result []APIToken `json:"result"`
+}
+
+// APITokenRollResponse is the API response when rolling the token.
+type APITokenRollResponse struct {
+	Response
+	Result string `json:"result"`
+}
+
+// APITokenVerifyResponse is the API response for verifying a token.
+type APITokenVerifyResponse struct {
+	Response
+	Result APITokenVerifyBody `json:"result"`
+}
+
+// APITokenVerifyBody is the API body for verifying a token.
+type APITokenVerifyBody struct {
+	ID        string    `json:"id"`
+	Status    string    `json:"status"`
+	NotBefore time.Time `json:"not_before"`
+	ExpiresOn time.Time `json:"expires_on"`
+}
+
+// GetAPIToken returns a single API token based on the ID.
+//
+// API reference: https://api.cloudflare.com/#user-api-tokens-token-details
+func (api *API) GetAPIToken(tokenID string) (APIToken, error) {
+	uri := "/user/tokens/" + tokenID
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return APIToken{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var apiTokenResponse APITokenResponse
+	err = json.Unmarshal(res, &apiTokenResponse)
+	if err != nil {
+		return APIToken{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return apiTokenResponse.Result, nil
+}
+
+// APITokens returns all available API tokens.
+//
+// API reference: https://api.cloudflare.com/#user-api-tokens-list-tokens
+func (api *API) APITokens() ([]APIToken, error) {
+	res, err := api.makeRequest("GET", "/user/tokens", nil)
+	if err != nil {
+		return []APIToken{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var apiTokenListResponse APITokenListResponse
+	err = json.Unmarshal(res, &apiTokenListResponse)
+	if err != nil {
+		return []APIToken{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return apiTokenListResponse.Result, nil
+}
+
+// CreateAPIToken creates a new token. Returns the API token that has been
+// generated.
+//
+// The token value itself is only shown once (post create) and will present as
+// `Value` from this method. If you fail to capture it at this point, you will
+// need to roll the token in order to get a new value.
+//
+// API reference: https://api.cloudflare.com/#user-api-tokens-create-token
+func (api *API) CreateAPIToken(token APIToken) (APIToken, error) {
+	res, err := api.makeRequest("POST", "/user/tokens", token)
+	if err != nil {
+		return APIToken{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var createTokenAPIResponse APITokenResponse
+	err = json.Unmarshal(res, &createTokenAPIResponse)
+	if err != nil {
+		return APIToken{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return createTokenAPIResponse.Result, nil
+}
+
+// UpdateAPIToken updates an existing API token.
+//
+// API reference: https://api.cloudflare.com/#user-api-tokens-update-token
+func (api *API) UpdateAPIToken(tokenID string, token APIToken) (APIToken, error) {
+	res, err := api.makeRequest("PUT", "/user/tokens/"+tokenID, token)
+	if err != nil {
+		return APIToken{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var updatedTokenResponse APITokenResponse
+	err = json.Unmarshal(res, &updatedTokenResponse)
+	if err != nil {
+		return APIToken{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return updatedTokenResponse.Result, nil
+}
+
+// RollAPIToken rolls the credential associated with the token.
+//
+// API reference: https://api.cloudflare.com/#user-api-tokens-roll-token
+func (api *API) RollAPIToken(tokenID string) (string, error) {
+	uri := fmt.Sprintf("/user/tokens/%s/value", tokenID)
+
+	res, err := api.makeRequest("PUT", uri, nil)
+	if err != nil {
+		return "", errors.Wrap(err, errMakeRequestError)
+	}
+
+	var apiTokenRollResponse APITokenRollResponse
+	err = json.Unmarshal(res, &apiTokenRollResponse)
+	if err != nil {
+		return "", errors.Wrap(err, errUnmarshalError)
+	}
+
+	return apiTokenRollResponse.Result, nil
+}
+
+// VerifyAPIToken rolls the value associated with the token.
+//
+// API reference: https://api.cloudflare.com/#user-api-tokens-roll-token
+func (api *API) VerifyAPIToken() (APITokenVerifyBody, error) {
+	res, err := api.makeRequest("GET", "/user/tokens/verify", nil)
+	if err != nil {
+		return APITokenVerifyBody{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var apiTokenVerifyResponse APITokenVerifyResponse
+	err = json.Unmarshal(res, &apiTokenVerifyResponse)
+	if err != nil {
+		return APITokenVerifyBody{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return apiTokenVerifyResponse.Result, nil
+}
+
+// DeleteAPIToken deletes a single API token.
+//
+// API reference: https://api.cloudflare.com/#user-api-tokens-delete-token
+func (api *API) DeleteAPIToken(tokenID string) error {
+	_, err := api.makeRequest("DELETE", "/user/tokens/"+tokenID, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	return nil
+}

--- a/api_token_test.go
+++ b/api_token_test.go
@@ -57,12 +57,12 @@ func TestAPITokens(t *testing.T) {
           "condition": {
             "request.ip": {
               "in": [
-                "199.27.128.0/21",
-                "2400:cb00::/32"
+                "192.0.2.0/24",
+                "2001:db8::/48"
               ],
               "not_in": [
-                "199.27.128.0/21",
-                "2400:cb00::/32"
+                "198.51.100.0/24",
+                "2001:db8:1::/48"
               ]
             }
           }
@@ -102,8 +102,8 @@ func TestAPITokens(t *testing.T) {
 		}},
 		Condition: &APITokenCondition{
 			RequestIP: &APITokenRequestIPCondition{
-				In:    []string{"199.27.128.0/21", "2400:cb00::/32"},
-				NotIn: []string{"199.27.128.0/21", "2400:cb00::/32"},
+				In:    []string{"192.0.2.0/24", "2001:db8::/48"},
+				NotIn: []string{"198.51.100.0/24", "2001:db8:1::/48"},
 			},
 		},
 	}
@@ -162,12 +162,12 @@ func TestGetAPIToken(t *testing.T) {
           "condition": {
             "request.ip": {
               "in": [
-                "199.27.128.0/21",
-                "2400:cb00::/32"
+                "192.0.2.0/24",
+                "2001:db8::/48"
               ],
               "not_in": [
-                "199.27.128.0/21",
-                "2400:cb00::/32"
+                "198.51.100.0/24",
+                "2001:db8:1::/48"
               ]
             }
           }
@@ -206,8 +206,8 @@ func TestGetAPIToken(t *testing.T) {
 		}},
 		Condition: &APITokenCondition{
 			RequestIP: &APITokenRequestIPCondition{
-				In:    []string{"199.27.128.0/21", "2400:cb00::/32"},
-				NotIn: []string{"199.27.128.0/21", "2400:cb00::/32"},
+				In:    []string{"192.0.2.0/24", "2001:db8::/48"},
+				NotIn: []string{"198.51.100.0/24", "2001:db8:1::/48"},
 			},
 		},
 	}

--- a/api_token_test.go
+++ b/api_token_test.go
@@ -1,0 +1,380 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPITokens(t *testing.T) {
+	setup()
+	defer teardown()
+
+	issuedOn, _ := time.Parse(time.RFC3339, "2018-07-01T05:20:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2018-07-02T05:20:00Z")
+	notBefore, _ := time.Parse(time.RFC3339, "2018-07-01T05:20:00Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": [
+        {
+          "id": "ed17574386854bf78a67040be0a770b0",
+          "name": "readonly token",
+          "status": "active",
+          "issued_on": "2018-07-01T05:20:00Z",
+          "modified_on": "2018-07-02T05:20:00Z",
+          "not_before": "2018-07-01T05:20:00Z",
+          "expires_on": "2020-01-01T00:00:00Z",
+          "policies": [
+            {
+              "id": "f267e341f3dd4697bd3b9f71dd96247f",
+              "effect": "allow",
+              "resources": {
+                "com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4": "*",
+                "com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43": "*"
+              },
+              "permission_groups": [
+                {
+                  "id": "c8fed203ed3043cba015a93ad1616f1f",
+                  "name": "Zone Read"
+                },
+                {
+                  "id": "82e64a83756745bbbb1c9c2701bf816b",
+                  "name": "DNS Read"
+                }
+              ]
+            }
+          ],
+          "condition": {
+            "request.ip": {
+              "in": [
+                "199.27.128.0/21",
+                "2400:cb00::/32"
+              ],
+              "not_in": [
+                "199.27.128.0/21",
+                "2400:cb00::/32"
+              ]
+            }
+          }
+        }
+      ]
+    }`)
+	}
+
+	mux.HandleFunc("/user/tokens", handler)
+
+	resources := make(map[string]interface{})
+	resources["com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4"] = "*"
+	resources["com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43"] = "*"
+
+	expectedAPIToken := APIToken{
+		ID:         "ed17574386854bf78a67040be0a770b0",
+		Name:       "readonly token",
+		Status:     "active",
+		IssuedOn:   issuedOn,
+		ModifiedOn: modifiedOn,
+		NotBefore:  notBefore,
+		ExpiresOn:  expiresOn,
+		Policies: []APITokenPolicies{{
+			ID:        "f267e341f3dd4697bd3b9f71dd96247f",
+			Effect:    "allow",
+			Resources: resources,
+			PermissionGroups: []APITokenPermissionGroups{
+				{
+					ID:   "c8fed203ed3043cba015a93ad1616f1f",
+					Name: "Zone Read",
+				},
+				{
+					ID:   "82e64a83756745bbbb1c9c2701bf816b",
+					Name: "DNS Read",
+				},
+			},
+		}},
+		Condition: &APITokenCondition{
+			RequestIP: &APITokenRequestIPCondition{
+				In:    []string{"199.27.128.0/21", "2400:cb00::/32"},
+				NotIn: []string{"199.27.128.0/21", "2400:cb00::/32"},
+			},
+		},
+	}
+
+	actual, err := client.APITokens()
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, []APIToken{expectedAPIToken}, actual)
+	}
+}
+
+func TestGetAPIToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	issuedOn, _ := time.Parse(time.RFC3339, "2018-07-01T05:20:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2018-07-02T05:20:00Z")
+	notBefore, _ := time.Parse(time.RFC3339, "2018-07-01T05:20:00Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+          "id": "ed17574386854bf78a67040be0a770b0",
+          "name": "readonly token",
+          "status": "active",
+          "issued_on": "2018-07-01T05:20:00Z",
+          "modified_on": "2018-07-02T05:20:00Z",
+          "not_before": "2018-07-01T05:20:00Z",
+          "expires_on": "2020-01-01T00:00:00Z",
+          "policies": [
+            {
+              "id": "f267e341f3dd4697bd3b9f71dd96247f",
+              "effect": "allow",
+              "resources": {
+                "com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4": "*",
+                "com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43": "*"
+              },
+              "permission_groups": [
+                {
+                  "id": "c8fed203ed3043cba015a93ad1616f1f",
+                  "name": "Zone Read"
+                },
+                {
+                  "id": "82e64a83756745bbbb1c9c2701bf816b",
+                  "name": "DNS Read"
+                }
+              ]
+            }
+          ],
+          "condition": {
+            "request.ip": {
+              "in": [
+                "199.27.128.0/21",
+                "2400:cb00::/32"
+              ],
+              "not_in": [
+                "199.27.128.0/21",
+                "2400:cb00::/32"
+              ]
+            }
+          }
+        }
+      }`)
+	}
+
+	mux.HandleFunc("/user/tokens/ed17574386854bf78a67040be0a770b0", handler)
+
+	resources := make(map[string]interface{})
+	resources["com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4"] = "*"
+	resources["com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43"] = "*"
+
+	expectedAPIToken := APIToken{
+		ID:         "ed17574386854bf78a67040be0a770b0",
+		Name:       "readonly token",
+		Status:     "active",
+		IssuedOn:   issuedOn,
+		ModifiedOn: modifiedOn,
+		NotBefore:  notBefore,
+		ExpiresOn:  expiresOn,
+		Policies: []APITokenPolicies{{
+			ID:        "f267e341f3dd4697bd3b9f71dd96247f",
+			Effect:    "allow",
+			Resources: resources,
+			PermissionGroups: []APITokenPermissionGroups{
+				{
+					ID:   "c8fed203ed3043cba015a93ad1616f1f",
+					Name: "Zone Read",
+				},
+				{
+					ID:   "82e64a83756745bbbb1c9c2701bf816b",
+					Name: "DNS Read",
+				},
+			},
+		}},
+		Condition: &APITokenCondition{
+			RequestIP: &APITokenRequestIPCondition{
+				In:    []string{"199.27.128.0/21", "2400:cb00::/32"},
+				NotIn: []string{"199.27.128.0/21", "2400:cb00::/32"},
+			},
+		},
+	}
+
+	actual, err := client.GetAPIToken("ed17574386854bf78a67040be0a770b0")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAPIToken, actual)
+	}
+}
+
+func TestCreateAPIToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// issuedOn, _ := time.Parse(time.RFC3339, "2018-07-01T05:20:00Z")
+	// modifiedOn, _ := time.Parse(time.RFC3339, "2018-07-02T05:20:00Z")
+	notBefore, _ := time.Parse(time.RFC3339, "2018-07-01T05:20:00Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+    "success":true,
+    "errors":[],
+    "messages":[],
+    "result":{
+      "id":"ed17574386854bf78a67040be0a770b0",
+      "name":"readonly token",
+      "status":"active",
+      "issued_on":"2018-07-01T05:20:00Z",
+      "modified_on":"2018-07-02T05:20:00Z",
+      "not_before":"2018-07-01T05:20:00Z",
+      "expires_on":"2020-01-01T00:00:00Z",
+      "policies":[
+        {
+          "id":"f267e341f3dd4697bd3b9f71dd96247f",
+          "effect":"allow",
+          "resources":{
+            "com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4":"*",
+            "com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43":"*"
+          },
+          "permission_groups":[
+            {
+              "id":"c8fed203ed3043cba015a93ad1616f1f",
+              "name":"Zone Read"
+            },
+            {
+              "id":"82e64a83756745bbbb1c9c2701bf816b",
+              "name":"DNS Read"
+            }
+          ]
+        }
+      ]
+    }
+  }`)
+	}
+
+	mux.HandleFunc("/user/tokens", handler)
+
+	resources := make(map[string]interface{})
+	resources["com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4"] = "*"
+	resources["com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43"] = "*"
+
+	tokenToCreate := APIToken{
+		Name:      "readonly token",
+		NotBefore: notBefore,
+		ExpiresOn: expiresOn,
+		Policies: []APITokenPolicies{{
+			ID:        "f267e341f3dd4697bd3b9f71dd96247f",
+			Effect:    "allow",
+			Resources: resources,
+			PermissionGroups: []APITokenPermissionGroups{
+				{
+					ID:   "c8fed203ed3043cba015a93ad1616f1f",
+					Name: "Zone Read",
+				},
+				{
+					ID:   "82e64a83756745bbbb1c9c2701bf816b",
+					Name: "DNS Read",
+				},
+			},
+		}},
+	}
+
+	actual, err := client.CreateAPIToken(tokenToCreate)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, tokenToCreate.Name, actual.Name)
+		assert.Equal(t, tokenToCreate.Policies, actual.Policies)
+	}
+}
+
+func TestRollAPIToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": "8M7wS6hCpXVc-DoRnPPY_UCWPgy8aea4Wy6kCe5T"
+    }
+    `)
+	}
+
+	mux.HandleFunc("/user/tokens/ed17574386854bf78a67040be0a770b0/value", handler)
+
+	actual, err := client.RollAPIToken("ed17574386854bf78a67040be0a770b0")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "8M7wS6hCpXVc-DoRnPPY_UCWPgy8aea4Wy6kCe5T", actual)
+	}
+}
+
+func TestVerifyAPIToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "id": "ed17574386854bf78a67040be0a770b0",
+        "status": "active",
+        "not_before": "2018-07-01T05:20:00Z",
+        "expires_on": "2020-01-01T00:00:00Z"
+      }
+    }`)
+	}
+
+	mux.HandleFunc("/user/tokens/verify", handler)
+
+	actual, err := client.VerifyAPIToken()
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, "active", actual.Status)
+	}
+}
+
+func TestDeleteAPIToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "id": "9a7806061c88ada191ed06f989cc3dac"
+      }
+    }`)
+	}
+
+	mux.HandleFunc("/user/tokens/ed17574386854bf78a67040be0a770b0", handler)
+
+	err := client.DeleteAPIToken("ed17574386854bf78a67040be0a770b0")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This introduces support for managing API tokens.

- List single and all API tokens
- Create API token
- Update API token
- Delete API token
- Verify API token
- Roll API token

Documentation: https://api.cloudflare.com/#user-api-tokens-properties