### PR TITLE
add List APITokenPermissionGroups endpoint

### DIFF
--- a/api_token.go
+++ b/api_token.go
@@ -24,8 +24,9 @@ type APIToken struct {
 
 // APITokenPermissionGroups is the permission groups associated with API tokens.
 type APITokenPermissionGroups struct {
-	ID   string `json:"id"`
-	Name string `json:"name,omitempty"`
+	ID     string   `json:"id"`
+	Name   string   `json:"name,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 // APITokenPolicies are policies attached to an API token.
@@ -71,6 +72,13 @@ type APITokenRollResponse struct {
 type APITokenVerifyResponse struct {
 	Response
 	Result APITokenVerifyBody `json:"result"`
+}
+
+// APITokenPermissionGroupsResponse is the API response for the available
+// permission groups.
+type APITokenPermissionGroupsResponse struct {
+	Response
+	Result []APITokenPermissionGroups `json:"result"`
 }
 
 // APITokenVerifyBody is the API body for verifying a token.
@@ -208,4 +216,22 @@ func (api *API) DeleteAPIToken(tokenID string) error {
 	}
 
 	return nil
+}
+
+// ListAPITokensPermissionGroups returns all available API token permission groups.
+//
+// API reference: https://api.cloudflare.com/#permission-groups-list-permission-groups
+func (api *API) ListAPITokensPermissionGroups() ([]APITokenPermissionGroups, error) {
+	var r APITokenPermissionGroupsResponse
+	res, err := api.makeRequest("GET", "/user/tokens/permission_groups", nil)
+	if err != nil {
+		return []APITokenPermissionGroups{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []APITokenPermissionGroups{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
 }

--- a/api_token_test.go
+++ b/api_token_test.go
@@ -378,3 +378,39 @@ func TestDeleteAPIToken(t *testing.T) {
 	err := client.DeleteAPIToken("ed17574386854bf78a67040be0a770b0")
 	assert.NoError(t, err)
 }
+
+func TestListAPITokensPermissionGroups(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var pgID = "47aa30b6eb97ecae0518b750d6b142b6"
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": [
+			{
+				"id": %q,
+				"name": "DNS Read",
+				"scopes": ["com.cloudflare.api.account.zone"]
+			}
+		  ]
+		}
+		`, pgID)
+	}
+
+	mux.HandleFunc("/user/tokens/permission_groups", handler)
+	want := []APITokenPermissionGroups{{
+		ID:     pgID,
+		Name:   "DNS Read",
+		Scopes: []string{"com.cloudflare.api.account.zone"},
+	}}
+	actual, err := client.ListAPITokensPermissionGroups()
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
Ability to list API token permission groups.

Missing part of https://github.com/cloudflare/cloudflare-go/pull/542

Hope it will be released together.

Docs: https://api.cloudflare.com/#permission-groups-properties
