### PR TITLE
feat(APIToken): make time.Time properties optional

### DIFF
--- a/api_token.go
+++ b/api_token.go
@@ -13,8 +13,8 @@ type APIToken struct {
 	ID         string             `json:"id,omitempty"`
 	Name       string             `json:"name"`
 	Status     string             `json:"status,omitempty"`
-	IssuedOn   time.Time          `json:"issued_on,omitempty"`
-	ModifiedOn time.Time          `json:"modified_on,omitempty"`
+	IssuedOn   *time.Time         `json:"issued_on,omitempty"`
+	ModifiedOn *time.Time         `json:"modified_on,omitempty"`
 	NotBefore  *time.Time         `json:"not_before,omitempty"`
 	ExpiresOn  *time.Time         `json:"expires_on,omitempty"`
 	Policies   []APITokenPolicies `json:"policies"`

--- a/api_token.go
+++ b/api_token.go
@@ -15,8 +15,8 @@ type APIToken struct {
 	Status     string             `json:"status,omitempty"`
 	IssuedOn   time.Time          `json:"issued_on,omitempty"`
 	ModifiedOn time.Time          `json:"modified_on,omitempty"`
-	NotBefore  time.Time          `json:"not_before"`
-	ExpiresOn  time.Time          `json:"expires_on"`
+	NotBefore  *time.Time         `json:"not_before,omitempty"`
+	ExpiresOn  *time.Time         `json:"expires_on,omitempty"`
 	Policies   []APITokenPolicies `json:"policies"`
 	Condition  *APITokenCondition `json:"condition,omitempty"`
 	Value      string             `json:"value,omitempty"`

--- a/api_token_test.go
+++ b/api_token_test.go
@@ -81,8 +81,8 @@ func TestAPITokens(t *testing.T) {
 		ID:         "ed17574386854bf78a67040be0a770b0",
 		Name:       "readonly token",
 		Status:     "active",
-		IssuedOn:   issuedOn,
-		ModifiedOn: modifiedOn,
+		IssuedOn:   &issuedOn,
+		ModifiedOn: &modifiedOn,
 		NotBefore:  &notBefore,
 		ExpiresOn:  &expiresOn,
 		Policies: []APITokenPolicies{{
@@ -185,8 +185,8 @@ func TestGetAPIToken(t *testing.T) {
 		ID:         "ed17574386854bf78a67040be0a770b0",
 		Name:       "readonly token",
 		Status:     "active",
-		IssuedOn:   issuedOn,
-		ModifiedOn: modifiedOn,
+		IssuedOn:   &issuedOn,
+		ModifiedOn: &modifiedOn,
 		NotBefore:  &notBefore,
 		ExpiresOn:  &expiresOn,
 		Policies: []APITokenPolicies{{

--- a/api_token_test.go
+++ b/api_token_test.go
@@ -83,8 +83,8 @@ func TestAPITokens(t *testing.T) {
 		Status:     "active",
 		IssuedOn:   issuedOn,
 		ModifiedOn: modifiedOn,
-		NotBefore:  notBefore,
-		ExpiresOn:  expiresOn,
+		NotBefore:  &notBefore,
+		ExpiresOn:  &expiresOn,
 		Policies: []APITokenPolicies{{
 			ID:        "f267e341f3dd4697bd3b9f71dd96247f",
 			Effect:    "allow",
@@ -187,8 +187,8 @@ func TestGetAPIToken(t *testing.T) {
 		Status:     "active",
 		IssuedOn:   issuedOn,
 		ModifiedOn: modifiedOn,
-		NotBefore:  notBefore,
-		ExpiresOn:  expiresOn,
+		NotBefore:  &notBefore,
+		ExpiresOn:  &expiresOn,
 		Policies: []APITokenPolicies{{
 			ID:        "f267e341f3dd4697bd3b9f71dd96247f",
 			Effect:    "allow",
@@ -275,8 +275,8 @@ func TestCreateAPIToken(t *testing.T) {
 
 	tokenToCreate := APIToken{
 		Name:      "readonly token",
-		NotBefore: notBefore,
-		ExpiresOn: expiresOn,
+		NotBefore: &notBefore,
+		ExpiresOn: &expiresOn,
 		Policies: []APITokenPolicies{{
 			ID:        "f267e341f3dd4697bd3b9f71dd96247f",
 			Effect:    "allow",


### PR DESCRIPTION
Now it is not possible to create non-expiring token or one would have to use a time far in the future.

Let's leave that decision to a user by making properties `NotBefore` and `ExpiresOn` pointers and thus nilable.

`ModifiedOn` and `IssuedOn` should also be nilable as they are set by API. To not sending json similar to the one below when creating new APIToken:
```
{
  ...
  "modified_on": "0001-01-01T00:00:00Z",
  "issued_on": "0001-01-01T00:00:00Z",
  ...
}
```