### PR TITLE
load_balancing: Add `DrainDuration` to session affinity attributes

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -83,8 +83,9 @@ type LoadBalancer struct {
 
 // SessionAffinityAttributes represents the fields used to set attributes in a load balancer session affinity cookie.
 type SessionAffinityAttributes struct {
-	SameSite string `json:"samesite,omitempty"`
-	Secure   string `json:"secure,omitempty"`
+	SameSite      string `json:"samesite,omitempty"`
+	Secure        string `json:"secure,omitempty"`
+	DrainDuration int    `json:"drain_duration,omitempty"`
 }
 
 // LoadBalancerOriginHealth represents the health of the origin.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -823,7 +823,8 @@ func TestCreateLoadBalancer(t *testing.T) {
               "session_affinity_ttl": 5000,
               "session_affinity_attributes": {
                 "samesite": "Strict",
-                "secure": "Always"
+                "secure": "Always",
+                "drain_duration": 60
               }
             }`, string(b))
 		}
@@ -871,7 +872,8 @@ func TestCreateLoadBalancer(t *testing.T) {
                 "session_affinity_ttl": 5000,
                 "session_affinity_attributes": {
                     "samesite": "Strict",
-                    "secure": "Always"
+                    "secure": "Always",
+                    "drain_duration": 60
                 }
             }
         }`)
@@ -919,8 +921,9 @@ func TestCreateLoadBalancer(t *testing.T) {
 		Persistence:    "cookie",
 		PersistenceTTL: 5000,
 		SessionAffinityAttributes: &SessionAffinityAttributes{
-			SameSite: "Strict",
-			Secure:   "Always",
+			SameSite:      "Strict",
+			Secure:        "Always",
+			DrainDuration: 60,
 		},
 	}
 	request := LoadBalancer{
@@ -959,8 +962,9 @@ func TestCreateLoadBalancer(t *testing.T) {
 		Persistence:    "cookie",
 		PersistenceTTL: 5000,
 		SessionAffinityAttributes: &SessionAffinityAttributes{
-			SameSite: "Strict",
-			Secure:   "Always",
+			SameSite:      "Strict",
+			Secure:        "Always",
+			DrainDuration: 60,
 		},
 	}
 


### PR DESCRIPTION
Discovered while adding Terraform support for session affinity
attributes.

API: https://api.cloudflare.com/#load-balancers-create-load-balancer