### PR TITLE
Add custom deny attributes to access application

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -23,6 +23,8 @@ type AccessApplication struct {
 	EnableBindingCookie    bool                          `json:"enable_binding_cookie,omitempty"`
 	AllowedIdps            []string                      `json:"allowed_idps,omitempty"`
 	CorsHeaders            *AccessApplicationCorsHeaders `json:"cors_headers,omitempty"`
+	CustomDenyMessage      string                        `json:"custom_deny_message,omitempty"`
+	CustomDenyURL          string                        `json:"custom_deny_url,omitempty"`
 }
 
 // AccessApplicationCorsHeaders represents the CORS HTTP headers for an Access

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -31,7 +31,9 @@ func TestAccessApplications(t *testing.T) {
 					"session_duration": "24h",
 					"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
 					"auto_redirect_to_identity": false,
-					"enable_binding_cookie": false
+					"enable_binding_cookie": false,
+					"custom_deny_url": "https://www.cloudflare.com",
+					"custom_deny_message": "denied!"
 				}
 			],
 			"result_info": {
@@ -58,6 +60,8 @@ func TestAccessApplications(t *testing.T) {
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
 		EnableBindingCookie:    false,
+		CustomDenyMessage:      "denied!",
+		CustomDenyURL:          "https://www.cloudflare.com",
 	}}
 
 	mux.HandleFunc("/accounts/"+accountID+"/access/apps", handler)
@@ -98,7 +102,9 @@ func TestAccessApplication(t *testing.T) {
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
 				"auto_redirect_to_identity": false,
-				"enable_binding_cookie": false
+				"enable_binding_cookie": false,
+				"custom_deny_url": "https://www.cloudflare.com",
+				"custom_deny_message": "denied!"
 			}
 		}
 		`)
@@ -118,6 +124,8 @@ func TestAccessApplication(t *testing.T) {
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
 		EnableBindingCookie:    false,
+		CustomDenyMessage:      "denied!",
+		CustomDenyURL:          "https://www.cloudflare.com",
 	}
 
 	mux.HandleFunc("/accounts/"+accountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
@@ -158,7 +166,9 @@ func TestCreateAccessApplications(t *testing.T) {
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
 				"auto_redirect_to_identity": false,
-				"enable_binding_cookie": false
+				"enable_binding_cookie": false,
+				"custom_deny_url": "https://www.cloudflare.com",
+				"custom_deny_message": "denied!"
 			}
 		}
 		`)
@@ -175,6 +185,8 @@ func TestCreateAccessApplications(t *testing.T) {
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
 		EnableBindingCookie:    false,
+		CustomDenyMessage:      "denied!",
+		CustomDenyURL:          "https://www.cloudflare.com",
 		CreatedAt:              &createdAt,
 		UpdatedAt:              &updatedAt,
 	}
@@ -231,7 +243,9 @@ func TestUpdateAccessApplication(t *testing.T) {
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
 				"auto_redirect_to_identity": false,
-				"enable_binding_cookie": false
+				"enable_binding_cookie": false,
+				"custom_deny_url": "https://www.cloudflare.com",
+				"custom_deny_message": "denied!"
 			}
 		}
 		`)
@@ -248,6 +262,8 @@ func TestUpdateAccessApplication(t *testing.T) {
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
 		EnableBindingCookie:    false,
+		CustomDenyMessage:      "denied!",
+		CustomDenyURL:          "https://www.cloudflare.com",
 		CreatedAt:              &createdAt,
 		UpdatedAt:              &updatedAt,
 	}


### PR DESCRIPTION
## Description

This PR adds support for custom deny attributes on Access applications.

## Has your change been tested?

Example curl request:
```
curl --request PUT \
  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/access/apps/<APP_ID> \
  --header 'authorization: Bearer <TOKEN>' \
  --header 'x-auth-email: <EMAIL>' \
  --header 'x-auth-key: <AUTH_KEY>'
  --data '{
        "aud": <REDACTED>,
        "cors_headers": {
                "allow_all_headers": true,
                "allow_all_methods": true,
                "allow_all_origins": true
        },
        "created_at": "2020-10-14T21:52:27Z",
        "domain": <REDACTED>,
        "name": "test app",
        "policies": [],
        "allowed_idps": [],
        "auto_redirect_to_identity": false,
        "session_duration": "1m",
        "custom_deny_url": "https://www.cloudflare.com",
        "custom_deny_message": "asdf"
}'
{
  "result": {
    "aud": <REDACTED>,
    "cors_headers": {
      "allow_all_headers": true,
      "allow_all_methods": true,
      "allow_all_origins": true
    },
    "created_at": "2020-10-14T21:52:27Z",
    "domain": <REDACTED>,
    "name": "test app",
    "policies": [],
    "allowed_idps": [],
    "auto_redirect_to_identity": false,
    "session_duration": "1m",
    "updated_at": "2020-12-16T20:07:11Z",
    "custom_deny_message": "asdf",
    "custom_deny_url": "https://www.cloudflare.com",
    "type": "self_hosted"
  },
  "success": true,
  "errors": [],
  "messages": []
}
```

The Cloudflare API docs will be updated with these new fields shortly.