### PR TITLE
argo_tunnel: Add initial support

### DIFF
--- a/argo_tunnel.go
+++ b/argo_tunnel.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -42,10 +43,10 @@ type ArgoTunnelDetailResponse struct {
 // ArgoTunnels lists all tunnels.
 //
 // API reference: https://api.cloudflare.com/#argo-tunnel-list-argo-tunnels
-func (api *API) ArgoTunnels(accountID string) ([]ArgoTunnel, error) {
+func (api *API) ArgoTunnels(ctx context.Context, accountID string) ([]ArgoTunnel, error) {
 	uri := "/accounts/" + accountID + "/tunnels"
 
-	res, err := api.makeRequest("GET", uri, nil)
+	res, err := api.makeRequestContext(ctx, "GET", uri, nil)
 	if err != nil {
 		return []ArgoTunnel{}, errors.Wrap(err, errMakeRequestError)
 	}
@@ -61,10 +62,10 @@ func (api *API) ArgoTunnels(accountID string) ([]ArgoTunnel, error) {
 // ArgoTunnel returns a single Argo tunnel.
 //
 // API reference: https://api.cloudflare.com/#argo-tunnel-get-argo-tunnel
-func (api *API) ArgoTunnel(accountID, tunnelUUID string) (ArgoTunnel, error) {
+func (api *API) ArgoTunnel(ctx context.Context, accountID, tunnelUUID string) (ArgoTunnel, error) {
 	uri := fmt.Sprintf("/accounts/%s/tunnels/%s", accountID, tunnelUUID)
 
-	res, err := api.makeRequest("GET", uri, nil)
+	res, err := api.makeRequestContext(ctx, "GET", uri, nil)
 	if err != nil {
 		return ArgoTunnel{}, errors.Wrap(err, errMakeRequestError)
 	}
@@ -80,12 +81,12 @@ func (api *API) ArgoTunnel(accountID, tunnelUUID string) (ArgoTunnel, error) {
 // CreateArgoTunnel creates a new tunnel for the account.
 //
 // API reference: https://api.cloudflare.com/#argo-tunnel-create-argo-tunnel
-func (api *API) CreateArgoTunnel(accountID, name, secret string) (ArgoTunnel, error) {
+func (api *API) CreateArgoTunnel(ctx context.Context, accountID, name, secret string) (ArgoTunnel, error) {
 	uri := "/accounts/" + accountID + "/tunnels"
 
 	tunnel := ArgoTunnel{Name: name, Secret: secret}
 
-	res, err := api.makeRequest("POST", uri, tunnel)
+	res, err := api.makeRequestContext(ctx, "POST", uri, tunnel)
 	if err != nil {
 		return ArgoTunnel{}, errors.Wrap(err, errMakeRequestError)
 	}
@@ -101,10 +102,10 @@ func (api *API) CreateArgoTunnel(accountID, name, secret string) (ArgoTunnel, er
 // DeleteArgoTunnel removes a single Argo tunnel.
 //
 // API reference: https://api.cloudflare.com/#argo-tunnel-delete-argo-tunnel
-func (api *API) DeleteArgoTunnel(accountID, tunnelUUID string) error {
+func (api *API) DeleteArgoTunnel(ctx context.Context, accountID, tunnelUUID string) error {
 	uri := fmt.Sprintf("/accounts/%s/tunnels/%s", accountID, tunnelUUID)
 
-	res, err := api.makeRequest("DELETE", uri, nil)
+	res, err := api.makeRequestContext(ctx, "DELETE", uri, nil)
 	if err != nil {
 		return errors.Wrap(err, errMakeRequestError)
 	}
@@ -121,10 +122,10 @@ func (api *API) DeleteArgoTunnel(accountID, tunnelUUID string) error {
 // CleanupArgoTunnelConnections deletes any inactive connections on a tunnel.
 //
 // API reference: https://api.cloudflare.com/#argo-tunnel-clean-up-argo-tunnel-connections
-func (api *API) CleanupArgoTunnelConnections(accountID, tunnelUUID string) error {
+func (api *API) CleanupArgoTunnelConnections(ctx context.Context, accountID, tunnelUUID string) error {
 	uri := fmt.Sprintf("/accounts/%s/tunnels/%s/connections", accountID, tunnelUUID)
 
-	res, err := api.makeRequest("DELETE", uri, nil)
+	res, err := api.makeRequestContext(ctx, "DELETE", uri, nil)
 	if err != nil {
 		return errors.Wrap(err, errMakeRequestError)
 	}

--- a/argo_tunnel.go
+++ b/argo_tunnel.go
@@ -1,0 +1,139 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ArgoTunnel is the struct definition of a tunnel.
+type ArgoTunnel struct {
+	ID          string                 `json:"id,omitempty"`
+	Name        string                 `json:"name,omitempty"`
+	Secret      string                 `json:"tunnel_secret,omitempty"`
+	CreatedAt   *time.Time             `json:"created_at,omitempty"`
+	DeletedAt   *time.Time             `json:"deleted_at,omitempty"`
+	Connections []ArgoTunnelConnection `json:"connections,omitempty"`
+}
+
+// ArgoTunnelConnection represents the connections associated with a tunnel.
+type ArgoTunnelConnection struct {
+	ColoName           string `json:"colo_name"`
+	UUID               string `json:"uuid"`
+	IsPendingReconnect bool   `json:"is_pending_reconnect"`
+}
+
+// ArgoTunnelsDetailResponse is used for representing the API response payload for
+// multiple tunnels.
+type ArgoTunnelsDetailResponse struct {
+	Result []ArgoTunnel `json:"result"`
+	Response
+}
+
+// ArgoTunnelDetailResponse is used for representing the API response payload for
+// a single tunnel.
+type ArgoTunnelDetailResponse struct {
+	Result ArgoTunnel `json:"result"`
+	Response
+}
+
+// ArgoTunnels lists all tunnels.
+//
+// API reference: https://api.cloudflare.com/#argo-tunnel-list-argo-tunnels
+func (api *API) ArgoTunnels(accountID string) ([]ArgoTunnel, error) {
+	uri := "/accounts/" + accountID + "/tunnels"
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []ArgoTunnel{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoTunnelsDetailResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return []ArgoTunnel{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return argoDetailsResponse.Result, nil
+}
+
+// ArgoTunnel returns a single Argo tunnel.
+//
+// API reference: https://api.cloudflare.com/#argo-tunnel-get-argo-tunnel
+func (api *API) ArgoTunnel(accountID, tunnelUUID string) (ArgoTunnel, error) {
+	uri := fmt.Sprintf("/accounts/%s/tunnels/%s", accountID, tunnelUUID)
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ArgoTunnel{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoTunnelDetailResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return ArgoTunnel{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return argoDetailsResponse.Result, nil
+}
+
+// CreateArgoTunnel creates a new tunnel for the account.
+//
+// API reference: https://api.cloudflare.com/#argo-tunnel-create-argo-tunnel
+func (api *API) CreateArgoTunnel(accountID, name, secret string) (ArgoTunnel, error) {
+	uri := "/accounts/" + accountID + "/tunnels"
+
+	tunnel := ArgoTunnel{Name: name, Secret: secret}
+
+	res, err := api.makeRequest("POST", uri, tunnel)
+	if err != nil {
+		return ArgoTunnel{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoTunnelDetailResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return ArgoTunnel{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return argoDetailsResponse.Result, nil
+}
+
+// DeleteArgoTunnel removes a single Argo tunnel.
+//
+// API reference: https://api.cloudflare.com/#argo-tunnel-delete-argo-tunnel
+func (api *API) DeleteArgoTunnel(accountID, tunnelUUID string) error {
+	uri := fmt.Sprintf("/accounts/%s/tunnels/%s", accountID, tunnelUUID)
+
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoTunnelDetailResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}
+
+// CleanupArgoTunnelConnections deletes any inactive connections on a tunnel.
+//
+// API reference: https://api.cloudflare.com/#argo-tunnel-clean-up-argo-tunnel-connections
+func (api *API) CleanupArgoTunnelConnections(accountID, tunnelUUID string) error {
+	uri := fmt.Sprintf("/accounts/%s/tunnels/%s/connections", accountID, tunnelUUID)
+
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	var argoDetailsResponse ArgoTunnelDetailResponse
+	err = json.Unmarshal(res, &argoDetailsResponse)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}

--- a/argo_tunnel_test.go
+++ b/argo_tunnel_test.go
@@ -1,0 +1,220 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArgoTunnels(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+					"name": "blog",
+					"created_at": "2009-11-10T23:00:00Z",
+					"deleted_at": "2009-11-10T23:00:00Z",
+					"connections": [
+						{
+							"colo_name": "DFW",
+							"uuid": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+							"is_pending_reconnect": false
+						}
+					]
+				}
+			]
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/tunnels", handler)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
+	deletedAt, _ := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
+	want := []ArgoTunnel{{
+		ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name:      "blog",
+		CreatedAt: &createdAt,
+		DeletedAt: &deletedAt,
+		Connections: []ArgoTunnelConnection{{
+			ColoName:           "DFW",
+			UUID:               "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+			IsPendingReconnect: false,
+		}},
+	}}
+
+	actual, err := client.ArgoTunnels("01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestArgoTunnel(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success":true,
+			"errors":[],
+			"messages":[],
+			"result":{
+				"id":"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name":"blog",
+				"created_at":"2009-11-10T23:00:00Z",
+				"deleted_at":"2009-11-10T23:00:00Z",
+				"connections":[
+					{
+						"colo_name":"DFW",
+						"uuid":"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+						"is_pending_reconnect":false
+					}
+				]
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/tunnels/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
+	deletedAt, _ := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
+	want := ArgoTunnel{
+		ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name:      "blog",
+		CreatedAt: &createdAt,
+		DeletedAt: &deletedAt,
+		Connections: []ArgoTunnelConnection{{
+			ColoName:           "DFW",
+			UUID:               "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+			IsPendingReconnect: false,
+		}},
+	}
+
+	actual, err := client.ArgoTunnel("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateArgoTunnel(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success":true,
+			"errors":[],
+			"messages":[],
+			"result":{
+				"id":"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name":"blog",
+				"created_at":"2009-11-10T23:00:00Z",
+				"deleted_at":"2009-11-10T23:00:00Z",
+				"connections":[
+					{
+						"colo_name":"DFW",
+						"uuid":"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+						"is_pending_reconnect":false
+					}
+				]
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/tunnels", handler)
+
+	createdAt, _ := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
+	deletedAt, _ := time.Parse(time.RFC3339, "2009-11-10T23:00:00Z")
+	want := ArgoTunnel{
+		ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name:      "blog",
+		CreatedAt: &createdAt,
+		DeletedAt: &deletedAt,
+		Connections: []ArgoTunnelConnection{{
+			ColoName:           "DFW",
+			UUID:               "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+			IsPendingReconnect: false,
+		}},
+	}
+
+	actual, err := client.CreateArgoTunnel("01a7362d577a6c3019a474fd6f485823", "blog", "notarealsecret")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeleteArgoTunnel(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success":true,
+			"errors":[],
+			"messages":[],
+			"result":{
+				"id":"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name":"blog",
+				"created_at":"2009-11-10T23:00:00Z",
+				"deleted_at":"2009-11-10T23:00:00Z",
+				"connections":[
+					{
+						"colo_name":"DFW",
+						"uuid":"f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+						"is_pending_reconnect":false
+					}
+				]
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/tunnels/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	err := client.DeleteArgoTunnel("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	assert.NoError(t, err)
+}
+
+func TestCleanupArgoTunnelConnections(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": []
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/tunnels/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/connections", handler)
+
+	err := client.CleanupArgoTunnelConnections("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	assert.NoError(t, err)
+}

--- a/argo_tunnel_test.go
+++ b/argo_tunnel_test.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -55,7 +56,7 @@ func TestArgoTunnels(t *testing.T) {
 		}},
 	}}
 
-	actual, err := client.ArgoTunnels("01a7362d577a6c3019a474fd6f485823")
+	actual, err := client.ArgoTunnels(context.Background(), "01a7362d577a6c3019a474fd6f485823")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -106,7 +107,7 @@ func TestArgoTunnel(t *testing.T) {
 		}},
 	}
 
-	actual, err := client.ArgoTunnel("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	actual, err := client.ArgoTunnel(context.Background(), "01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -157,7 +158,7 @@ func TestCreateArgoTunnel(t *testing.T) {
 		}},
 	}
 
-	actual, err := client.CreateArgoTunnel("01a7362d577a6c3019a474fd6f485823", "blog", "notarealsecret")
+	actual, err := client.CreateArgoTunnel(context.Background(), "01a7362d577a6c3019a474fd6f485823", "blog", "notarealsecret")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -194,7 +195,7 @@ func TestDeleteArgoTunnel(t *testing.T) {
 
 	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/tunnels/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
 
-	err := client.DeleteArgoTunnel("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	err := client.DeleteArgoTunnel(context.Background(), "01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
 	assert.NoError(t, err)
 }
 
@@ -215,6 +216,6 @@ func TestCleanupArgoTunnelConnections(t *testing.T) {
 
 	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/tunnels/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/connections", handler)
 
-	err := client.CleanupArgoTunnelConnections("01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+	err := client.CleanupArgoTunnelConnections(context.Background(), "01a7362d577a6c3019a474fd6f485823", "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Introduces support for Argo Tunnel CRUD operations (including cleaning
up connections).

API documentation: https://api.cloudflare.com/#argo-tunnel-properties

This unblocks cloudflare/terraform-provider-cloudflare#603

