### PR TITLE
api_token: allow `APITokenRequestIPCondition` fields to be omitted

### DIFF
--- a/api_token.go
+++ b/api_token.go
@@ -40,8 +40,8 @@ type APITokenPolicies struct {
 // APITokenRequestIPCondition is the struct for adding an IP restriction to an
 // API token.
 type APITokenRequestIPCondition struct {
-	In    []string `json:"in"`
-	NotIn []string `json:"not_in"`
+	In    []string `json:"in,omitempty"`
+	NotIn []string `json:"not_in,omitempty"`
 }
 
 // APITokenCondition is the outer structure for request conditions (currently


### PR DESCRIPTION
Updates the `APITokenRequestIPCondition` fields to be omitted when empty
to support only setting one of the values.

Supports the changes in cloudflare/terraform-provider-cloudflare#902

