### PR TITLE
worker_cron_triggers: Add initial support

### DIFF
--- a/workers_cron_triggers.go
+++ b/workers_cron_triggers.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -32,13 +33,13 @@ type WorkerCronTrigger struct {
 // script.
 //
 // API reference: https://api.cloudflare.com/#worker-cron-trigger-get-cron-triggers
-func (api *API) ListWorkerCronTriggers(scriptName string) ([]WorkerCronTrigger, error) {
+func (api *API) ListWorkerCronTriggers(ctx context.Context, scriptName string) ([]WorkerCronTrigger, error) {
 	if err := api.checkAccountID(); err != nil {
 		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
 	}
 
 	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", api.AccountID, scriptName)
-	res, err := api.makeRequest(http.MethodGet, uri, nil)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
 	}
@@ -54,13 +55,13 @@ func (api *API) ListWorkerCronTriggers(scriptName string) ([]WorkerCronTrigger, 
 // UpdateWorkerCronTriggers updates a single schedule for a Worker cron trigger.
 //
 // API reference: https://api.cloudflare.com/#worker-cron-trigger-update-cron-triggers
-func (api *API) UpdateWorkerCronTriggers(scriptName string, crons []WorkerCronTrigger) ([]WorkerCronTrigger, error) {
+func (api *API) UpdateWorkerCronTriggers(ctx context.Context, scriptName string, crons []WorkerCronTrigger) ([]WorkerCronTrigger, error) {
 	if err := api.checkAccountID(); err != nil {
 		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
 	}
 
 	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", api.AccountID, scriptName)
-	res, err := api.makeRequest(http.MethodPut, uri, crons)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, crons)
 	if err != nil {
 		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
 	}

--- a/workers_cron_triggers.go
+++ b/workers_cron_triggers.go
@@ -1,0 +1,74 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// WorkerCronTriggerResponse represents the response from the Worker cron trigger
+// API endpoint.
+type WorkerCronTriggerResponse struct {
+	Response
+	Result WorkerCronTriggerSchedules `json:"result"`
+}
+
+// WorkerCronTriggerSchedules contains the schedule of Worker cron triggers.
+type WorkerCronTriggerSchedules struct {
+	Schedules []WorkerCronTrigger `json:"schedules"`
+}
+
+// WorkerCronTrigger holds an individual cron schedule for a worker.
+type WorkerCronTrigger struct {
+	Cron       string     `json:"cron"`
+	CreatedOn  *time.Time `json:"created_on,omitempty"`
+	ModifiedOn *time.Time `json:"modified_on,omitempty"`
+}
+
+// ListWorkerCronTriggers fetches all available cron triggers for a single Worker
+// script.
+//
+// API reference: https://api.cloudflare.com/#worker-cron-trigger-get-cron-triggers
+func (api *API) ListWorkerCronTriggers(scriptName string) ([]WorkerCronTrigger, error) {
+	if err := api.checkAccountID(); err != nil {
+		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", api.AccountID, scriptName)
+	res, err := api.makeRequest(http.MethodGet, uri, nil)
+	if err != nil {
+		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := WorkerCronTriggerResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []WorkerCronTrigger{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result.Schedules, err
+}
+
+// UpdateWorkerCronTriggers updates a single schedule for a Worker cron trigger.
+//
+// API reference: https://api.cloudflare.com/#worker-cron-trigger-update-cron-triggers
+func (api *API) UpdateWorkerCronTriggers(scriptName string, crons []WorkerCronTrigger) ([]WorkerCronTrigger, error) {
+	if err := api.checkAccountID(); err != nil {
+		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", api.AccountID, scriptName)
+	res, err := api.makeRequest(http.MethodPut, uri, crons)
+	if err != nil {
+		return []WorkerCronTrigger{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	result := WorkerCronTriggerResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []WorkerCronTrigger{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result.Schedules, err
+}

--- a/workers_cron_triggers_test.go
+++ b/workers_cron_triggers_test.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -41,7 +42,7 @@ func TestListWorkerCronTriggers(t *testing.T) {
 		CreatedOn:  &createdOn,
 	}}
 
-	actual, err := client.ListWorkerCronTriggers("example-script")
+	actual, err := client.ListWorkerCronTriggers(context.Background(), "example-script")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -79,7 +80,7 @@ func TestUpdateWorkerCronTriggers(t *testing.T) {
 		CreatedOn:  &createdOn,
 	}}
 
-	actual, err := client.UpdateWorkerCronTriggers("example-script", want)
+	actual, err := client.UpdateWorkerCronTriggers(context.Background(), "example-script", want)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}

--- a/workers_cron_triggers_test.go
+++ b/workers_cron_triggers_test.go
@@ -1,0 +1,86 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListWorkerCronTriggers(t *testing.T) {
+	setup(UsingAccount("9a7806061c88ada191ed06f989cc3dac"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"schedules": [
+					{
+						"cron": "*/30 * * * *",
+						"created_on": "2017-01-01T00:00:00Z",
+						"modified_on": "2017-01-01T00:00:00Z"
+					}
+				]
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/9a7806061c88ada191ed06f989cc3dac/workers/scripts/example-script/schedules", handler)
+	createdOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
+	want := []WorkerCronTrigger{{
+		Cron:       "*/30 * * * *",
+		ModifiedOn: &modifiedOn,
+		CreatedOn:  &createdOn,
+	}}
+
+	actual, err := client.ListWorkerCronTriggers("example-script")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateWorkerCronTriggers(t *testing.T) {
+	setup(UsingAccount("9a7806061c88ada191ed06f989cc3dac"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"schedules": [
+					{
+						"cron": "*/30 * * * *",
+						"created_on": "2017-01-01T00:00:00Z",
+						"modified_on": "2017-01-01T00:00:00Z"
+					}
+				]
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/9a7806061c88ada191ed06f989cc3dac/workers/scripts/example-script/schedules", handler)
+	createdOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
+	want := []WorkerCronTrigger{{
+		Cron:       "*/30 * * * *",
+		ModifiedOn: &modifiedOn,
+		CreatedOn:  &createdOn,
+	}}
+
+	actual, err := client.UpdateWorkerCronTriggers("example-script", want)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
Introduces support for Worker Cron Triggers. As of right now, there is
only two available endpoints; one for listing all schedules and one for
updating.

- https://api.cloudflare.com/#worker-cron-trigger-get-cron-triggers
- https://api.cloudflare.com/#worker-cron-trigger-update-cron-triggers

Closes #549
