### PR TITLE
Add support for Access Mutual TLS certificates

### DIFF
--- a/access_mutual_tls_certificates.go
+++ b/access_mutual_tls_certificates.go
@@ -1,0 +1,225 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// AccessMutualTLSCertificate is the structure of a single Access Mutual TLS
+// certificate.
+type AccessMutualTLSCertificate struct {
+	ID                  string    `json:"id,omitempty"`
+	CreatedAt           time.Time `json:"created_at,omitempty"`
+	UpdatedAt           time.Time `json:"updated_at,omitempty"`
+	ExpiresOn           time.Time `json:"expires_on,omitempty"`
+	Name                string    `json:"name,omitempty"`
+	Fingerprint         string    `json:"fingerprint,omitempty"`
+	Certificate         string    `json:"certificate,omitempty"`
+	AssociatedHostnames []string  `json:"associated_hostnames,omitempty"`
+}
+
+// AccessMutualTLSCertificateListResponse is the API response for all Access
+// Mutual TLS certificates.
+type AccessMutualTLSCertificateListResponse struct {
+	Response
+	Result []AccessMutualTLSCertificate `json:"result"`
+}
+
+// AccessMutualTLSCertificateDetailResponse is the API response for a single
+// Access Mutual TLS certificate.
+type AccessMutualTLSCertificateDetailResponse struct {
+	Response
+	Result AccessMutualTLSCertificate `json:"result"`
+}
+
+// AccessMutualTLSCertificates returns all Access TLS certificates for the account
+// level.
+//
+// API reference: https://api.cloudflare.com/#access-mutual-tls-authentication-properties
+func (api *API) AccessMutualTLSCertificates(accountID string) ([]AccessMutualTLSCertificate, error) {
+	return api.accessMutualTLSCertificates(accountID, AccountRouteRoot)
+}
+
+// ZoneAccessMutualTLSCertificates returns all Access TLS certificates for the
+// zone level.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-properties
+func (api *API) ZoneAccessMutualTLSCertificates(zoneID string) ([]AccessMutualTLSCertificate, error) {
+	return api.accessMutualTLSCertificates(zoneID, ZoneRouteRoot)
+}
+
+func (api *API) accessMutualTLSCertificates(id string, routeRoot RouteRoot) ([]AccessMutualTLSCertificate, error) {
+	uri := fmt.Sprintf(
+		"/%s/%s/access/certificates",
+		routeRoot,
+		id,
+	)
+
+	res, err := api.makeRequestContext(context.Background(), "GET", uri, nil)
+	if err != nil {
+		return []AccessMutualTLSCertificate{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessMutualTLSCertificateListResponse AccessMutualTLSCertificateListResponse
+	err = json.Unmarshal(res, &accessMutualTLSCertificateListResponse)
+	if err != nil {
+		return []AccessMutualTLSCertificate{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessMutualTLSCertificateListResponse.Result, nil
+}
+
+// AccessMutualTLSCertificate returns a single account level Access Mutual TLS
+// certificate.
+//
+// API reference: https://api.cloudflare.com/#access-mutual-tls-authentication-access-certificate-details
+func (api *API) AccessMutualTLSCertificate(accountID, certificateID string) (AccessMutualTLSCertificate, error) {
+	return api.accessMutualTLSCertificate(accountID, certificateID, AccountRouteRoot)
+}
+
+// ZoneAccessMutualTLSCertificate returns a single zone level Access Mutual TLS
+// certificate.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-access-certificate-details
+func (api *API) ZoneAccessMutualTLSCertificate(zoneID, certificateID string) (AccessMutualTLSCertificate, error) {
+	return api.accessMutualTLSCertificate(zoneID, certificateID, ZoneRouteRoot)
+}
+
+func (api *API) accessMutualTLSCertificate(id, certificateID string, routeRoot RouteRoot) (AccessMutualTLSCertificate, error) {
+	uri := fmt.Sprintf(
+		"/%s/%s/access/certificates/%s",
+		routeRoot,
+		id,
+		certificateID,
+	)
+
+	res, err := api.makeRequestContext(context.Background(), "GET", uri, nil)
+	if err != nil {
+		return AccessMutualTLSCertificate{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessMutualTLSCertificateDetailResponse AccessMutualTLSCertificateDetailResponse
+	err = json.Unmarshal(res, &accessMutualTLSCertificateDetailResponse)
+	if err != nil {
+		return AccessMutualTLSCertificate{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessMutualTLSCertificateDetailResponse.Result, nil
+}
+
+// CreateAccessMutualTLSCertificate creates an account level Access TLS Mutual
+// certificate.
+//
+// API reference: https://api.cloudflare.com/#access-mutual-tls-authentication-create-access-certificate
+func (api *API) CreateAccessMutualTLSCertificate(accountID string, certificate AccessMutualTLSCertificate) (AccessMutualTLSCertificate, error) {
+	return api.createAccessMutualTLSCertificate(accountID, certificate, AccountRouteRoot)
+}
+
+// CreateZoneAccessMutualTLSCertificate creates a zone level Access TLS Mutual
+// certificate.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-create-access-certificate
+func (api *API) CreateZoneAccessMutualTLSCertificate(zoneID string, certificate AccessMutualTLSCertificate) (AccessMutualTLSCertificate, error) {
+	return api.createAccessMutualTLSCertificate(zoneID, certificate, ZoneRouteRoot)
+}
+
+func (api *API) createAccessMutualTLSCertificate(id string, certificate AccessMutualTLSCertificate, routeRoot RouteRoot) (AccessMutualTLSCertificate, error) {
+	uri := fmt.Sprintf(
+		"/%s/%s/access/certificates",
+		routeRoot,
+		id,
+	)
+
+	res, err := api.makeRequestContext(context.Background(), "POST", uri, certificate)
+	if err != nil {
+		return AccessMutualTLSCertificate{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessMutualTLSCertificateDetailResponse AccessMutualTLSCertificateDetailResponse
+	err = json.Unmarshal(res, &accessMutualTLSCertificateDetailResponse)
+	if err != nil {
+		return AccessMutualTLSCertificate{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessMutualTLSCertificateDetailResponse.Result, nil
+}
+
+// UpdateAccessMutualTLSCertificate updates an account level Access TLS Mutual
+// certificate.
+//
+// API reference: https://api.cloudflare.com/#access-mutual-tls-authentication-update-access-certificate
+func (api *API) UpdateAccessMutualTLSCertificate(accountID, certificateID string, certificate AccessMutualTLSCertificate) (AccessMutualTLSCertificate, error) {
+	return api.updateAccessMutualTLSCertificate(accountID, certificateID, certificate, AccountRouteRoot)
+}
+
+// UpdateZoneAccessMutualTLSCertificate updates a zone level Access TLS Mutual
+// certificate.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-update-access-certificate
+func (api *API) UpdateZoneAccessMutualTLSCertificate(zoneID, certificateID string, certificate AccessMutualTLSCertificate) (AccessMutualTLSCertificate, error) {
+	return api.updateAccessMutualTLSCertificate(zoneID, certificateID, certificate, ZoneRouteRoot)
+}
+
+func (api *API) updateAccessMutualTLSCertificate(id string, certificateID string, certificate AccessMutualTLSCertificate, routeRoot RouteRoot) (AccessMutualTLSCertificate, error) {
+	uri := fmt.Sprintf(
+		"/%s/%s/access/certificates/%s",
+		routeRoot,
+		id,
+		certificateID,
+	)
+
+	res, err := api.makeRequestContext(context.Background(), "PUT", uri, certificate)
+	if err != nil {
+		return AccessMutualTLSCertificate{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessMutualTLSCertificateDetailResponse AccessMutualTLSCertificateDetailResponse
+	err = json.Unmarshal(res, &accessMutualTLSCertificateDetailResponse)
+	if err != nil {
+		return AccessMutualTLSCertificate{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return accessMutualTLSCertificateDetailResponse.Result, nil
+}
+
+// DeleteAccessMutualTLSCertificate destroys an account level Access Mutual
+// TLS certificate.
+//
+// API reference: https://api.cloudflare.com/#access-mutual-tls-authentication-update-access-certificate
+func (api *API) DeleteAccessMutualTLSCertificate(accountID, certificateID string) error {
+	return api.deleteAccessMutualTLSCertificate(accountID, certificateID, AccountRouteRoot)
+}
+
+// DeleteZoneAccessMutualTLSCertificate destroys a zone level Access Mutual TLS
+// certificate.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-update-access-certificate
+func (api *API) DeleteZoneAccessMutualTLSCertificate(zoneID, certificateID string) error {
+	return api.deleteAccessMutualTLSCertificate(zoneID, certificateID, ZoneRouteRoot)
+}
+
+func (api *API) deleteAccessMutualTLSCertificate(id, certificateID string, routeRoot RouteRoot) error {
+	uri := fmt.Sprintf(
+		"/%s/%s/access/certificates/%s",
+		routeRoot,
+		id,
+		certificateID,
+	)
+
+	res, err := api.makeRequestContext(context.Background(), "DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	var accessMutualTLSCertificateDetailResponse AccessMutualTLSCertificateDetailResponse
+	err = json.Unmarshal(res, &accessMutualTLSCertificateDetailResponse)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}

--- a/access_mutual_tls_certificates_test.go
+++ b/access_mutual_tls_certificates_test.go
@@ -1,0 +1,276 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccessMutualTLSCertificates(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+					"created_at": "2014-01-01T05:20:00.12345Z",
+					"updated_at": "2014-01-01T05:20:00.12345Z",
+					"expires_on": "2014-01-01T05:20:00.12345Z",
+					"name": "Allow devs",
+					"fingerprint": "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+					"associated_hostnames": [
+						"admin.example.com"
+					]
+				}
+			]
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+
+	want := []AccessMutualTLSCertificate{{
+		ID:                  "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		CreatedAt:           createdAt,
+		UpdatedAt:           updatedAt,
+		ExpiresOn:           expiresOn,
+		Name:                "Allow devs",
+		Fingerprint:         "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+		AssociatedHostnames: []string{"admin.example.com"},
+	}}
+
+	mux.HandleFunc("/accounts/"+accountID+"/access/certificates", handler)
+
+	actual, err := client.AccessMutualTLSCertificates(accountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/certificates", handler)
+
+	actual, err = client.ZoneAccessMutualTLSCertificates(zoneID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestAccessMutualTLSCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "GET", "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z",
+				"expires_on": "2014-01-01T05:20:00.12345Z",
+				"name": "Allow devs",
+				"fingerprint": "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+				"associated_hostnames": [
+					"admin.example.com"
+				]
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+
+	want := AccessMutualTLSCertificate{
+		ID:                  "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		CreatedAt:           createdAt,
+		UpdatedAt:           updatedAt,
+		ExpiresOn:           expiresOn,
+		Name:                "Allow devs",
+		Fingerprint:         "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+		AssociatedHostnames: []string{"admin.example.com"},
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/access/certificates/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err := client.AccessMutualTLSCertificate(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/certificates/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err = client.ZoneAccessMutualTLSCertificate(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateAccessMutualTLSCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z",
+				"expires_on": "2014-01-01T05:20:00.12345Z",
+				"name": "Allow devs",
+				"fingerprint": "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+				"associated_hostnames": [
+					"admin.example.com"
+				]
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+
+	certificate := AccessMutualTLSCertificate{
+		Name:        "Allow devs",
+		Certificate: "-----BEGIN CERTIFICATE-----\nMIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...N4RI7KKB7nikiuUf8vhULKy5IX10\nDrUtmu/B\n-----END CERTIFICATE-----",
+	}
+
+	want := AccessMutualTLSCertificate{
+		ID:                  "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		CreatedAt:           createdAt,
+		UpdatedAt:           updatedAt,
+		ExpiresOn:           expiresOn,
+		Name:                "Allow devs",
+		Fingerprint:         "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+		AssociatedHostnames: []string{"admin.example.com"},
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/access/certificates", handler)
+
+	actual, err := client.CreateAccessMutualTLSCertificate(accountID, certificate)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/certificates", handler)
+
+	actual, err = client.CreateZoneAccessMutualTLSCertificate(zoneID, certificate)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateAccessMutualTLSCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "PUT", "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z",
+				"expires_on": "2014-01-01T05:20:00.12345Z",
+				"name": "Allow devs",
+				"fingerprint": "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+				"associated_hostnames": [
+					"admin.example.com"
+				]
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	expiresOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+
+	certificate := AccessMutualTLSCertificate{
+		Name:        "Allow devs",
+		Certificate: "-----BEGIN CERTIFICATE-----\nMIIGAjCCA+qgAwIBAgIJAI7kymlF7CWT...N4RI7KKB7nikiuUf8vhULKy5IX10\nDrUtmu/B\n-----END CERTIFICATE-----",
+	}
+
+	want := AccessMutualTLSCertificate{
+		ID:                  "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		CreatedAt:           createdAt,
+		UpdatedAt:           updatedAt,
+		ExpiresOn:           expiresOn,
+		Name:                "Allow devs",
+		Fingerprint:         "MD5 Fingerprint=1E:80:0F:7A:FD:31:55:96:DE:D5:CB:E2:F0:91:F6:91",
+		AssociatedHostnames: []string{"admin.example.com"},
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/access/certificates/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err := client.UpdateAccessMutualTLSCertificate(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415", certificate)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/certificates/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	actual, err = client.UpdateZoneAccessMutualTLSCertificate(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415", certificate)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeleteAccessMutualTLSCertificate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415"
+			}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/access/certificates/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	err := client.DeleteAccessMutualTLSCertificate(accountID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	assert.NoError(t, err)
+
+	mux.HandleFunc("/zones/"+zoneID+"/access/certificates/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
+
+	err = client.DeleteZoneAccessMutualTLSCertificate(zoneID, "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Introduces support for Access Mutual TLS certificates at the account and
zone level following similar patterns to the previous implementations.

### API documentation

List all certificates

- https://api.cloudflare.com/#access-mutual-tls-authentication-properties
- https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-properties

List single certificate

- https://api.cloudflare.com/#access-mutual-tls-authentication-access-certificate-details
- https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-access-certificate-details

Create certificate

- https://api.cloudflare.com/#access-mutual-tls-authentication-create-access-certificate
- https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-create-access-certificate

Update certificate

- https://api.cloudflare.com/#access-mutual-tls-authentication-update-access-certificate
- https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-update-access-certificate

Delete certificate

- https://api.cloudflare.com/#access-mutual-tls-authentication-update-access-certificate
- https://api.cloudflare.com/#zone-level-access-mutual-tls-authentication-update-access-certificate

Closes #559
