### PR TITLE
Account support

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strconv"
 
@@ -17,7 +18,8 @@ type AccountSettings struct {
 type Account struct {
 	ID       string           `json:"id,omitempty"`
 	Name     string           `json:"name,omitempty"`
-	Settings *AccountSettings `json:"settings"`
+	Type     string           `json:"type,omitempty"`
+	Settings *AccountSettings `json:"settings,omitempty"`
 }
 
 // AccountResponse represents the response from the accounts endpoint for a
@@ -100,6 +102,27 @@ func (api *API) UpdateAccount(accountID string, account Account) (Account, error
 	uri := "/accounts/" + accountID
 
 	res, err := api.makeRequest("PUT", uri, account)
+	if err != nil {
+		return Account{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var a AccountDetailResponse
+	err = json.Unmarshal(res, &a)
+	if err != nil {
+		return Account{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return a.Result, nil
+}
+
+// CreateAccount creates a new account. Note: This requires the Tenant
+// entitlement.
+//
+// API reference: https://developers.cloudflare.com/tenant/tutorial/provisioning-resources#creating-an-account
+func (api *API) CreateAccount(account Account) (Account, error) {
+	uri := "/accounts"
+
+	res, err := api.makeRequest("POST", uri, account)
 	if err != nil {
 		return Account{}, errors.Wrap(err, errMakeRequestError)
 	}

--- a/accounts.go
+++ b/accounts.go
@@ -135,3 +135,22 @@ func (api *API) CreateAccount(account Account) (Account, error) {
 
 	return a.Result, nil
 }
+
+// DeleteAccount removes an account. Note: This requires the Tenant
+// entitlement.
+//
+// API reference: https://developers.cloudflare.com/tenant/tutorial/provisioning-resources#optional-deleting-accounts
+func (api *API) DeleteAccount(accountID string) error {
+	if accountID == "" {
+		return errors.New(errMissingAccountID)
+	}
+
+	uri := fmt.Sprintf("/accounts/%s", accountID)
+
+	_, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	return nil
+}

--- a/accounts.go
+++ b/accounts.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -119,10 +120,10 @@ func (api *API) UpdateAccount(accountID string, account Account) (Account, error
 // entitlement.
 //
 // API reference: https://developers.cloudflare.com/tenant/tutorial/provisioning-resources#creating-an-account
-func (api *API) CreateAccount(account Account) (Account, error) {
+func (api *API) CreateAccount(ctx context.Context, account Account) (Account, error) {
 	uri := "/accounts"
 
-	res, err := api.makeRequest("POST", uri, account)
+	res, err := api.makeRequestContext(ctx, "POST", uri, account)
 	if err != nil {
 		return Account{}, errors.Wrap(err, errMakeRequestError)
 	}
@@ -140,14 +141,14 @@ func (api *API) CreateAccount(account Account) (Account, error) {
 // entitlement.
 //
 // API reference: https://developers.cloudflare.com/tenant/tutorial/provisioning-resources#optional-deleting-accounts
-func (api *API) DeleteAccount(accountID string) error {
+func (api *API) DeleteAccount(ctx context.Context, accountID string) error {
 	if accountID == "" {
 		return errors.New(errMissingAccountID)
 	}
 
 	uri := fmt.Sprintf("/accounts/%s", accountID)
 
-	_, err := api.makeRequest("DELETE", uri, nil)
+	_, err := api.makeRequestContext(ctx, "DELETE", uri, nil)
 	if err != nil {
 		return errors.Wrap(err, errMakeRequestError)
 	}

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -183,7 +184,7 @@ func TestCreateAccount(t *testing.T) {
 		Type: "standard",
 	}
 
-	actual, err := client.CreateAccount(newAccount)
+	actual, err := client.CreateAccount(context.Background(), newAccount)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, newAccount, actual)
@@ -209,7 +210,7 @@ func TestDeleteAccount(t *testing.T) {
 	}
 
 	mux.HandleFunc("/accounts/"+accountID, handler)
-	err := client.DeleteAccount(accountID)
+	err := client.DeleteAccount(context.Background(), accountID)
 
 	assert.NoError(t, err)
 }

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -151,3 +151,41 @@ func TestUpdateAccount(t *testing.T) {
 		assert.Equal(t, account.Name, "Cloudflare Demo - New")
 	}
 }
+
+func TestCreateAccount(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "POST", "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"name": "Cloudflare Demo",
+				"type": "standard"
+			},
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts", handler)
+	newAccount := Account{
+		Name: "Cloudflare Demo",
+		Type: "standard",
+	}
+
+	actual, err := client.CreateAccount(newAccount)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, newAccount, actual)
+	}
+}

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -189,3 +189,27 @@ func TestCreateAccount(t *testing.T) {
 		assert.Equal(t, newAccount, actual)
 	}
 }
+
+func TestDeleteAccount(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, "DELETE", "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "1b16db169c9cb7853009857198fae1b9"
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/"+accountID, handler)
+	err := client.DeleteAccount(accountID)
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Adds the ability to create and delete Accounts. 

Note: This does require the Tenant entitlement present on the user 
initiating the request.