### PR TITLE
firewall_rule: Fix the ability to delete multiple rules

### DIFF
--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -163,7 +162,7 @@ func (api *API) UpdateFirewallRules(zoneID string, firewallRules []FirewallRule)
 	return firewallRulesDetailResponse.Result, nil
 }
 
-// DeleteFirewallRule updates a single firewall rule.
+// DeleteFirewallRule deletes a single firewall rule.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/delete/#delete-a-single-rule
 func (api *API) DeleteFirewallRule(zoneID, firewallRuleID string) error {
@@ -181,12 +180,17 @@ func (api *API) DeleteFirewallRule(zoneID, firewallRuleID string) error {
 	return nil
 }
 
-// DeleteFirewallRules updates a single firewall rule.
+// DeleteFirewallRules deletes multiple firewall rules at once.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/delete/#delete-multiple-rules
 func (api *API) DeleteFirewallRules(zoneID string, firewallRuleIDs []string) error {
-	ids := strings.Join(firewallRuleIDs, ",")
-	uri := fmt.Sprintf("/zones/%s/firewall/rules?id=%s", zoneID, ids)
+	v := url.Values{}
+
+	for _, ruleID := range firewallRuleIDs {
+		v.Add("id", ruleID)
+	}
+
+	uri := fmt.Sprintf("/zones/%s/firewall/rules?%s", zoneID, v.Encode())
 
 	_, err := api.makeRequest("DELETE", uri, nil)
 	if err != nil {


### PR DESCRIPTION
Updates the internals of `DeleteFirewallRules` to build the correct
query string parameters for deleting multiple rules in a single request.

I attempted the following without any luck:

- `?id=abc123,def456`
- `?id[]=abc123&id[]=def456`
- `DELETE /zones/:zone_id/firewall/rules` with a payload of 
  `[{"id":"abc123"},{"id":"def456"}]`

The first option was the initial version that worked however it looks like the
API has moved on to another method which we now support here.

Closes #565

