### PR TITLE
dns: swap `Priority` to *uint16

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -25,7 +25,7 @@ type DNSRecord struct {
 	ModifiedOn time.Time   `json:"modified_on,omitempty"`
 	Data       interface{} `json:"data,omitempty"` // data returned by: SRV, LOC
 	Meta       interface{} `json:"meta,omitempty"`
-	Priority   int         `json:"priority,omitempty"`
+	Priority   *uint16     `json:"priority,omitempty"`
 }
 
 // DNSRecordResponse represents the response from the DNS endpoint.


### PR DESCRIPTION
`DNSRecord` priority was initially an int. This worked most of the time
however in some cases, 0 was intended to be used as a zero value and in
others, a valid value. This causes confusion and in combination with
`omitempty` on the struct, makes it impossible to send 0 as a value.

```go
type DNSRecord struct {
	Type     string  `json:"type,omitempty"`
	Priority int `json:"priority,omitempty"`
}

func main() {
	// using 0 as a value
	var p = int(0)
	d := DNSRecord{
		Type:     "MX",
		Priority: p,
	}
	b, _ := json.Marshal(d)
	fmt.Println(string(b))

	// => {"type":"MX"}
}
```

To rectify, I've swapped the struct to `*uint16` which accomplishes two
things. The first, aligns with our internal representation of the data
struct. The second, allows us to use 0 in both contexts as a zero value
but also as a value reference where it is needed.

```go
type DNSRecord struct {
	Type     string  `json:"type,omitempty"`
	Priority *uint16 `json:"priority,omitempty"`
}

func main() {
	var p1 = uint16(0)
	d1 := DNSRecord{
		Type:     "MX",
		Priority: &p1,
	}
	b1, _ := json.Marshal(d1)
	fmt.Println(string(b1))
	// => {"type":"MX","priority":0}

	var p2 = uint16(10)
	d2 := DNSRecord{
		Type:     "MX",
		Priority: &p2,
	}
	b2, _ := json.Marshal(d2)
	fmt.Println(string(b2))
	// => {"type":"MX","priority":10}

	d3 := DNSRecord{
		Type:       "MX",
		Priority: nil,
	}
	b3, _ := json.Marshal(d3)
	fmt.Println(string(b3))
	// => {"type":"MX"}
}
```

Fixes SDK-114 and lays the ground work for the Terraform provider fix.