### PR TITLE
ip_address_management: add `on_demand_locked` field

### DIFF
--- a/ip_address_management.go
+++ b/ip_address_management.go
@@ -20,6 +20,7 @@ type IPPrefix struct {
 	Description          string     `json:"description"`
 	Approved             string     `json:"approved"`
 	OnDemandEnabled      bool       `json:"on_demand_enabled"`
+	OnDemandLocked       bool       `json:"on_demand_locked"`
 	Advertised           bool       `json:"advertised"`
 	AdvertisedModifiedAt *time.Time `json:"advertised_modified_at"`
 }

--- a/ip_address_management_test.go
+++ b/ip_address_management_test.go
@@ -28,6 +28,7 @@ func TestListIPPrefix(t *testing.T) {
 					"description": "Sample Prefix",
 					"approved": "V",
 					"on_demand_enabled": true,
+					"on_demand_locked": false,
 					"advertised": true,
 					"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
 				}
@@ -82,6 +83,7 @@ func TestGetIPPrefix(t *testing.T) {
 				"description": "Sample Prefix",
 				"approved": "V",
 				"on_demand_enabled": true,
+				"on_demand_locked": false,
 				"advertised": true,
 				"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
 			},
@@ -133,6 +135,7 @@ func TestUpdatePrefixDescription(t *testing.T) {
 				"description": "My IP Prefix",
 				"approved": "V",
 				"on_demand_enabled": true,
+				"on_demand_locked": false,
 				"advertised": true,
 				"advertised_modified_at": "2020-04-24T21:25:55.643771Z"
 			},


### PR DESCRIPTION
Updates the `IPPrefix` struct to include the newly available
`on_demand_locked` value.

See ADDR-1351

