### PR TITLE
Added the header to the LoadBalancerOrigin struct

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -29,10 +29,11 @@ type LoadBalancerPool struct {
 
 // LoadBalancerOrigin represents a Load Balancer origin's properties.
 type LoadBalancerOrigin struct {
-	Name    string  `json:"name"`
-	Address string  `json:"address"`
-	Enabled bool    `json:"enabled"`
-	Weight  float64 `json:"weight"`
+	Name    string              `json:"name"`
+	Address string              `json:"address"`
+	Enabled bool                `json:"enabled"`
+	Weight  float64             `json:"weight"`
+	Header  map[string][]string `json:"header"`
 }
 
 // LoadBalancerMonitor represents a load balancer monitor's properties.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -31,8 +31,13 @@ func TestCreateLoadBalancerPool(t *testing.T) {
                   "name": "app-server-1",
                   "address": "0.0.0.0",
                   "enabled": true,
-                  "weight": 1
-                }
+                  "weight": 1,
+				  "header": {
+					  "Host": [
+						  "example.com"
+					  ]
+				  }
+				}
               ],
               "notification_email": "someone@example.com",
               "check_regions": [
@@ -58,8 +63,13 @@ func TestCreateLoadBalancerPool(t *testing.T) {
                   "name": "app-server-1",
                   "address": "0.0.0.0",
                   "enabled": true,
-                  "weight": 1
-                }
+                  "weight": 1,
+				  "header": {
+					  "Host": [
+						  "example.com"
+					  ]
+				  }
+				}
               ],
               "notification_email": "someone@example.com",
               "check_regions": [
@@ -87,6 +97,9 @@ func TestCreateLoadBalancerPool(t *testing.T) {
 				Address: "0.0.0.0",
 				Enabled: true,
 				Weight:  1,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
 			},
 		},
 		NotificationEmail: "someone@example.com",
@@ -105,6 +118,9 @@ func TestCreateLoadBalancerPool(t *testing.T) {
 				Address: "0.0.0.0",
 				Enabled: true,
 				Weight:  1,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
 			},
 		},
 		NotificationEmail: "someone@example.com",
@@ -294,7 +310,12 @@ func TestModifyLoadBalancerPool(t *testing.T) {
                   "name": "app-server-2",
                   "address": "0.0.0.1",
                   "enabled": false,
-                  "weight": 1
+                  "weight": 1,
+				  "header": {
+					  "Host": [
+						  "example.com"
+					  ]
+				  }
                 }
               ],
               "notification_email": "nobody@example.com",
@@ -319,7 +340,12 @@ func TestModifyLoadBalancerPool(t *testing.T) {
                   "name": "app-server-2",
                   "address": "0.0.0.1",
                   "enabled": false,
-                  "weight": 1
+                  "weight": 1,
+				  "header": {
+					  "Host": [
+						  "example.com"
+					  ]
+				  }
                 }
               ],
               "notification_email": "nobody@example.com",
@@ -346,6 +372,9 @@ func TestModifyLoadBalancerPool(t *testing.T) {
 				Address: "0.0.0.1",
 				Enabled: false,
 				Weight:  1,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
 			},
 		},
 		NotificationEmail: "nobody@example.com",
@@ -364,6 +393,9 @@ func TestModifyLoadBalancerPool(t *testing.T) {
 				Address: "0.0.0.1",
 				Enabled: false,
 				Weight:  1,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
 			},
 		},
 		NotificationEmail: "nobody@example.com",


### PR DESCRIPTION
The header field in the LoadBalancerOrigin struct was missing. The API for the [loadbalancer](https://api.cloudflare.com/#load-balancer-pools-create-pool) defines the `header` field. 

## Description

The [terraform-provider-cloudflare](https://github.com/cloudflare/terraform-provider-cloudflare) relies on this project to be able to implement the Cloudflare API. Since the `header` field is missing, things like overriding the Cloudflare Loadbalancer Origin's `host` header are not possible via the provider.

https://github.com/cloudflare/terraform-provider-cloudflare/issues/957

## Has your change been tested?

I ran `go test .` and all tests passed after modifying `load_balancing_test.go`.

```
ok      github.com/cloudflare/cloudflare-go     (cached)
```

## Types of changes

What sort of change does your code introduce/modify?

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
