### PR TITLE
always marshal CustomHostnameSSL.Wildcard into api request body payload

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -52,7 +52,7 @@ type CustomHostnameSSL struct {
 	Type                 string                              `json:"type,omitempty"`
 	CnameTarget          string                              `json:"cname_target,omitempty"`
 	CnameName            string                              `json:"cname,omitempty"`
-	Wildcard             bool                                `json:"wildcard,omitempty"`
+	Wildcard             *bool                               `json:"wildcard,omitempty"`
 	CustomCertificate    string                              `json:"custom_certificate,omitempty"`
 	CustomKey            string                              `json:"custom_key,omitempty"`
 	CertificateAuthority string                              `json:"certificate_authority,omitempty"`


### PR DESCRIPTION
## Description

When the `CustomHostnameSSL` field is converted to a json payload for the http request body, the `Wildcard` value is stripped when set to `false`. 

## Has your change been tested?

* I tested updating a custom hostname wildcard from `true` to `false` with my branch and the update succeeded
* The modified tests also succeeded via `go test .`

## Types of changes

What sort of change does your code introduce/modify?

- [x] Breaking change (fix or feature that would cause existing functionality to change)

> Previously omitting the `Wildcard` key from the `CustomHostname` struct would effectively execute a partial update and omit the update of the wildcard field. Custom hostname updates will now always set the wildcard to the value of the passed in struct (whether or not explicitly referenced).

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
