### PR TITLE
options: Add BaseURL for clients

### DIFF
--- a/options.go
+++ b/options.go
@@ -84,6 +84,14 @@ func UserAgent(userAgent string) Option {
 	}
 }
 
+// BaseURL allows you to override the default HTTP base URL used for API calls.
+func BaseURL(baseURL string) Option {
+	return func(api *API) error {
+		api.BaseURL = baseURL
+		return nil
+	}
+}
+
 // parseOptions parses the supplied options functions and returns a configured
 // *API instance.
 func (api *API) parseOptions(opts ...Option) error {


### PR DESCRIPTION
Updates the client to be able to override the [`baseURL`](https://github.com/cloudflare/cloudflare-go/blob/1426b776f85bc6c5c9390247d48b6ea0bcffa13f/cloudflare.go#L22) when
instantiating the client.

Use cases are generally restricted to Cloudflare employees but who knows
who else may have use for this.

Here is an example of setting up two clients and compare the output from
local and production and how we would use this.

```go
package main

import (
	"fmt"

	"github.com/cloudflare/cloudflare-go"
)

func main() {
	local, lErr := cloudflare.New(
		"API_KEY",
		"API_EMAIL",
		cloudflare.BaseURL("https://api.test"),
	)

	prod, pErr := cloudflare.New(
		"API_KEY",
		"API_EMAIL",
	)

	if lErr != nil || pErr != nil {
		fmt.Errorf("failed to create clients")
	}

	z1, _ := local.ZoneIDByName("example.com")
	z2, _ := prod.ZoneIDByName("example.com")

	// compare the outputs
}
```

