### PR TITLE
Adds GetWorker route API (singular) endpoint

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -696,7 +696,7 @@ func (api *API) ListWorkerRoutes(ctx context.Context, zoneID string) (WorkerRout
 	return r, nil
 }
 
-// GetWorkerRoute returns a worker route
+// GetWorkerRoute returns a worker route.
 //
 // API reference: https://api.cloudflare.com/#worker-routes-get-route
 func (api *API) GetWorkerRoute(ctx context.Context, zoneID string, routeID string) (WorkerRouteResponse, error) {

--- a/workers.go
+++ b/workers.go
@@ -696,6 +696,23 @@ func (api *API) ListWorkerRoutes(ctx context.Context, zoneID string) (WorkerRout
 	return r, nil
 }
 
+// GetWorkerRoute returns a worker route
+//
+// API reference: https://api.cloudflare.com/#worker-routes-get-route
+func (api *API) GetWorkerRoute(ctx context.Context, zoneID string, routeID string) (WorkerRouteResponse, error) {
+	uri := "/zones/" + zoneID + "/workers/routes/" + routeID
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return WorkerRouteResponse{}, err
+	}
+	var r WorkerRouteResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return WorkerRouteResponse{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r, nil
+}
+
 // UpdateWorkerRoute updates worker route for a zone.
 //
 // API reference: https://api.cloudflare.com/#worker-filters-update-filter, https://api.cloudflare.com/#worker-routes-update-route

--- a/workers_test.go
+++ b/workers_test.go
@@ -98,6 +98,16 @@ const (
     "errors": [],
     "messages": []
 }`
+	getRouteResponseData = `{
+    "result": {
+       "id": "e7a57d8746e74ae49c25994dadb421b1",
+       "pattern": "app1.example.com/*",
+       "script": "script-name"
+    },
+    "success": true,
+    "errors": [],
+    "messages": []
+}`
 	listBindingsResponseData = `{
 		"result": [
 			{
@@ -812,6 +822,28 @@ func TestWorkers_ListWorkerRoutesEnt(t *testing.T) {
 			{ID: "f8b68e9857f85bf59c25994dadb421b1", Pattern: "app2.example.com/*", Script: "test_script_2", Enabled: true},
 			{ID: "2b5bf4240cd34c77852fac70b1bf745a", Pattern: "app3.example.com/*", Script: "", Enabled: false},
 		},
+	}
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, res)
+	}
+}
+
+func TestWorkers_GetWorkerRoute(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/zones/foo/workers/routes/1234", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application-json")
+		fmt.Fprintf(w, getRouteResponseData)
+	})
+
+	res, err := client.GetWorkerRoute(context.Background(), "foo", "1234")
+	want := WorkerRouteResponse{successResponse,
+		WorkerRoute{
+			ID:      "e7a57d8746e74ae49c25994dadb421b1",
+			Pattern: "app1.example.com/*",
+			Script:  "script-name"},
 	}
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, res)


### PR DESCRIPTION
## Description

Adds GetWorkerRoute API. https://api.cloudflare.com/#worker-routes-get-route

Wasn't entirely sure on the naming of the function and kept it same as the API endpoint.

## Has your change been tested?

I've added testing code however I noted that the other tests have a normal zone vs Enterprise zone JSON blobs. I don't think this API returns any different data based on zone type but I was unable to test this.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
