### PR TITLE
errors: Add helper methods for searching in slices

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -98,3 +98,26 @@ func (e *APIRequestError) ClientError() bool {
 func (e *APIRequestError) ClientRateLimited() bool {
 	return e.StatusCode == http.StatusTooManyRequests
 }
+
+// InternalErrorCodeIs returns a boolean whether or not the desired internal
+// error code is present in `e.InternalErrorCodes`.
+func (e *APIRequestError) InternalErrorCodeIs(code int) bool {
+	for _, errCode := range e.InternalErrorCodes() {
+		if errCode == code {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ErrorMessageContains returns a boolean whether or not a substring exists in
+// any of the `e.ErrorMessages` slice entries.
+func (e *APIRequestError) ErrorMessageContains(s string) bool {
+	for _, errMsg := range e.ErrorMessages() {
+		if strings.Contains(errMsg, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -176,3 +176,21 @@ func TestAPIRequestError_ClientRateLimited(t *testing.T) {
 		})
 	}
 }
+
+func TestAPIRequestError_InternalErrorCodeIs(t *testing.T) {
+	err := &APIRequestError{Errors: []ResponseInfo{
+		{Code: 1001},
+		{Code: 2001},
+		{Code: 3001},
+	}}
+	assert.Equal(t, err.InternalErrorCodeIs(3001), true)
+}
+
+func TestAPIRequestError_ErrorMessageContains(t *testing.T) {
+	err := &APIRequestError{Errors: []ResponseInfo{
+		{Message: "dns thing broke"},
+		{Message: "application thing broke"},
+		{Message: "network thing broke"},
+	}}
+	assert.Equal(t, err.ErrorMessageContains("application thing broke"), true)
+}


### PR DESCRIPTION
Introduces two new helper methods to search inside of the
`InternalErrorCodes()` and `ErrorMessages()` for cases where we want to
know if either of them contains a value we want.

Examples:

- Was an internal error code returned for a specific error?
```go
if err.(*cloudflare.APIRequestError).InternalErrorCodeIs(1414) {
    // do something specific for error code 1414
}
```

- Did the error message contain a mention of "failed to update"?
```go
if err.(*cloudflare.APIRequestError).ErrorMessageContains("failed to update") {
    // do something specific when it fails to update
}
```