### PR TITLE
add device_posture rule type for Access

### DIFF
--- a/access_group.go
+++ b/access_group.go
@@ -168,6 +168,7 @@ type AccessGroupLoginMethod struct {
 	} `json:"login_method"`
 }
 
+// AccessGroupDevicePosture restricts the application to specific devices
 type AccessGroupDevicePosture struct {
 	DevicePosture struct {
 		ID string `json:"integration_uid"`

--- a/access_group.go
+++ b/access_group.go
@@ -168,6 +168,12 @@ type AccessGroupLoginMethod struct {
 	} `json:"login_method"`
 }
 
+type AccessGroupDevicePosture struct {
+	DevicePosture struct {
+		ID string `json:"integration_uid"`
+	} `json:"device_posture"`
+}
+
 // AccessGroupListResponse represents the response from the list
 // access group endpoint.
 type AccessGroupListResponse struct {


### PR DESCRIPTION
## Description

Adds support for the device_posture rule in Access. An example of the rule can be seen in our developer docs shortly: https://developers.cloudflare.com/cloudflare-one/api-terraform/rule-api-examples.

## Has your change been tested?

```
curl --request POST \                                                                                                                         
  --url http://localhost:9002/api/apps \
  --header 'Content-Type: application/json' \
  --header 'X-Auth-Email: ************' \                 
  --header 'X-Auth-Key: *****************' \
  --data '{
      "domain": "****",
      "id": "*********",
      "name": "app",
      "policies": [
        {
          "created_at": "2021-04-21T21:30:29Z",
          "decision": "allow",
          "exclude": [],
          "id":  "**********************",
          "include": [
            {
              "device_posture": {
                "integration_uid": "**********************"
              }
            }
          ],
          "name": "test",
          "precedence": 1,
          "require": [],
          "uid": "***********************",
        }
      ],
      "allowed_idps": [],
      "auto_redirect_to_identity": false,
      "session_duration": "0s",
      "uid": "***********************",
      "type": "self_hosted"
    }'
```

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
