### PR TITLE
Add Teams List

### DIFF
--- a/teams_list.go
+++ b/teams_list.go
@@ -1,0 +1,194 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// TeamsList represents a Teams List.
+type TeamsList struct {
+	ID          string          `json:"id,omitempty"`
+	Name        string          `json:"name"`
+	Type        string          `json:"type"`
+	Description string          `json:"description,omitempty"`
+	Items       []TeamsListItem `json:"items,omitempty"`
+	Count       uint64          `json:"count,omitempty"`
+	CreatedAt   *time.Time      `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time      `json:"updated_at,omitempty"`
+}
+
+// TeamsListItem represents a single list item.
+type TeamsListItem struct {
+	Value string `json:"value"`
+}
+
+// PatchTeamsList represents a patch request for appending/removing list items.
+type PatchTeamsList struct {
+	ID     string          `json:"id"`
+	Append []TeamsListItem `json:"append"`
+	Remove []string        `json:"remove"`
+}
+
+// TeamsListListResponse represents the response from the list
+// teams lists endpoint.
+type TeamsListListResponse struct {
+	Result []TeamsList `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// TeamsListDetailResponse is the API response, containing a single
+// teams list.
+type TeamsListDetailResponse struct {
+	Success  bool      `json:"success"`
+	Errors   []string  `json:"errors"`
+	Messages []string  `json:"messages"`
+	Result   TeamsList `json:"result"`
+}
+
+// TeamsLists returns all lists within an account.
+//
+// API reference: TODO
+func (api *API) TeamsLists(ctx context.Context, accountID string) ([]TeamsList, ResultInfo, error) {
+	uri := fmt.Sprintf("/%s/%s/lists", AccountRouteRoot, accountID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []TeamsList{}, ResultInfo{}, err
+	}
+
+	var teamsListListResponse TeamsListListResponse
+	err = json.Unmarshal(res, &teamsListListResponse)
+	if err != nil {
+		return []TeamsList{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return teamsListListResponse.Result, teamsListListResponse.ResultInfo, nil
+}
+
+// TeamsList returns a single list based on the list ID.
+//
+// API reference: TODO
+func (api *API) TeamsList(ctx context.Context, accountID, listID string) (TeamsList, error) {
+	uri := fmt.Sprintf(
+		"/%s/%s/lists/%s",
+		AccountRouteRoot,
+		accountID,
+		listID,
+	)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return TeamsList{}, err
+	}
+
+	var teamsListDetailResponse TeamsListDetailResponse
+	err = json.Unmarshal(res, &teamsListDetailResponse)
+	if err != nil {
+		return TeamsList{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return teamsListDetailResponse.Result, nil
+}
+
+// CreateTeamsList creates a new teams list.
+//
+// API reference: TODO
+func (api *API) CreateTeamsList(ctx context.Context, accountID string, teamsList TeamsList) (TeamsList, error) {
+	uri := fmt.Sprintf("/%s/%s/lists", AccountRouteRoot, accountID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, teamsList)
+	if err != nil {
+		return TeamsList{}, err
+	}
+
+	var teamsListDetailResponse TeamsListDetailResponse
+	err = json.Unmarshal(res, &teamsListDetailResponse)
+	if err != nil {
+		return TeamsList{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return teamsListDetailResponse.Result, nil
+}
+
+// UpdateTeamsList updates an existing teams list.
+//
+// API reference: TODO
+func (api *API) UpdateTeamsList(ctx context.Context, accountID string, teamsList TeamsList) (TeamsList, error) {
+	if teamsList.ID == "" {
+		return TeamsList{}, errors.Errorf("teams list ID cannot be empty")
+	}
+
+	uri := fmt.Sprintf(
+		"/%s/%s/lists/%s",
+		AccountRouteRoot,
+		accountID,
+		teamsList.ID,
+	)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, teamsList)
+	if err != nil {
+		return TeamsList{}, err
+	}
+
+	var teamsListDetailResponse TeamsListDetailResponse
+	err = json.Unmarshal(res, &teamsListDetailResponse)
+	if err != nil {
+		return TeamsList{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return teamsListDetailResponse.Result, nil
+}
+
+// PatchTeamsList updates the items in an existing teams list.
+//
+// API reference: TODO
+func (api *API) PatchTeamsList(ctx context.Context, accountID string, listPatch PatchTeamsList) (TeamsList, error) {
+	if listPatch.ID == "" {
+		return TeamsList{}, errors.Errorf("teams list ID cannot be empty")
+	}
+
+	uri := fmt.Sprintf(
+		"/%s/%s/lists/%s",
+		AccountRouteRoot,
+		accountID,
+		listPatch.ID,
+	)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, listPatch)
+	if err != nil {
+		return TeamsList{}, err
+	}
+
+	var teamsListDetailResponse TeamsListDetailResponse
+	err = json.Unmarshal(res, &teamsListDetailResponse)
+	if err != nil {
+		return TeamsList{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return teamsListDetailResponse.Result, nil
+}
+
+// DeleteTeamsList deletes a teams list.
+//
+// API reference: TODO
+func (api *API) DeleteTeamsList(ctx context.Context, accountID, teamsListID string) error {
+	uri := fmt.Sprintf(
+		"/%s/%s/lists/%s",
+		AccountRouteRoot,
+		accountID,
+		teamsListID,
+	)
+
+	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/teams_list.go
+++ b/teams_list.go
@@ -53,7 +53,7 @@ type TeamsListDetailResponse struct {
 
 // TeamsLists returns all lists within an account.
 //
-// API reference: TODO
+// API reference: https://api.cloudflare.com/#teams-lists-list-teams-lists
 func (api *API) TeamsLists(ctx context.Context, accountID string) ([]TeamsList, ResultInfo, error) {
 	uri := fmt.Sprintf("/%s/%s/lists", AccountRouteRoot, accountID)
 
@@ -73,7 +73,7 @@ func (api *API) TeamsLists(ctx context.Context, accountID string) ([]TeamsList, 
 
 // TeamsList returns a single list based on the list ID.
 //
-// API reference: TODO
+// API reference: https://api.cloudflare.com/#teams-lists-teams-list-details
 func (api *API) TeamsList(ctx context.Context, accountID, listID string) (TeamsList, error) {
 	uri := fmt.Sprintf(
 		"/%s/%s/lists/%s",
@@ -98,7 +98,7 @@ func (api *API) TeamsList(ctx context.Context, accountID, listID string) (TeamsL
 
 // CreateTeamsList creates a new teams list.
 //
-// API reference: TODO
+// API reference: https://api.cloudflare.com/#teams-lists-create-teams-list
 func (api *API) CreateTeamsList(ctx context.Context, accountID string, teamsList TeamsList) (TeamsList, error) {
 	uri := fmt.Sprintf("/%s/%s/lists", AccountRouteRoot, accountID)
 
@@ -118,7 +118,7 @@ func (api *API) CreateTeamsList(ctx context.Context, accountID string, teamsList
 
 // UpdateTeamsList updates an existing teams list.
 //
-// API reference: TODO
+// API reference: https://api.cloudflare.com/#teams-lists-update-teams-list
 func (api *API) UpdateTeamsList(ctx context.Context, accountID string, teamsList TeamsList) (TeamsList, error) {
 	if teamsList.ID == "" {
 		return TeamsList{}, errors.Errorf("teams list ID cannot be empty")
@@ -147,7 +147,7 @@ func (api *API) UpdateTeamsList(ctx context.Context, accountID string, teamsList
 
 // PatchTeamsList updates the items in an existing teams list.
 //
-// API reference: TODO
+// API reference: https://api.cloudflare.com/#teams-lists-patch-teams-list
 func (api *API) PatchTeamsList(ctx context.Context, accountID string, listPatch PatchTeamsList) (TeamsList, error) {
 	if listPatch.ID == "" {
 		return TeamsList{}, errors.Errorf("teams list ID cannot be empty")
@@ -176,7 +176,7 @@ func (api *API) PatchTeamsList(ctx context.Context, accountID string, listPatch 
 
 // DeleteTeamsList deletes a teams list.
 //
-// API reference: TODO
+// API reference: https://api.cloudflare.com/#teams-lists-delete-teams-list
 func (api *API) DeleteTeamsList(ctx context.Context, accountID, teamsListID string) error {
 	uri := fmt.Sprintf(
 		"/%s/%s/lists/%s",

--- a/teams_list.go
+++ b/teams_list.go
@@ -45,10 +45,8 @@ type TeamsListListResponse struct {
 // TeamsListDetailResponse is the API response, containing a single
 // teams list.
 type TeamsListDetailResponse struct {
-	Success  bool      `json:"success"`
-	Errors   []string  `json:"errors"`
-	Messages []string  `json:"messages"`
-	Result   TeamsList `json:"result"`
+	Response
+	Result TeamsList `json:"result"`
 }
 
 // TeamsLists returns all lists within an account.

--- a/teams_list_test.go
+++ b/teams_list_test.go
@@ -1,0 +1,287 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeamsLists(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodGet, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+					"name": "My Serial List",
+					"description": "My Description",
+					"type": "SERIAL",
+					"count": 1,
+					"created_at": "2014-01-01T05:20:00.12345Z",
+					"updated_at": "2014-01-01T05:20:00.12345Z"
+				}
+			],
+			"result_info": {
+				"page": 1,
+				"per_page": 20,
+				"count": 1,
+				"total_count": 2000
+			}
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+
+	want := []TeamsList{{
+		ID:          "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:        "My Serial List",
+		Description: "My Description",
+		Type:        "SERIAL",
+		Count:       1,
+		CreatedAt:   &createdAt,
+		UpdatedAt:   &updatedAt,
+	}}
+
+	mux.HandleFunc("/accounts/"+accountID+"/lists", handler)
+
+	actual, _, err := client.TeamsLists(context.Background(), accountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestTeamsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodGet, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+				"name": "My Serial List",
+				"description": "My Description",
+				"type": "SERIAL",
+				"count": 1,
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z"
+			}
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+
+	want := TeamsList{
+		ID:          "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:        "My Serial List",
+		Description: "My Description",
+		Type:        "SERIAL",
+		Count:       1,
+		CreatedAt:   &createdAt,
+		UpdatedAt:   &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/lists/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err := client.TeamsList(context.Background(), accountID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateTeamsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodPost, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+				"name": "My Serial List",
+				"description": "My Description",
+				"type": "SERIAL",
+				"count": 1,
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z"
+			}
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	teamsList := TeamsList{
+		ID:          "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:        "My Serial List",
+		Description: "My Description",
+		Type:        "SERIAL",
+		Count:       1,
+		CreatedAt:   &createdAt,
+		UpdatedAt:   &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/lists", handler)
+
+	actual, err := client.CreateTeamsList(context.Background(), accountID, TeamsList{
+		Name:        "My Serial List",
+		Description: "My Description",
+		Type:        "SERIAL",
+		Count:       1,
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, teamsList, actual)
+	}
+}
+
+func TestUpdateTeamsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodPut, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+				"name": "My Serial List",
+				"description": "My Updated Description",
+				"type": "SERIAL",
+				"count": 1,
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z"
+			}
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	teamsList := TeamsList{
+		ID:          "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:        "My Serial List",
+		Description: "My Updated Description",
+		Type:        "SERIAL",
+		Count:       1,
+		CreatedAt:   &createdAt,
+		UpdatedAt:   &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/lists/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err := client.UpdateTeamsList(context.Background(), accountID, teamsList)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, teamsList, actual)
+	}
+}
+
+func TestUpdateTeamsListWithMissingID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	_, err := client.UpdateTeamsList(context.Background(), zoneID, TeamsList{})
+	assert.EqualError(t, err, "teams list ID cannot be empty")
+}
+
+func TestPatchTeamsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodPatch, "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+				"name": "My Serial List",
+				"description": "My Updated Description",
+				"type": "SERIAL",
+				"count": 1,
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z"
+			}
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	teamsList := TeamsList{
+		ID:          "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:        "My Serial List",
+		Description: "My Updated Description",
+		Type:        "SERIAL",
+		Count:       1,
+		CreatedAt:   &createdAt,
+		UpdatedAt:   &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/lists/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err := client.PatchTeamsList(context.Background(), accountID, PatchTeamsList{
+		ID:     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Append: []TeamsListItem{{Value: "abcd-1234"}},
+		Remove: []string{"def-5678"},
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, teamsList, actual)
+	}
+}
+
+func TestDeleteTeamsList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Method, http.MethodDelete, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db"
+      }
+    }
+    `)
+	}
+
+	mux.HandleFunc("/accounts/"+accountID+"/lists/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+	err := client.DeleteTeamsList(context.Background(), accountID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Description

Adds support for Teams Lists which are used for Gateway policies and Access policies (to a smaller extent). More details on lists are detailed here: https://developers.cloudflare.com/cloudflare-one/policies/lists.

API reference will be added once the documentation becomes publicly available.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)