### PR TITLE
Add new UnsuccessfulResponseError struct for unsuccessful API responses

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -119,5 +119,75 @@ func (e *APIRequestError) ErrorMessageContains(s string) bool {
 			return true
 		}
 	}
+
+	return false
+}
+
+// UnsuccessfulResponseError is an error type that is raised
+// when a server response contains a negative status in the body.
+type UnsuccessfulResponseError struct {
+	Messages []ResponseInfo
+}
+
+func (e UnsuccessfulResponseError) Error() string {
+	var errMessages []string
+
+	for _, err := range e.Messages {
+		var m string
+		if err.Message != "" {
+			m += fmt.Sprintf("%s", err.Message)
+		}
+
+		if err.Code != 0 {
+			m += fmt.Sprintf(" (%d)", err.Code)
+		}
+
+		errMessages = append(errMessages, m)
+	}
+
+	return strings.Join(errMessages, ", ")
+}
+
+// ErrorMessages exposes the error messages as a slice of strings from the error
+// response encountered.
+func (e *UnsuccessfulResponseError) ErrorMessages() (messages []string) {
+	for _, err := range e.Messages {
+		messages = append(messages, err.Message)
+	}
+
+	return messages
+}
+
+// InternalErrorCodes exposes the internal error codes as a slice of int from
+// the error response encountered.
+func (e *UnsuccessfulResponseError) InternalErrorCodes() (codes []int) {
+	for _, err := range e.Messages {
+		codes = append(codes, err.Code)
+	}
+
+	return codes
+}
+
+// InternalErrorCodeIs returns a boolean whether or not the desired internal
+// error code is present in `e.InternalErrorCodes`.
+func (e *UnsuccessfulResponseError) InternalErrorCodeIs(code int) bool {
+	for _, errCode := range e.InternalErrorCodes() {
+		if errCode == code {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ErrorMessageContains returns a boolean whether or not a substring exists in
+// any of the `e.ErrorMessages` slice entries.
+func (e *UnsuccessfulResponseError) ErrorMessageContains(s string) bool {
+	for _, errMsg := range e.ErrorMessages() {
+		if strings.Contains(errMsg, s) {
+			return true
+		}
+	}
+
 	return false
 }

--- a/waf.go
+++ b/waf.go
@@ -132,8 +132,7 @@ func (api *API) ListWAFPackages(ctx context.Context, zoneID string) ([]WAFPackag
 		}
 
 		if !p.Success {
-			// TODO: Provide an actual error message instead of always returning nil
-			return []WAFPackage{}, err
+			return []WAFPackage{}, errors.New(errRequestNotSuccessful)
 		}
 
 		packages = append(packages, p.Result...)
@@ -215,8 +214,7 @@ func (api *API) ListWAFGroups(ctx context.Context, zoneID, packageID string) ([]
 		}
 
 		if !r.Success {
-			// TODO: Provide an actual error message instead of always returning nil
-			return []WAFGroup{}, err
+			return []WAFGroup{}, errors.New(errRequestNotSuccessful)
 		}
 
 		groups = append(groups, r.Result...)
@@ -298,8 +296,7 @@ func (api *API) ListWAFRules(ctx context.Context, zoneID, packageID string) ([]W
 		}
 
 		if !r.Success {
-			// TODO: Provide an actual error message instead of always returning nil
-			return []WAFRule{}, err
+			return []WAFRule{}, errors.New(errRequestNotSuccessful)
 		}
 
 		rules = append(rules, r.Result...)

--- a/waf.go
+++ b/waf.go
@@ -132,7 +132,9 @@ func (api *API) ListWAFPackages(ctx context.Context, zoneID string) ([]WAFPackag
 		}
 
 		if !p.Success {
-			return []WAFPackage{}, errors.New(errRequestNotSuccessful)
+			err = &UnsuccessfulResponseError{p.Messages}
+
+			return []WAFPackage{}, errors.Wrap(err, errRequestNotSuccessful)
 		}
 
 		packages = append(packages, p.Result...)
@@ -214,7 +216,9 @@ func (api *API) ListWAFGroups(ctx context.Context, zoneID, packageID string) ([]
 		}
 
 		if !r.Success {
-			return []WAFGroup{}, errors.New(errRequestNotSuccessful)
+			err = &UnsuccessfulResponseError{r.Messages}
+
+			return []WAFGroup{}, errors.Wrap(err, errRequestNotSuccessful)
 		}
 
 		groups = append(groups, r.Result...)
@@ -296,7 +300,9 @@ func (api *API) ListWAFRules(ctx context.Context, zoneID, packageID string) ([]W
 		}
 
 		if !r.Success {
-			return []WAFRule{}, errors.New(errRequestNotSuccessful)
+			err = &UnsuccessfulResponseError{r.Messages}
+
+			return []WAFRule{}, errors.Wrap(err, errRequestNotSuccessful)
 		}
 
 		rules = append(rules, r.Result...)

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -115,7 +115,9 @@ func (api *API) ListWorkersKVNamespaces(ctx context.Context) ([]WorkersKVNamespa
 		}
 
 		if !p.Success {
-			return []WorkersKVNamespace{}, errors.New(errRequestNotSuccessful)
+			err = &UnsuccessfulResponseError{p.Messages}
+
+			return []WorkersKVNamespace{}, errors.Wrap(err, errRequestNotSuccessful)
 		}
 
 		namespaces = append(namespaces, p.Result...)

--- a/zone.go
+++ b/zone.go
@@ -373,8 +373,9 @@ func (api *API) ListZones(ctx context.Context, z ...string) ([]Zone, error) {
 				return []Zone{}, errors.Wrap(err, errUnmarshalError)
 			}
 			if !r.Success {
-				// TODO: Provide an actual error message instead of always returning nil
-				return []Zone{}, err
+				err = &UnsuccessfulResponseError{r.Messages}
+
+				return []Zone{}, errors.Wrap(err, errRequestNotSuccessful)
 			}
 			for zi := range r.Result {
 				zones = append(zones, r.Result[zi])


### PR DESCRIPTION
## Description

Returning nil error along with empty slice of expected struct is unconventional for Go code. We can construct an error message from slice of `message` returned in body with `status` false.

## Has your change been tested?

- New tests have been added for all methods of the `UnsuccessfulResponseError`
- `NoError` assertion is already in tests for `ListWAFPackages`, `ListWAFGroups`, `ListWAFRules` and `ListWAFOverrides`

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.