### PR TITLE
test/lint: Swap to golangci-lint instead of `golint`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args: "--config .golintci.yaml"
+          only-new-issues: true # only show new issues in the PR, not all.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,6 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
-      - name: Lint
-        if: matrix.os != 'windows-latest'
-        run: |
-          go get -v -u golang.org/x/lint/golint
-          $(go env GOPATH)/bin/golint -set_exit_status . cmd/flarectl
       - name: Vet
         run: go vet ./...
       - name: Test

--- a/.golintci.yaml
+++ b/.golintci.yaml
@@ -1,0 +1,19 @@
+run:
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 1m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+  # default is true. Enables skipping of directories:
+  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
+  skip-dirs-use-default: true
+
+  modules-download-mode: readonly
+
+output:
+  format: colored-line-number


### PR DESCRIPTION
More configuration and options for controlling linters.
