### PR TITLE
add support for Custom Hostnames without SSL

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -74,7 +74,7 @@ type CustomHostname struct {
 	ID                        string                                  `json:"id,omitempty"`
 	Hostname                  string                                  `json:"hostname,omitempty"`
 	CustomOriginServer        string                                  `json:"custom_origin_server,omitempty"`
-	SSL                       CustomHostnameSSL                       `json:"ssl,omitempty"`
+	SSL                       *CustomHostnameSSL                      `json:"ssl,omitempty"`
 	CustomMetadata            CustomMetadata                          `json:"custom_metadata,omitempty"`
 	Status                    CustomHostnameStatus                    `json:"status,omitempty"`
 	VerificationErrors        []string                                `json:"verification_errors,omitempty"`
@@ -119,7 +119,7 @@ type CustomHostnameFallbackOriginResponse struct {
 // hostname in the given zone.
 //
 // API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-update-custom-hostname-configuration
-func (api *API) UpdateCustomHostnameSSL(ctx context.Context, zoneID string, customHostnameID string, ssl CustomHostnameSSL) (*CustomHostnameResponse, error) {
+func (api *API) UpdateCustomHostnameSSL(ctx context.Context, zoneID string, customHostnameID string, ssl *CustomHostnameSSL) (*CustomHostnameResponse, error) {
 	uri := fmt.Sprintf("/zones/%s/custom_hostnames/%s", zoneID, customHostnameID)
 	ch := CustomHostname{
 		SSL: ssl,

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -76,7 +76,7 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 }`)
 	})
 
-	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com", SSL: CustomHostnameSSL{Method: "cname", Type: "dv"}})
+	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com", SSL: &CustomHostnameSSL{Method: "cname", Type: "dv"}})
 
 	createdAt, _ := time.Parse(time.RFC3339, "2020-02-06T18:11:23.531995Z")
 
@@ -85,7 +85,7 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 			Hostname:           "app.example.com",
 			CustomOriginServer: "example.app.com",
-			SSL: CustomHostnameSSL{
+			SSL: &CustomHostnameSSL{
 				Type:        "dv",
 				Method:      "cname",
 				Status:      "pending_validation",
@@ -148,14 +148,14 @@ func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 }`)
 	})
 
-	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com", CustomOriginServer: "example.app.com", SSL: CustomHostnameSSL{Method: "cname", Type: "dv"}})
+	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com", CustomOriginServer: "example.app.com", SSL: &CustomHostnameSSL{Method: "cname", Type: "dv"}})
 
 	want := &CustomHostnameResponse{
 		Result: CustomHostname{
 			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 			Hostname:           "app.example.com",
 			CustomOriginServer: "example.app.com",
-			SSL: CustomHostnameSSL{
+			SSL: &CustomHostnameSSL{
 				Type:        "dv",
 				Method:      "cname",
 				Status:      "pending_validation",
@@ -165,6 +165,72 @@ func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 					HTTP2: "on",
 				},
 			},
+		},
+		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, response)
+	}
+}
+
+func TestCustomHostname_CreateCustomHostname_No_SSL(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/zones/foo/custom_hostnames", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `
+{
+	"success": true,
+	"errors": [],
+	"messages": [],
+	"result": {
+		"id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+		"hostname": "app.example.com",
+		"custom_origin_server": "example.app.com",
+		"status": "pending",
+		"verification_errors": [
+		  "None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
+		],
+		"ownership_verification": {
+		  "type": "txt",
+		  "name": "_cf-custom-hostname.app.example.com",
+		  "value": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
+		},
+		"ownership_verification_http": {
+		  "http_url": "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+		  "http_body": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
+		},
+		"created_at": "2020-02-06T18:11:23.531995Z"
+	}
+}`)
+	})
+
+	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com"})
+
+	createdAt, _ := time.Parse(time.RFC3339, "2020-02-06T18:11:23.531995Z")
+
+	want := &CustomHostnameResponse{
+		Result: CustomHostname{
+			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+			Hostname:           "app.example.com",
+			CustomOriginServer: "example.app.com",
+			Status:             "pending",
+			VerificationErrors: []string{"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."},
+			OwnershipVerification: CustomHostnameOwnershipVerification{
+				Type:  "txt",
+				Name:  "_cf-custom-hostname.app.example.com",
+				Value: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
+			},
+			OwnershipVerificationHTTP: CustomHostnameOwnershipVerificationHTTP{
+				HTTPUrl:  "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+				HTTPBody: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
+			},
+			CreatedAt: &createdAt,
 		},
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
 	}
@@ -229,7 +295,7 @@ func TestCustomHostname_CustomHostnames(t *testing.T) {
 		{
 			ID:       "custom_host_1",
 			Hostname: "custom.host.one",
-			SSL: CustomHostnameSSL{
+			SSL: &CustomHostnameSSL{
 				ID:           "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 				Type:         "dv",
 				Method:       "cname",
@@ -305,7 +371,7 @@ func TestCustomHostname_CustomHostname(t *testing.T) {
 	want := CustomHostname{
 		ID:       "bar",
 		Hostname: "foo.bar.com",
-		SSL: CustomHostnameSSL{
+		SSL: &CustomHostnameSSL{
 			ID:           "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 			Status:       "active",
 			Method:       "http",
@@ -374,7 +440,7 @@ func TestCustomHostname_CustomHostname_WithSSLError(t *testing.T) {
 	want := CustomHostname{
 		ID:       "bar",
 		Hostname: "example.com",
-		SSL: CustomHostnameSSL{
+		SSL: &CustomHostnameSSL{
 			Type:        "dv",
 			Method:      "cname",
 			Status:      "pending_validation",
@@ -433,14 +499,14 @@ func TestCustomHostname_UpdateCustomHostnameSSL(t *testing.T) {
 }`)
 	})
 
-	response, err := client.UpdateCustomHostnameSSL(context.Background(), "foo", "0d89c70d-ad9f-4843-b99f-6cc0252067e9", CustomHostnameSSL{Method: "cname", Type: "dv", Settings: CustomHostnameSSLSettings{HTTP2: "off", TLS13: "on"}})
+	response, err := client.UpdateCustomHostnameSSL(context.Background(), "foo", "0d89c70d-ad9f-4843-b99f-6cc0252067e9", &CustomHostnameSSL{Method: "cname", Type: "dv", Settings: CustomHostnameSSLSettings{HTTP2: "off", TLS13: "on"}})
 
 	want := &CustomHostnameResponse{
 		Result: CustomHostname{
 			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 			Hostname:           "app.example.com",
 			CustomOriginServer: "example.app.com",
-			SSL: CustomHostnameSSL{
+			SSL: &CustomHostnameSSL{
 				Type:        "dv",
 				Method:      "cname",
 				Status:      "pending_validation",
@@ -511,14 +577,14 @@ func TestCustomHostname_UpdateCustomHostname(t *testing.T) {
 	})
 
 	wildcard := false
-	response, err := client.UpdateCustomHostname(context.Background(), "foo", "0d89c70d-ad9f-4843-b99f-6cc0252067e9", CustomHostname{Hostname: "app.example.com", CustomOriginServer: "example.app.com", SSL: CustomHostnameSSL{Method: "cname", Type: "dv", Wildcard: &wildcard}})
+	response, err := client.UpdateCustomHostname(context.Background(), "foo", "0d89c70d-ad9f-4843-b99f-6cc0252067e9", CustomHostname{Hostname: "app.example.com", CustomOriginServer: "example.app.com", SSL: &CustomHostnameSSL{Method: "cname", Type: "dv", Wildcard: &wildcard}})
 
 	want := &CustomHostnameResponse{
 		Result: CustomHostname{
 			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
 			Hostname:           "app.example.com",
 			CustomOriginServer: "example.app.com",
-			SSL: CustomHostnameSSL{
+			SSL: &CustomHostnameSSL{
 				Type:        "dv",
 				Method:      "cname",
 				Status:      "pending_validation",
@@ -670,7 +736,7 @@ func TestCustomHostname_CreateCustomHostnameCustomCertificateAuthority(t *testin
 }`)
 	})
 
-	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com", SSL: CustomHostnameSSL{Method: "cname", Type: "dv", CertificateAuthority: "lets_encrypt"}})
+	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com", SSL: &CustomHostnameSSL{Method: "cname", Type: "dv", CertificateAuthority: "lets_encrypt"}})
 
 	createdAt, _ := time.Parse(time.RFC3339, "2020-06-30T21:37:36.563495Z")
 
@@ -680,7 +746,7 @@ func TestCustomHostname_CreateCustomHostnameCustomCertificateAuthority(t *testin
 			ID:                 "614b3124-cd57-42f0-8307-000000000000",
 			Hostname:           "app.example.com",
 			CustomOriginServer: "origin.example.com",
-			SSL: CustomHostnameSSL{
+			SSL: &CustomHostnameSSL{
 				ID:     "d9ae4881-34d2-4820-8e28-000000000000",
 				Type:   "dv",
 				Method: "http",


### PR DESCRIPTION
This change updates the client to match the fact that the `ssl` is an optional (yet almost always used) attribute on the custom hostnames API. Breaking change since an existing struct field was modified.

One caveat/part I haven't implemented here is that to turn off SSL for a hostname, you have to PATCH with a payload of `{"hostname: "x", "ssl":"null"}`, quotes important, simply relying on `omitempty` (`{"hostname: "x"}`) is not enough. 

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.