### PR TITLE
rulesets: make downstream life easier for Terraform

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -48,6 +48,70 @@ const (
 	RulesetRuleActionParametersHTTPHeaderOperationSet    RulesetRuleActionParametersHTTPHeaderOperation = "set"
 )
 
+// RulesetKindValues exposes all the available `RulesetKind` values as a slice
+// of strings.
+func RulesetKindValues() []string {
+	return []string{
+		string(RulesetKindCustom),
+		string(RulesetKindManaged),
+		string(RulesetKindRoot),
+		string(RulesetKindSchema),
+		string(RulesetKindZone),
+	}
+}
+
+// RulesetPhaseValues exposes all the available `RulesetPhase` values as a slice
+// of strings.
+func RulesetPhaseValues() []string {
+	return []string{
+		string(RulesetPhaseDDoSL7),
+		string(RulesetPhaseHTTPRequestFirewallCustom),
+		string(RulesetPhaseHTTPRequestFirewallManaged),
+		string(RulesetPhaseHTTPRequestMain),
+		string(RulesetPhaseHTTPRequestSanitize),
+		string(RulesetPhaseHTTPRequestTransform),
+		string(RulesetPhaseMagicTransit),
+	}
+}
+
+// RulesetRuleActionValues exposes all the available `RulesetRuleAction` values
+// as a slice of strings.
+func RulesetRuleActionValues() []string {
+	return []string{
+		string(RulesetRuleActionBlock),
+		string(RulesetRuleActionChallenge),
+		string(RulesetRuleActionDDoSDynamic),
+		string(RulesetRuleActionExecute),
+		string(RulesetRuleActionForceConnectionClose),
+		string(RulesetRuleActionJSChallenge),
+		string(RulesetRuleActionLog),
+		string(RulesetRuleActionRewrite),
+		string(RulesetRuleActionScore),
+		string(RulesetRuleActionSkip),
+	}
+}
+
+// RulesetActionParameterProductValues exposes all the available
+// `RulesetActionParameterProduct` values as a slice of strings.
+func RulesetActionParameterProductValues() []string {
+	return []string{
+		string(RulesetActionParameterProductBIC),
+		string(RulesetActionParameterProductHOT),
+		string(RulesetActionParameterProductRateLimit),
+		string(RulesetActionParameterProductSecurityLevel),
+		string(RulesetActionParameterProductUABlock),
+		string(RulesetActionParameterProductWAF),
+		string(RulesetActionParameterProductZoneLockdown),
+	}
+}
+
+func RulesetRuleActionParametersHTTPHeaderOperationValues() []string {
+	return []string{
+		string(RulesetRuleActionParametersHTTPHeaderOperationRemove),
+		string(RulesetRuleActionParametersHTTPHeaderOperationSet),
+	}
+}
+
 // RulesetRuleAction defines a custom type that is used to express allowed
 // values for the rule action.
 type RulesetRuleAction string
@@ -59,21 +123,27 @@ type RulesetKind string
 // be applied in the request pipeline.
 type RulesetPhase string
 
+// RulesetActionParameterProduct is the custom type for defining what products
+// can be used within the action parameters of a ruleset.
 type RulesetActionParameterProduct string
 
 // RulesetRuleActionParametersHTTPHeaderOperation defines available options for
 // HTTP header operations in actions.
 type RulesetRuleActionParametersHTTPHeaderOperation string
 
-// Ruleset contains the structure of a Ruleset.
+// Ruleset contains the structure of a Ruleset. Using `string` for Kind and
+// Phase is a developer nicety to support downstream clients like Terraform who
+// don't really have a strong and expansive type system. As always, the
+// recommendation is to use the types provided where possible to avoid
+// surprises.
 type Ruleset struct {
 	ID          string        `json:"id,omitempty"`
 	Name        string        `json:"name"`
 	Description string        `json:"description"`
-	Kind        RulesetKind   `json:"kind"`
+	Kind        string        `json:"kind"`
 	Version     string        `json:"version,omitempty"`
 	LastUpdated *time.Time    `json:"last_updated,omitempty"`
-	Phase       RulesetPhase  `json:"phase"`
+	Phase       string        `json:"phase"`
 	Rules       []RulesetRule `json:"rules"`
 }
 
@@ -85,7 +155,7 @@ type RulesetRuleActionParameters struct {
 	Increment int                                              `json:"increment,omitempty"`
 	URI       RulesetRuleActionParametersURI                   `json:"uri,omitempty"`
 	Headers   map[string]RulesetRuleActionParametersHTTPHeader `json:"headers,omitempty"`
-	Products  []RulesetActionParameterProduct                  `json:"products,omitempty"`
+	Products  []string                                         `json:"products,omitempty"`
 }
 
 // RulesetRuleActionParametersURI holds the URI struct for an action parameter.
@@ -120,7 +190,7 @@ type RulesetRuleActionParametersHTTPHeader struct {
 type RulesetRule struct {
 	ID               string                       `json:"id,omitempty"`
 	Version          string                       `json:"version,omitempty"`
-	Action           RulesetRuleAction            `json:"action"`
+	Action           string                       `json:"action"`
 	ActionParameters *RulesetRuleActionParameters `json:"action_parameters,omitempty"`
 	Expression       string                       `json:"expression"`
 	Description      string                       `json:"description"`

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -48,7 +48,7 @@ func TestListRulesets(t *testing.T) {
 			Kind:        "root",
 			Version:     "1",
 			LastUpdated: &lastUpdated,
-			Phase:       RulesetPhaseMagicTransit,
+			Phase:       string(RulesetPhaseMagicTransit),
 		},
 	}
 
@@ -98,7 +98,7 @@ func TestGetRuleset_MagicTransit(t *testing.T) {
 		Kind:        "root",
 		Version:     "1",
 		LastUpdated: &lastUpdated,
-		Phase:       RulesetPhaseMagicTransit,
+		Phase:       string(RulesetPhaseMagicTransit),
 	}
 
 	zoneActual, err := client.GetZoneRuleset(context.Background(), testZoneID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
@@ -162,7 +162,7 @@ func TestGetRuleset_WAF(t *testing.T) {
 	rules := []RulesetRule{{
 		ID:      "78723a9e0c7c4c6dbec5684cb766231d",
 		Version: "1",
-		Action:  RulesetRuleActionRewrite,
+		Action:  string(RulesetRuleActionRewrite),
 		ActionParameters: &RulesetRuleActionParameters{
 			URI: RulesetRuleActionParametersURI{
 				Path: RulesetRuleActionParametersURIPath{
@@ -181,10 +181,10 @@ func TestGetRuleset_WAF(t *testing.T) {
 		ID:          "70339d97bdb34195bbf054b1ebe81f76",
 		Name:        "Cloudflare Normalization Ruleset",
 		Description: "Created by the Cloudflare security team, this ruleset provides normalization on the URL path",
-		Kind:        RulesetKindManaged,
+		Kind:        string(RulesetKindManaged),
 		Version:     "1",
 		LastUpdated: &lastUpdated,
-		Phase:       RulesetPhaseHTTPRequestSanitize,
+		Phase:       string(RulesetPhaseHTTPRequestSanitize),
 		Rules:       rules,
 	}
 
@@ -245,7 +245,7 @@ func TestCreateRuleset(t *testing.T) {
 	rules := []RulesetRule{{
 		ID:      "62449e2e0de149619edb35e59c10d801",
 		Version: "1",
-		Action:  RulesetRuleActionSkip,
+		Action:  string(RulesetRuleActionSkip),
 		ActionParameters: &RulesetRuleActionParameters{
 			Ruleset: "current",
 		},
@@ -260,7 +260,7 @@ func TestCreateRuleset(t *testing.T) {
 		Name:        "my example ruleset",
 		Description: "Test magic transit ruleset",
 		Kind:        "root",
-		Phase:       RulesetPhaseMagicTransit,
+		Phase:       string(RulesetPhaseMagicTransit),
 		Rules:       rules,
 	}
 
@@ -271,7 +271,7 @@ func TestCreateRuleset(t *testing.T) {
 		Kind:        "root",
 		Version:     "1",
 		LastUpdated: &lastUpdated,
-		Phase:       RulesetPhaseMagicTransit,
+		Phase:       string(RulesetPhaseMagicTransit),
 		Rules:       rules,
 	}
 
@@ -365,7 +365,7 @@ func TestUpdateRuleset(t *testing.T) {
 	rules := []RulesetRule{{
 		ID:      "62449e2e0de149619edb35e59c10d801",
 		Version: "1",
-		Action:  RulesetRuleActionSkip,
+		Action:  string(RulesetRuleActionSkip),
 		ActionParameters: &RulesetRuleActionParameters{
 			Ruleset: "current",
 		},
@@ -377,7 +377,7 @@ func TestUpdateRuleset(t *testing.T) {
 	}, {
 		ID:      "62449e2e0de149619edb35e59c10d802",
 		Version: "1",
-		Action:  RulesetRuleActionSkip,
+		Action:  string(RulesetRuleActionSkip),
 		ActionParameters: &RulesetRuleActionParameters{
 			Ruleset: "current",
 		},
@@ -395,7 +395,7 @@ func TestUpdateRuleset(t *testing.T) {
 		Kind:        "root",
 		Version:     "1",
 		LastUpdated: &lastUpdated,
-		Phase:       RulesetPhaseMagicTransit,
+		Phase:       string(RulesetPhaseMagicTransit),
 		Rules:       rules,
 	}
 


### PR DESCRIPTION
Updates rulesets to be a little more friendly to systems where types aren't as strong.