### PR TITLE
Add txt_name & txt_value fields (DNS validation) to CustomHostname struct

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -54,6 +54,8 @@ type CustomHostnameSSL struct {
 	Type                 string                              `json:"type,omitempty"`
 	CnameTarget          string                              `json:"cname_target,omitempty"`
 	CnameName            string                              `json:"cname,omitempty"`
+	TxtName              string                              `json:"txt_name,omitempty"`
+	TxtValue             string                              `json:"txt_value,omitempty"`
 	Wildcard             *bool                               `json:"wildcard,omitempty"`
 	CustomCertificate    string                              `json:"custom_certificate,omitempty"`
 	CustomKey            string                              `json:"custom_key,omitempty"`

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -116,6 +116,92 @@ func TestCustomHostname_CreateCustomHostname(t *testing.T) {
 	}
 }
 
+func TestCustomHostname_CreateCustomHostname_MethodTxt(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/zones/foo/custom_hostnames", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `
+{
+	"success": true,
+	"errors": [],
+	"messages": [],
+	"result": {
+		"id": "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+		"hostname": "app.example.com",
+		"custom_origin_server": "example.app.com",
+		"ssl": {
+			"status": "pending_validation",
+			"method": "txt",
+			"type": "dv",
+			"txt_name": "app.example.com",
+			"txt_value": "ca3-f8db94da174g4c409b17fcaa5470deb2",
+			"settings": {
+			"http2": "on"
+			}
+		},
+		"status": "pending",
+		"verification_errors": [
+		  "None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."
+		],
+		"ownership_verification": {
+		  "type": "txt",
+		  "name": "_cf-custom-hostname.app.example.com",
+		  "value": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
+		},
+		"ownership_verification_http": {
+		  "http_url": "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+		  "http_body": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
+		},
+		"created_at": "2020-02-06T18:11:23.531995Z"
+	}
+}`)
+	})
+
+	response, err := client.CreateCustomHostname(context.Background(), "foo", CustomHostname{Hostname: "app.example.com", SSL: &CustomHostnameSSL{Method: "txt", Type: "dv"}})
+
+	createdAt, _ := time.Parse(time.RFC3339, "2020-02-06T18:11:23.531995Z")
+
+	want := &CustomHostnameResponse{
+		Result: CustomHostname{
+			ID:                 "0d89c70d-ad9f-4843-b99f-6cc0252067e9",
+			Hostname:           "app.example.com",
+			CustomOriginServer: "example.app.com",
+			SSL: &CustomHostnameSSL{
+				Type:     "dv",
+				Method:   "txt",
+				Status:   "pending_validation",
+				TxtName:  "app.example.com",
+				TxtValue: "ca3-f8db94da174g4c409b17fcaa5470deb2",
+				Settings: CustomHostnameSSLSettings{
+					HTTP2: "on",
+				},
+			},
+			Status:             "pending",
+			VerificationErrors: []string{"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."},
+			OwnershipVerification: CustomHostnameOwnershipVerification{
+				Type:  "txt",
+				Name:  "_cf-custom-hostname.app.example.com",
+				Value: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
+			},
+			OwnershipVerificationHTTP: CustomHostnameOwnershipVerificationHTTP{
+				HTTPUrl:  "http://app.example.com/.well-known/cf-custom-hostname-challenge/37c82d20-99fb-490e-ba0a-489fa483b776",
+				HTTPBody: "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0",
+			},
+			CreatedAt: &createdAt,
+		},
+		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, response)
+	}
+}
+
 func TestCustomHostname_CreateCustomHostname_CustomOrigin(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description

Adds txt_name and txt_value fields to CustomHostname struct that are needed for SSL Verification when using the txt method


## Has your change been tested?

No unit tests yet. Unsure if needed.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
