### PR TITLE
fix: multiple bugs in ListZones and ListZonesContext

### DIFF
--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -333,9 +333,9 @@ func TestZoneIDByNameWithNonUniqueZonesWithoutOrgID(t *testing.T) {
 			],
 			"result_info": {
 				"page": 1,
-				"per_page": 20,
-				"count": 1,
-				"total_count": 2000,
+				"per_page": 50,
+				"count": 2,
+				"total_count": 2,
 				"total_pages": 1
 			}
 		}
@@ -418,9 +418,9 @@ func TestZoneIDByNameWithIDN(t *testing.T) {
 			],
 			"result_info": {
 				"page": 1,
-				"per_page": 20,
+				"per_page": 50,
 				"count": 1,
-				"total_count": 2000,
+				"total_count": 1,
 				"total_pages": 1
 			}
 		}

--- a/errors.go
+++ b/errors.go
@@ -17,7 +17,8 @@ const (
 	errMissingAccountID          = "account ID is empty and must be provided"
 	errOperationStillRunning     = "bulk operation did not finish before timeout"
 	errOperationUnexpectedStatus = "bulk operation returned an unexpected status"
-	errPagination                = "unexpected pagination"
+	errPagination                = "unexpected pagination in response"
+	errManualPagination          = "unexpected pagination parameters in request"
 )
 
 // APIRequestError is a type of error raised by API calls made by this library.

--- a/errors.go
+++ b/errors.go
@@ -18,7 +18,7 @@ const (
 	errOperationStillRunning     = "bulk operation did not finish before timeout"
 	errOperationUnexpectedStatus = "bulk operation returned an unexpected status"
 	errPagination                = "unexpected pagination in response"
-	errManualPagination          = "unexpected pagination parameters in request"
+	errManualPagination          = "unexpected pagination options passed to functions that handle pagination automatically"
 )
 
 // APIRequestError is a type of error raised by API calls made by this library.

--- a/errors.go
+++ b/errors.go
@@ -17,6 +17,7 @@ const (
 	errMissingAccountID          = "account ID is empty and must be provided"
 	errOperationStillRunning     = "bulk operation did not finish before timeout"
 	errOperationUnexpectedStatus = "bulk operation returned an unexpected status"
+	errPagination                = "unexpected pagination"
 )
 
 // APIRequestError is a type of error raised by API calls made by this library.

--- a/errors.go
+++ b/errors.go
@@ -17,7 +17,7 @@ const (
 	errMissingAccountID          = "account ID is empty and must be provided"
 	errOperationStillRunning     = "bulk operation did not finish before timeout"
 	errOperationUnexpectedStatus = "bulk operation returned an unexpected status"
-	errPagination                = "unexpected pagination in response"
+	errResultInfo                = "incorrect pagination info (result_info) in responses"
 	errManualPagination          = "unexpected pagination options passed to functions that handle pagination automatically"
 )
 

--- a/zone.go
+++ b/zone.go
@@ -454,7 +454,7 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 			defer wg.Done()
 
 			opt.params.Set("page", strconv.Itoa(pageNumber))
-			res, err = api.makeRequestContext(ctx, http.MethodGet, "/zones?"+opt.params.Encode(), nil)
+			res, err := api.makeRequestContext(ctx, http.MethodGet, "/zones?"+opt.params.Encode(), nil)
 			if err != nil {
 				recordError(err)
 				return

--- a/zone.go
+++ b/zone.go
@@ -422,14 +422,6 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 		totalCount     = r.Total
 	)
 
-	// These checks should be redundant when CloudFlare works as advertised.
-	// However, this function critically relies on these conditions.
-	if len(r.Result) != pageSize || // first page does not have exactly 50 zones
-		pageSize*totalPageCount < totalCount || // too few pages
-		totalCount < pageSize*(totalPageCount-1) { // too many pages
-		return ZonesResponse{}, errors.New(errPagination)
-	}
-
 	var (
 		// The size of the last page (which would be <= 50).
 		lastPageSize = totalCount - pageSize*(totalPageCount-1)

--- a/zone.go
+++ b/zone.go
@@ -469,7 +469,7 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 
 			if (pageNumber < totalPageCount && len(r.Result) != pageSize) ||
 				(pageNumber == totalPageCount && len(r.Result) != lastPageSize) {
-				recordError(err)
+				recordError(errors.New(errPagination))
 				return
 			}
 

--- a/zone.go
+++ b/zone.go
@@ -419,7 +419,7 @@ func (api *API) listZonesFetch(ctx context.Context, wg *sync.WaitGroup, errc cha
 	}
 
 	if len(r.Result) != pageSize {
-		recordError(errors.New(errPagination))
+		recordError(errors.New(errResultInfo))
 		return
 	}
 

--- a/zone.go
+++ b/zone.go
@@ -389,7 +389,7 @@ func (api *API) ListZones(ctx context.Context, z ...string) ([]Zone, error) {
 	return zones, nil
 }
 
-const listZonesPageSize = 50
+const listZonesPerPage = 50
 
 // listZonesFetch fetches one page of zones.
 // This is placed as a separate function to prevent any possibility of unintended capturing.
@@ -440,7 +440,7 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 		return ZonesResponse{}, errors.New(errManualPagination)
 	}
 
-	opt.params.Add("per_page", strconv.Itoa(listZonesPageSize))
+	opt.params.Add("per_page", strconv.Itoa(listZonesPerPage))
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, "/zones?"+opt.params.Encode(), nil)
 	if err != nil {
@@ -477,9 +477,9 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 		opt.params.Set("page", strconv.Itoa(pageNum))
 
 		// start is the first index in the zone buffer
-		start := listZonesPageSize * (pageNum - 1)
+		start := listZonesPerPage * (pageNum - 1)
 
-		pageSize := listZonesPageSize
+		pageSize := listZonesPerPage
 		if pageNum == totalPageCount {
 			// The size of the last page (which would be <= 50).
 			pageSize = totalCount - start

--- a/zone.go
+++ b/zone.go
@@ -401,6 +401,10 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 		of(&opt)
 	}
 
+	if opt.params.Get("page") != "" || opt.params.Get("per_page") != "" {
+		return ZonesResponse{}, errors.New("manual pagination is not supported for ListZonesContext")
+	}
+
 	opt.params.Add("per_page", strconv.Itoa(pageSize))
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, "/zones?"+opt.params.Encode(), nil)

--- a/zone.go
+++ b/zone.go
@@ -402,7 +402,7 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 	}
 
 	if opt.params.Get("page") != "" || opt.params.Get("per_page") != "" {
-		return ZonesResponse{}, errors.New("manual pagination is not supported for ListZonesContext")
+		return ZonesResponse{}, errors.New(errManualPagination)
 	}
 
 	opt.params.Add("per_page", strconv.Itoa(pageSize))

--- a/zone.go
+++ b/zone.go
@@ -451,6 +451,7 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 		return ZonesResponse{}, errors.Wrap(err, errUnmarshalError)
 	}
 
+	// avoid overhead in most common cases where the total #zones <= 50
 	if r.TotalPages < 2 {
 		return r, nil
 	}

--- a/zone.go
+++ b/zone.go
@@ -460,7 +460,7 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 		totalPageCount = r.TotalPages
 		totalCount     = r.Total
 
-		// zones is a large slice to prevent resizing during concurrent access.
+		// zones is a large slice to prevent resizing during concurrent writes.
 		zones = make([]Zone, totalCount)
 	)
 
@@ -473,10 +473,10 @@ func (api *API) ListZonesContext(ctx context.Context, opts ...ReqOption) (r Zone
 
 	// Creating all the workers.
 	for pageNum := 2; pageNum <= totalPageCount; pageNum++ {
-		// note: URL.Values is just a map[string].
+		// Note: URL.Values is just a map[string], so this would override the existing 'page'
 		opt.params.Set("page", strconv.Itoa(pageNum))
 
-		// The first index in the zone buffer
+		// start is the first index in the zone buffer
 		start := listZonesPageSize * (pageNum - 1)
 
 		pageSize := listZonesPageSize

--- a/zone_test.go
+++ b/zone_test.go
@@ -1349,16 +1349,24 @@ func TestListZones(t *testing.T) {
 	)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		assert.Equal(t, "50", r.URL.Query().Get("per_page"))
+		if !assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method) {
+			return
+		}
+
+		if !assert.Equal(t, "50", r.URL.Query().Get("per_page")) {
+			return
+		}
 
 		page := 1
 		if r.URL.Query().Get("page") != "" {
 			p, err := strconv.Atoi(r.URL.Query().Get("page"))
-			assert.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return
+			}
 
-			assert.LessOrEqual(t, page, totalPage)
-			assert.GreaterOrEqual(t, page, 1)
+			if !assert.LessOrEqual(t, page, totalPage) || !assert.GreaterOrEqual(t, page, 1) {
+				return
+			}
 
 			page = p
 		}
@@ -1372,10 +1380,15 @@ func TestListZones(t *testing.T) {
 		}
 
 		res, err := json.Marshal(mockZonesResponse(total, page, start, count))
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 
 		w.Header().Set("content-type", "application/json")
-		w.Write(res)
+
+		if _, err = w.Write(res); assert.NoError(t, err) {
+			return
+		}
 	}
 
 	mux.HandleFunc("/zones", handler)

--- a/zone_test.go
+++ b/zone_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // mockID returns a hex string of length 32, suitable for all kinds of IDs
-// used in the CloudFlare API.
+// used in the Cloudflare API.
 func mockID(seed string) string {
 	arr := md5.Sum([]byte(seed))
 	return hex.EncodeToString(arr[:])

--- a/zone_test.go
+++ b/zone_test.go
@@ -30,6 +30,124 @@ func mustParseTime(s string) time.Time {
 	return t
 }
 
+func mockZone(i int) *Zone {
+	return &Zone{
+		ID:      mockID(fmt.Sprintf("zone %d", i)),
+		Name:    fmt.Sprintf("%d.example.org", i),
+		DevMode: 0,
+		OriginalNS: []string{
+			"linda.ns.cloudflare.com",
+			"merlin.ns.cloudflare.com",
+		},
+		OriginalRegistrar: "cloudflare, inc. (id: 1910)",
+		OriginalDNSHost:   "",
+		CreatedOn:         mustParseTime("2021-07-28T05:06:20.736244Z"),
+		ModifiedOn:        mustParseTime("2021-07-28T05:06:20.736244Z"),
+		NameServers: []string{
+			"abby.ns.cloudflare.com",
+			"noel.ns.cloudflare.com",
+		},
+		Owner: Owner{
+			ID:        mockID("Test Account"),
+			Email:     "",
+			Name:      "Test Account",
+			OwnerType: "organization",
+		},
+		Permissions: []string{
+			"#access:read",
+			"#analytics:read",
+			"#auditlogs:read",
+			"#billing:read",
+			"#dns_records:read",
+			"#lb:read",
+			"#legal:read",
+			"#logs:read",
+			"#member:read",
+			"#organization:read",
+			"#ssl:read",
+			"#stream:read",
+			"#subscription:read",
+			"#waf:read",
+			"#webhooks:read",
+			"#worker:read",
+			"#zone:read",
+			"#zone_settings:read",
+		},
+		Plan: ZonePlan{
+			ZonePlanCommon: ZonePlanCommon{
+				ID:       "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+				Name:     "Free Website",
+				Currency: "USD",
+			},
+			IsSubscribed:      false,
+			CanSubscribe:      false,
+			LegacyID:          "free",
+			LegacyDiscount:    false,
+			ExternallyManaged: false,
+		},
+		PlanPending: ZonePlan{
+			ZonePlanCommon: ZonePlanCommon{
+				ID: "",
+			},
+			IsSubscribed:      false,
+			CanSubscribe:      false,
+			LegacyID:          "",
+			LegacyDiscount:    false,
+			ExternallyManaged: false,
+		},
+		Status: "active",
+		Paused: false,
+		Type:   "full",
+		Host: struct {
+			Name    string
+			Website string
+		}{
+			Name:    "",
+			Website: "",
+		},
+		VanityNS:    nil,
+		Betas:       nil,
+		DeactReason: "",
+		Meta: ZoneMeta{
+			PageRuleQuota:     3,
+			WildcardProxiable: false,
+			PhishingDetected:  false,
+		},
+		Account: Account{
+			ID:   mockID("Test Account"),
+			Name: "Test Account",
+		},
+		VerificationKey: "",
+	}
+}
+
+func mockResultInfo(total, page, start, count int) *ResultInfo {
+	return &ResultInfo{
+		Page:       page,
+		PerPage:    50,
+		TotalPages: (total + 49) / 50,
+		Count:      count,
+		Total:      total,
+	}
+}
+
+func mockZonesResponse(total, page, start, count int) *ZonesResponse {
+	zones := make([]Zone, count)
+	for i := range zones {
+		zones[i] = *mockZone(start + i)
+	}
+
+	return &ZonesResponse{
+		Result:     zones,
+		ResultInfo: *mockResultInfo(total, page, start, count),
+		Response: Response{
+			Success:  true,
+			Errors:   []ResponseInfo{},
+			Messages: []ResponseInfo{},
+		},
+	}
+}
+
 func TestZoneAnalyticsDashboard(t *testing.T) {
 	setup()
 	defer teardown()
@@ -1225,124 +1343,6 @@ func TestListZones(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mockZone := func(i int) Zone {
-		return Zone{
-			ID:      mockID(fmt.Sprintf("zone %d", i)),
-			Name:    fmt.Sprintf("%d.example.org", i),
-			DevMode: 0,
-			OriginalNS: []string{
-				"linda.ns.cloudflare.com",
-				"merlin.ns.cloudflare.com",
-			},
-			OriginalRegistrar: "cloudflare, inc. (id: 1910)",
-			OriginalDNSHost:   "",
-			CreatedOn:         mustParseTime("2021-07-28T05:06:20.736244Z"),
-			ModifiedOn:        mustParseTime("2021-07-28T05:06:20.736244Z"),
-			NameServers: []string{
-				"abby.ns.cloudflare.com",
-				"noel.ns.cloudflare.com",
-			},
-			Owner: Owner{
-				ID:        mockID("Test Account"),
-				Email:     "",
-				Name:      "Test Account",
-				OwnerType: "organization",
-			},
-			Permissions: []string{
-				"#access:read",
-				"#analytics:read",
-				"#auditlogs:read",
-				"#billing:read",
-				"#dns_records:read",
-				"#lb:read",
-				"#legal:read",
-				"#logs:read",
-				"#member:read",
-				"#organization:read",
-				"#ssl:read",
-				"#stream:read",
-				"#subscription:read",
-				"#waf:read",
-				"#webhooks:read",
-				"#worker:read",
-				"#zone:read",
-				"#zone_settings:read",
-			},
-			Plan: ZonePlan{
-				ZonePlanCommon: ZonePlanCommon{
-					ID:       "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-					Name:     "Free Website",
-					Currency: "USD",
-				},
-				IsSubscribed:      false,
-				CanSubscribe:      false,
-				LegacyID:          "free",
-				LegacyDiscount:    false,
-				ExternallyManaged: false,
-			},
-			PlanPending: ZonePlan{
-				ZonePlanCommon: ZonePlanCommon{
-					ID: "",
-				},
-				IsSubscribed:      false,
-				CanSubscribe:      false,
-				LegacyID:          "",
-				LegacyDiscount:    false,
-				ExternallyManaged: false,
-			},
-			Status: "active",
-			Paused: false,
-			Type:   "full",
-			Host: struct {
-				Name    string
-				Website string
-			}{
-				Name:    "",
-				Website: "",
-			},
-			VanityNS:    nil,
-			Betas:       nil,
-			DeactReason: "",
-			Meta: ZoneMeta{
-				PageRuleQuota:     3,
-				WildcardProxiable: false,
-				PhishingDetected:  false,
-			},
-			Account: Account{
-				ID:   mockID("Test Account"),
-				Name: "Test Account",
-			},
-			VerificationKey: "",
-		}
-	}
-
-	mockResultInfo := func(total, page, start, count int) ResultInfo {
-		return ResultInfo{
-			Page:       page,
-			PerPage:    50,
-			TotalPages: (total + 49) / 50,
-			Count:      count,
-			Total:      total,
-		}
-	}
-
-	mockZonesResponse := func(total, page, start, count int) ZonesResponse {
-		zones := make([]Zone, count)
-		for i := range zones {
-			zones[i] = mockZone(start + i)
-		}
-
-		return ZonesResponse{
-			Result:     zones,
-			ResultInfo: mockResultInfo(total, page, start, count),
-			Response: Response{
-				Success:  true,
-				Errors:   []ResponseInfo{},
-				Messages: []ResponseInfo{},
-			},
-		}
-	}
-
 	const (
 		total     = 392
 		totalPage = (total + 49) / 50
@@ -1399,6 +1399,6 @@ func TestListZones(t *testing.T) {
 	}
 
 	for i, zone := range zones {
-		assert.Equal(t, mockZone(i), zone)
+		assert.Equal(t, *mockZone(i), zone)
 	}
 }

--- a/zone_test.go
+++ b/zone_test.go
@@ -31,7 +31,7 @@ func mustParseTime(s string) time.Time {
 }
 
 func mockZone(i int) *Zone {
-	zoneName := fmt.Sprintf("%d.example.org", i)
+	zoneName := fmt.Sprintf("%d.example.com", i)
 	ownerName := "Test Account"
 
 	return &Zone{

--- a/zone_test.go
+++ b/zone_test.go
@@ -134,8 +134,8 @@ func mockZonesResponse(total, page, start, count int) *ZonesResponse {
 		Result: zones,
 		ResultInfo: ResultInfo{
 			Page:       page,
-			PerPage:    listZonesPerPage,
-			TotalPages: (total + listZonesPerPage - 1) / listZonesPerPage,
+			PerPage:    50,
+			TotalPages: (total + 49) / 50,
 			Count:      count,
 			Total:      total,
 		},

--- a/zone_test.go
+++ b/zone_test.go
@@ -124,16 +124,6 @@ func mockZone(i int) *Zone {
 	}
 }
 
-func mockResultInfo(total, page, start, count int) *ResultInfo {
-	return &ResultInfo{
-		Page:       page,
-		PerPage:    50,
-		TotalPages: (total + 49) / 50,
-		Count:      count,
-		Total:      total,
-	}
-}
-
 func mockZonesResponse(total, page, start, count int) *ZonesResponse {
 	zones := make([]Zone, count)
 	for i := range zones {
@@ -141,8 +131,14 @@ func mockZonesResponse(total, page, start, count int) *ZonesResponse {
 	}
 
 	return &ZonesResponse{
-		Result:     zones,
-		ResultInfo: *mockResultInfo(total, page, start, count),
+		Result: zones,
+		ResultInfo: ResultInfo{
+			Page:       page,
+			PerPage:    listZonesPerPage,
+			TotalPages: (total + listZonesPerPage - 1) / listZonesPerPage,
+			Count:      count,
+			Total:      total,
+		},
 		Response: Response{
 			Success:  true,
 			Errors:   []ResponseInfo{},

--- a/zone_test.go
+++ b/zone_test.go
@@ -2,14 +2,33 @@ package cloudflare
 
 import (
 	"context"
+	"crypto/md5"   // for generating IDs
+	"encoding/hex" // for generating IDs
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// mockID returns a hex string of length 32, suitable for all kinds of IDs
+//
+func mockID(seed string) string {
+	arr := md5.Sum([]byte(seed))
+	return hex.EncodeToString(arr[:])
+}
+
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
 
 func TestZoneAnalyticsDashboard(t *testing.T) {
 	setup()
@@ -1199,5 +1218,174 @@ func TestUpdateZoneDNSSEC(t *testing.T) {
 		assert.Equal(t, z.PublicKey, "oXiGYrSTO+LSCJ3mohc8EP+CzF9KxBj8/ydXJ22pKuZP3VAC3/Md/k7xZfz470CoRyZJ6gV6vml07IC3d8xqhA==")
 		time, _ := time.Parse("2006-01-02T15:04:05Z", "2014-01-01T05:20:00Z")
 		assert.Equal(t, z.ModifiedOn, time)
+	}
+}
+
+func TestListZones(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mockZone := func(i int) Zone {
+		return Zone{
+			ID:      mockID(fmt.Sprintf("zone %d", i)),
+			Name:    fmt.Sprintf("%d.example.org", i),
+			DevMode: 0,
+			OriginalNS: []string{
+				"linda.ns.cloudflare.com",
+				"merlin.ns.cloudflare.com",
+			},
+			OriginalRegistrar: "cloudflare, inc. (id: 1910)",
+			OriginalDNSHost:   "",
+			CreatedOn:         mustParseTime("2021-07-28T05:06:20.736244Z"),
+			ModifiedOn:        mustParseTime("2021-07-28T05:06:20.736244Z"),
+			NameServers: []string{
+				"abby.ns.cloudflare.com",
+				"noel.ns.cloudflare.com",
+			},
+			Owner: Owner{
+				ID:        mockID("Test Account"),
+				Email:     "",
+				Name:      "Test Account",
+				OwnerType: "organization",
+			},
+			Permissions: []string{
+				"#access:read",
+				"#analytics:read",
+				"#auditlogs:read",
+				"#billing:read",
+				"#dns_records:read",
+				"#lb:read",
+				"#legal:read",
+				"#logs:read",
+				"#member:read",
+				"#organization:read",
+				"#ssl:read",
+				"#stream:read",
+				"#subscription:read",
+				"#waf:read",
+				"#webhooks:read",
+				"#worker:read",
+				"#zone:read",
+				"#zone_settings:read",
+			},
+			Plan: ZonePlan{
+				ZonePlanCommon: ZonePlanCommon{
+					ID:       "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+					Name:     "Free Website",
+					Currency: "USD",
+				},
+				IsSubscribed:      false,
+				CanSubscribe:      false,
+				LegacyID:          "free",
+				LegacyDiscount:    false,
+				ExternallyManaged: false,
+			},
+			PlanPending: ZonePlan{
+				ZonePlanCommon: ZonePlanCommon{
+					ID: "",
+				},
+				IsSubscribed:      false,
+				CanSubscribe:      false,
+				LegacyID:          "",
+				LegacyDiscount:    false,
+				ExternallyManaged: false,
+			},
+			Status: "active",
+			Paused: false,
+			Type:   "full",
+			Host: struct {
+				Name    string
+				Website string
+			}{
+				Name:    "",
+				Website: "",
+			},
+			VanityNS:    nil,
+			Betas:       nil,
+			DeactReason: "",
+			Meta: ZoneMeta{
+				PageRuleQuota:     3,
+				WildcardProxiable: false,
+				PhishingDetected:  false,
+			},
+			Account: Account{
+				ID:   mockID("Test Account"),
+				Name: "Test Account",
+			},
+			VerificationKey: "",
+		}
+	}
+
+	mockResultInfo := func(total, page, start, count int) ResultInfo {
+		return ResultInfo{
+			Page:       page,
+			PerPage:    50,
+			TotalPages: (total + 49) / 50,
+			Count:      count,
+			Total:      total,
+		}
+	}
+
+	mockZonesResponse := func(total, page, start, count int) ZonesResponse {
+		zones := make([]Zone, count)
+		for i := range zones {
+			zones[i] = mockZone(start + i)
+		}
+
+		return ZonesResponse{
+			Result:     zones,
+			ResultInfo: mockResultInfo(total, page, start, count),
+			Response: Response{
+				Success:  true,
+				Errors:   []ResponseInfo{},
+				Messages: []ResponseInfo{},
+			},
+		}
+	}
+
+	const (
+		total     = 392
+		totalPage = (total + 49) / 50
+	)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		assert.Equal(t, "50", r.URL.Query().Get("per_page"))
+
+		page := 1
+		if r.URL.Query().Get("page") != "" {
+			p, err := strconv.Atoi(r.URL.Query().Get("page"))
+			assert.NoError(t, err)
+
+			assert.LessOrEqual(t, page, totalPage)
+			assert.GreaterOrEqual(t, page, 1)
+
+			page = p
+		}
+
+		start := (page - 1) * 50
+
+		count := 50
+		if page == totalPage {
+			count = total - start
+			assert.GreaterOrEqual(t, count, 0)
+		}
+
+		res, err := json.Marshal(mockZonesResponse(total, page, start, count))
+		assert.NoError(t, err)
+
+		w.Header().Set("content-type", "application/json")
+		w.Write(res)
+	}
+
+	mux.HandleFunc("/zones", handler)
+
+	zones, err := client.ListZones(context.Background())
+	if !assert.NoError(t, err) || !assert.Equal(t, total, len(zones)) {
+		return
+	}
+
+	for i, zone := range zones {
+		assert.Equal(t, mockZone(i), zone)
 	}
 }

--- a/zone_test.go
+++ b/zone_test.go
@@ -1369,11 +1369,10 @@ func TestListZones(t *testing.T) {
 	)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		if !assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method) {
+		switch {
+		case !assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method):
 			return
-		}
-
-		if !assert.Equal(t, "50", r.URL.Query().Get("per_page")) {
+		case !assert.Equal(t, "50", r.URL.Query().Get("per_page")):
 			return
 		}
 
@@ -1426,20 +1425,18 @@ func TestListZonesFailingPages(t *testing.T) {
 	isReject := func(i int) bool { return i == 4 || i == 7 }
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		if !assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method) {
+		switch {
+		case !assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method):
 			return
-		}
-
-		if !assert.Equal(t, "50", r.URL.Query().Get("per_page")) {
+		case !assert.Equal(t, "50", r.URL.Query().Get("per_page")):
 			return
 		}
 
 		page, ok := parsePage(t, totalPage, r.URL.Query().Get("page"))
-		if !ok {
+		switch {
+		case !ok:
 			return
-		}
-
-		if isReject(page) {
+		case isReject(page):
 			return
 		}
 

--- a/zone_test.go
+++ b/zone_test.go
@@ -1469,29 +1469,11 @@ func TestListZonesFailingPages(t *testing.T) {
 }
 
 func TestListZonesContextManualPagination1(t *testing.T) {
-	setup()
-	defer teardown()
-
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		assert.FailNow(t, "no requests should have been made")
-	}
-
-	mux.HandleFunc("/zones", handler)
-
 	_, err := client.ListZonesContext(context.Background(), WithPagination(PaginationOptions{Page: 2}))
 	assert.EqualError(t, err, errManualPagination)
 }
 
 func TestListZonesContextManualPagination2(t *testing.T) {
-	setup()
-	defer teardown()
-
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		assert.FailNow(t, "no requests should have been made")
-	}
-
-	mux.HandleFunc("/zones", handler)
-
 	_, err := client.ListZonesContext(context.Background(), WithPagination(PaginationOptions{PerPage: 30}))
 	assert.EqualError(t, err, errManualPagination)
 }

--- a/zone_test.go
+++ b/zone_test.go
@@ -31,9 +31,12 @@ func mustParseTime(s string) time.Time {
 }
 
 func mockZone(i int) *Zone {
+	zoneName := fmt.Sprintf("%d.example.org", i)
+	ownerName := "Test Account"
+
 	return &Zone{
-		ID:      mockID(fmt.Sprintf("zone %d", i)),
-		Name:    fmt.Sprintf("%d.example.org", i),
+		ID:      mockID(zoneName),
+		Name:    zoneName,
 		DevMode: 0,
 		OriginalNS: []string{
 			"linda.ns.cloudflare.com",
@@ -48,9 +51,9 @@ func mockZone(i int) *Zone {
 			"noel.ns.cloudflare.com",
 		},
 		Owner: Owner{
-			ID:        mockID("Test Account"),
+			ID:        mockID(ownerName),
 			Email:     "",
-			Name:      "Test Account",
+			Name:      ownerName,
 			OwnerType: "organization",
 		},
 		Permissions: []string{
@@ -114,8 +117,8 @@ func mockZone(i int) *Zone {
 			PhishingDetected:  false,
 		},
 		Account: Account{
-			ID:   mockID("Test Account"),
-			Name: "Test Account",
+			ID:   mockID(ownerName),
+			Name: ownerName,
 		},
 		VerificationKey: "",
 	}

--- a/zone_test.go
+++ b/zone_test.go
@@ -1410,7 +1410,7 @@ func TestListZones(t *testing.T) {
 	}
 }
 
-func TestListZonesFailure(t *testing.T) {
+func TestListZonesFailingPages(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -1463,4 +1463,32 @@ func TestListZonesFailure(t *testing.T) {
 
 	_, err := client.ListZones(context.Background())
 	assert.Error(t, err)
+}
+
+func TestListZonesContextManualPagination1(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.FailNow(t, "no requests should have been made")
+	}
+
+	mux.HandleFunc("/zones", handler)
+
+	_, err := client.ListZonesContext(context.Background(), WithPagination(PaginationOptions{Page: 2}))
+	assert.EqualError(t, err, errManualPagination)
+}
+
+func TestListZonesContextManualPagination2(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.FailNow(t, "no requests should have been made")
+	}
+
+	mux.HandleFunc("/zones", handler)
+
+	_, err := client.ListZonesContext(context.Background(), WithPagination(PaginationOptions{PerPage: 30}))
+	assert.EqualError(t, err, errManualPagination)
 }

--- a/zone_test.go
+++ b/zone_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // mockID returns a hex string of length 32, suitable for all kinds of IDs
-//
+// used in the CloudFlare API.
 func mockID(seed string) string {
 	arr := md5.Sum([]byte(seed))
 	return hex.EncodeToString(arr[:])


### PR DESCRIPTION
## Description

Current implementation of `ListZonesContext` has several issues (some shared by `ListZones`): 
1. **Deadlock:** if all workers failed, no one is receiving the error from the unbuffered `errc`.
2. **Deadlock:** `wg.Done()` might not be called when there's an error, and `wg.Wait()` will block forever in that case.
3. **Racing**: the built-in function `append` is not (obviously) thread-safe.
4. **Inefficiency**: The first page is fetched twice.
5. **(Lack of) error-reporting**: The errors from workers seem to be dropped.
6. **Code duplication**: Code seems to be duplicated in `ListZonesContext` and `ListZones`.

This PR draft attempts to fix all of the above by implementing a robust and correct `ListZonesContext` and calling `ListZonesContext` in `ListZones` when no zone names are specified.

## Has your change been tested?

Yes. Two test cases were added to test concurrent fetching. Another two were added to test unexpected pagination options.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.