### PR TITLE
certificate_pack: update `id` and `primary_certificate` types

### DIFF
--- a/certificate_packs.go
+++ b/certificate_packs.go
@@ -19,7 +19,7 @@ type CertificatePackGeoRestrictions struct {
 // CertificatePackCertificate is the base structure of a TLS certificate that is
 // contained within a certificate pack.
 type CertificatePackCertificate struct {
-	ID              int                            `json:"id"`
+	ID              string                         `json:"id"`
 	Hosts           []string                       `json:"hosts"`
 	Issuer          string                         `json:"issuer"`
 	Signature       string                         `json:"signature"`
@@ -39,7 +39,7 @@ type CertificatePack struct {
 	Type               string                       `json:"type"`
 	Hosts              []string                     `json:"hosts"`
 	Certificates       []CertificatePackCertificate `json:"certificates"`
-	PrimaryCertificate int                          `json:"primary_certificate"`
+	PrimaryCertificate string                       `json:"primary_certificate"`
 }
 
 // CertificatePackRequest is used for requesting a new certificate.

--- a/certificate_packs_test.go
+++ b/certificate_packs_test.go
@@ -18,9 +18,9 @@ var (
 		ID:                 "3822ff90-ea29-44df-9e55-21300bb9419b",
 		Type:               "custom",
 		Hosts:              []string{"example.com", "*.example.com", "www.example.com"},
-		PrimaryCertificate: 12345678,
+		PrimaryCertificate: "b2cfa4183267af678ea06c7407d4d6d8",
 		Certificates: []CertificatePackCertificate{{
-			ID:              12345678,
+			ID:              "3822ff90-ea29-44df-9e55-21300bb9419b",
 			Hosts:           []string{"example.com"},
 			Issuer:          "GlobalSign",
 			Signature:       "SHA256WithRSA",
@@ -58,7 +58,7 @@ func TestListCertificatePacks(t *testing.T) {
       ],
       "certificates": [
         {
-          "id": 12345678,
+          "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
           "hosts": [
             "example.com"
           ],
@@ -76,7 +76,7 @@ func TestListCertificatePacks(t *testing.T) {
           "priority": 1
         }
       ],
-      "primary_certificate": 12345678
+      "primary_certificate": "b2cfa4183267af678ea06c7407d4d6d8"
     }
   ]
 }
@@ -114,7 +114,7 @@ func TestListCertificatePack(t *testing.T) {
     ],
     "certificates": [
       {
-        "id": 12345678,
+        "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
         "hosts": [
           "example.com"
         ],
@@ -132,7 +132,7 @@ func TestListCertificatePack(t *testing.T) {
         "priority": 1
       }
     ],
-    "primary_certificate": 12345678
+    "primary_certificate": "b2cfa4183267af678ea06c7407d4d6d8"
   }
 }
 		`)
@@ -168,7 +168,7 @@ func TestCreateCertificatePack(t *testing.T) {
     ],
     "certificates": [
       {
-        "id": 12345678,
+        "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
         "hosts": [
           "example.com"
         ],
@@ -186,7 +186,7 @@ func TestCreateCertificatePack(t *testing.T) {
         "priority": 1
       }
     ],
-    "primary_certificate": 12345678
+    "primary_certificate": "b2cfa4183267af678ea06c7407d4d6d8"
   }
 }
 		`)


### PR DESCRIPTION
Updates the Go structs to match the changes made in the APIs to return
strings instead of integers for `id` and `primary_certificate` values.

Closes cloudflare/terraform-provider-cloudflare#1139