### PR TITLE
Add ability to change certificate validation method

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -11,6 +11,7 @@ const (
 	ZoneRouteRoot RouteRoot = "zones"
 
 	// Used for testing
-	testAccountID = "01a7362d577a6c3019a474fd6f485823"
-	testZoneID    = "d56084adb405e0b7e32c52321bf07be6"
+	testAccountID    = "01a7362d577a6c3019a474fd6f485823"
+	testZoneID       = "d56084adb405e0b7e32c52321bf07be6"
+	testCertPackUUID = "a77f8bd7-3b47-46b4-a6f1-75cf98109948"
 )

--- a/universal_ssl.go
+++ b/universal_ssl.go
@@ -41,6 +41,15 @@ type universalSSLVerificationResponse struct {
 	Result []UniversalSSLVerificationDetails `json:"result"`
 }
 
+type UniversalSSLCertificatePackValidationMethodSetting struct {
+	ValidationMethod string `json:"validation_method"`
+}
+
+type universalSSLCertificatePackValidationMethodSettingResponse struct {
+	Response
+	Result UniversalSSLCertificatePackValidationMethodSetting `json:"result"`
+}
+
 // UniversalSSLSettingDetails returns the details for a universal ssl setting
 //
 // API reference: https://api.cloudflare.com/#universal-ssl-settings-for-a-zone-universal-ssl-settings-details
@@ -86,6 +95,22 @@ func (api *API) UniversalSSLVerificationDetails(ctx context.Context, zoneID stri
 	var r universalSSLVerificationResponse
 	if err := json.Unmarshal(res, &r); err != nil {
 		return []UniversalSSLVerificationDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// EditUniversalSSLCertificatePackValidationMethod changes the validation method for a certificate pack
+//
+// API reference: https://api.cloudflare.com/#ssl-verification-ssl-verification-details
+func (api *API) EditUniversalSSLCertificatePackValidationMethod(ctx context.Context, zoneID string, certPackUUID string, setting UniversalSSLCertificatePackValidationMethodSetting) (UniversalSSLCertificatePackValidationMethodSetting, error) {
+	uri := fmt.Sprintf("/zones/%s/ssl/verification/%s", zoneID, certPackUUID)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, setting)
+	if err != nil {
+		return UniversalSSLCertificatePackValidationMethodSetting{}, err
+	}
+	var r universalSSLCertificatePackValidationMethodSettingResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return UniversalSSLCertificatePackValidationMethodSetting{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
 }

--- a/universal_ssl.go
+++ b/universal_ssl.go
@@ -99,10 +99,10 @@ func (api *API) UniversalSSLVerificationDetails(ctx context.Context, zoneID stri
 	return r.Result, nil
 }
 
-// EditUniversalSSLCertificatePackValidationMethod changes the validation method for a certificate pack
+// UpdateUniversalSSLCertificatePackValidationMethod changes the validation method for a certificate pack
 //
 // API reference: https://api.cloudflare.com/#ssl-verification-ssl-verification-details
-func (api *API) EditUniversalSSLCertificatePackValidationMethod(ctx context.Context, zoneID string, certPackUUID string, setting UniversalSSLCertificatePackValidationMethodSetting) (UniversalSSLCertificatePackValidationMethodSetting, error) {
+func (api *API) UpdateUniversalSSLCertificatePackValidationMethod(ctx context.Context, zoneID string, certPackUUID string, setting UniversalSSLCertificatePackValidationMethodSetting) (UniversalSSLCertificatePackValidationMethodSetting, error) {
 	uri := fmt.Sprintf("/zones/%s/ssl/verification/%s", zoneID, certPackUUID)
 	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, setting)
 	if err != nil {

--- a/universal_ssl_test.go
+++ b/universal_ssl_test.go
@@ -121,3 +121,41 @@ func TestUniversalSSLVerificationDetails(t *testing.T) {
 		assert.Equal(t, want, got)
 	}
 }
+
+func TestEditSSLCertificatePackValidationMethod(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method, "Expected method 'PATCH', got %s", r.Method)
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		defer r.Body.Close()
+
+		assert.Equal(t, `{"validation_method":"txt"}`, string(body))
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"validation_method": "txt",
+				"status": "pending_validation"
+			}
+		  }`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/verification/"+testCertPackUUID, handler)
+
+	want := UniversalSSLCertificatePackValidationMethodSetting{
+		ValidationMethod: "txt",
+	}
+
+	got, err := client.EditUniversalSSLCertificatePackValidationMethod(context.Background(), testZoneID, testCertPackUUID, want)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}

--- a/universal_ssl_test.go
+++ b/universal_ssl_test.go
@@ -122,7 +122,7 @@ func TestUniversalSSLVerificationDetails(t *testing.T) {
 	}
 }
 
-func TestEditSSLCertificatePackValidationMethod(t *testing.T) {
+func TestUpdateSSLCertificatePackValidationMethod(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -154,7 +154,7 @@ func TestEditSSLCertificatePackValidationMethod(t *testing.T) {
 		ValidationMethod: "txt",
 	}
 
-	got, err := client.EditUniversalSSLCertificatePackValidationMethod(context.Background(), testZoneID, testCertPackUUID, want)
+	got, err := client.UpdateUniversalSSLCertificatePackValidationMethod(context.Background(), testZoneID, testCertPackUUID, want)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, got)
 	}


### PR DESCRIPTION
Hello, first time contributor and novice go programmer. Let me know if there are any changes / tasks that need to be completed and I'll get on them ASAP.

## Description

This adds the ability to change the certificate validation method for universal ssl. Having the option to change validation method opens up the possibility of implementing changes required to fix the following [this cloudflare terraform provider issue](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1130).

## Has your change been tested?

`universal_ssl_test.go` has been updated with a test that matches the API documentation. I've also tested in this in a simple go app:

```go
	want := cloudflare.UniversalSSLCertificatePackValidationMethodSetting{
		ValidationMethod: "txt",
	}

	ver, err := api.EditUniversalSSLCertificatePackValidationMethod(ctx, "4040c861546af1562fd2fb7478dc8f02", "106df4cc-8fc8-400e-b2c3-48e0d352bc10", want)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Println(ver)
```

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. **I'm not sure how/where documentation gets updated?**
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
