### PR TITLE
Add functionality related to Origin CA root certificates

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -22,6 +22,11 @@ import (
 const apiURL = "https://api.cloudflare.com/client/v4"
 
 const (
+	originCARootCertEccURL = "https://developers.cloudflare.com/ssl/0d2cd0f374da0fb6dbf53128b60bbbf7/origin_ca_ecc_root.pem"
+	originCARootCertRsaURL = "https://developers.cloudflare.com/ssl/e2b9968022bf23b071d95229b5678452/origin_ca_rsa_root.pem"
+)
+
+const (
 	// AuthKeyEmail specifies that we should authenticate with API key and email address
 	AuthKeyEmail = 1 << iota
 	// AuthUserService specifies that we should authenticate with a User-Service key

--- a/cmd/flarectl/README.md
+++ b/cmd/flarectl/README.md
@@ -41,15 +41,16 @@ VERSION:
    2017.10.0
    
 COMMANDS:
-   ips, i		Print Cloudflare IP ranges
-   user, u		User information
-   zone, z		Zone information
-   dns, d		DNS records
-   user-agents, ua	User-Agent blocking
-   pagerules, p		Page Rules
-   railgun, r		Railgun information
-   firewall, f		Firewall
-   help, h		Shows a list of commands or help for one command
+   ips, i                     Print Cloudflare IP ranges
+   user, u                    User information
+   zone, z                    Zone information
+   dns, d                     DNS records
+   user-agents, ua            User-Agent blocking
+   pagerules, p               Page Rules
+   railgun, r                 Railgun information
+   firewall, f                Firewall
+   origin-ca-root-cert, ocrc  Print Origin CA Root Certificate (in PEM format)
+   help, h                    Shows a list of commands or help for one command
    
 GLOBAL OPTIONS:
    --help, -h		show help

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -682,6 +682,19 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:    "origin-ca-root-cert",
+			Aliases: []string{"ocrc"},
+			Action:  originCARootCertificate,
+			Usage:   "Print Origin CA Root Certificate (in PEM format)",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "algorithm",
+					Usage:    "certificate algorithm ( ecc | rsa )",
+					Required: true,
+				},
+			},
+		},
 	}
 	err := app.Run(os.Args)
 	if err != nil {

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -206,6 +206,16 @@ func pageRules(c *cli.Context) error {
 	return nil
 }
 
+func originCARootCertificate(c *cli.Context) error {
+	cert, err := cloudflare.OriginCARootCertificate(c.String("algorithm"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(cert[:]))
+	return nil
+}
+
 func railgun(*cli.Context) error {
 	return nil
 }


### PR DESCRIPTION
## Description

This PR introduces the ability to:
- retrieve the Cloudflare Origin CA Root certificate(s) using this library
- print the Origin CA root certificate(s) via e.g. `flarectl origin-ca-root-cert --algorithm rsa`
 
See https://github.com/cloudflare/terraform-provider-cloudflare/issues/1096#issuecomment-875302579 for additional information.

## Has your change been tested?

Tests have been added as well as explicit comment regarding testing the live endpoints. Unfortunately the Origin CA root certificates are not exposed by Cloudflare on a _fixed/API_ endpoint (as per IPs) so the current solution is brittle as the URLs in use may change over time (which originally led to https://github.com/cloudflare/terraform-provider-cloudflare/issues/1096 being raised). 

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
