### PR TITLE
test: introduce utility function checkResultInfo

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -456,8 +456,8 @@ func WithPagination(opts PaginationOptions) ReqOption {
 // ignores the cursor information. perPage, page, and count are the requested #items
 // per page, the requested page number, and the actual length of the Result array.
 //
-// Responses from the actual CloudFlare servers should pass all these checks (or we
-// discover a serious bug in the CloudFlare servers). However, the unit tests can
+// Responses from the actual Cloudflare servers should pass all these checks (or we
+// discover a serious bug in the Cloudflare servers). However, the unit tests can
 // easily violate these constraints and this utility function can help debugging.
 // Correct pagination information is crucial for more advanced List* functions that
 // handle pagination automatically and fetch different pages in parallel.
@@ -470,38 +470,29 @@ func checkResultInfo(perPage, page, count int, info *ResultInfo) bool {
 
 	switch {
 	case info.PerPage != perPage || info.Page != page || info.Count != count:
-		// ResultInfo does not match the expected perPage or the actual count.
 		return false
 
 	case info.PerPage <= 0:
-		// PerPage is zero or negative.
 		return false
 
 	case info.Total == 0 && info.TotalPages == 0 && info.Page == 1 && info.Count == 0:
-		// Special case for total == 0. All following checks assume there is at least one item.
 		return true
 
 	case info.Total <= 0 || info.TotalPages <= 0:
-		// Total and TotalPages must be positive.
 		return false
 
 	case info.Total > info.PerPage*info.TotalPages || info.Total <= info.PerPage*(info.TotalPages-1):
-		// Total must lie in [PerPage*(TotalPages-1)+1...PerPage*TotalPages].
 		return false
 	}
 
-	// At least point, only Page or Count could go wrong.
 	switch {
 	case info.Page > info.TotalPages || info.Page <= 0:
-		// Page must lie in [1...TotalPages].
 		return false
 
 	case info.Page < info.TotalPages:
-		// Every page before the last page must be full.
 		return info.Count == info.PerPage
 
 	case info.Page == info.TotalPages:
-		// The last page contains exactly the items not in the privous pages.
 		return info.Count == info.Total-info.PerPage*(info.TotalPages-1)
 
 	default:

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -453,8 +453,8 @@ func WithPagination(opts PaginationOptions) ReqOption {
 }
 
 // checkResultInfo checks whether ResultInfo is reasonable except that it currently
-// ignores the cursor information. perPage is the expected page size and count is
-// the actual length of the Result array.
+// ignores the cursor information. perPage, page, and count are the requested #items
+// per page, the requested page number, and the actual length of the Result array.
 //
 // Responses from the actual CloudFlare servers should pass all these checks (or we
 // discover a serious bug in the CloudFlare servers). However, the unit tests can
@@ -463,13 +463,13 @@ func WithPagination(opts PaginationOptions) ReqOption {
 // handle pagination automatically and fetch different pages in parallel.
 //
 // TODO: check cursors as well.
-func checkResultInfo(perPage, count int, info *ResultInfo) bool {
+func checkResultInfo(perPage, page, count int, info *ResultInfo) bool {
 	if info.Cursor != "" || info.Cursors.Before != "" || info.Cursors.After != "" {
 		panic("checkResultInfo could not handle cursors yet.")
 	}
 
 	switch {
-	case info.Count != count || info.PerPage != perPage:
+	case info.PerPage != perPage || info.Page != page || info.Count != count:
 		// ResultInfo does not match the expected perPage or the actual count.
 		return false
 

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -503,13 +503,12 @@ func TestContextTimeout(t *testing.T) {
 }
 
 func TestCheckResultInfo(t *testing.T) {
-	type checkResultInfoTest struct {
+	cases := [...]struct {
 		PerPage    int
 		Count      int
 		ResultInfo ResultInfo
 		Verdict    bool
-	}
-	cases := [...]checkResultInfoTest{
+	}{
 		// PerPage's do not match
 		{20, 0, ResultInfo{Page: 1, PerPage: 30, TotalPages: 0, Count: 0, Total: 0}, false},
 		// Count's do not match

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -505,41 +505,46 @@ func TestContextTimeout(t *testing.T) {
 func TestCheckResultInfo(t *testing.T) {
 	cases := [...]struct {
 		PerPage    int
+		Page       int
 		Count      int
 		ResultInfo ResultInfo
 		Verdict    bool
 	}{
 		// PerPage's do not match
-		{20, 0, ResultInfo{Page: 1, PerPage: 30, TotalPages: 0, Count: 0, Total: 0}, false},
+		{20, 1, 0, ResultInfo{Page: 1, PerPage: 30, TotalPages: 0, Count: 0, Total: 0}, false},
+		// Page's do not match
+		{20, 2, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 40}, false},
 		// Count's do not match
-		{20, 2, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 1, Total: 1}, false},
+		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 19, Total: 21}, false},
+		// Count's do not match
+		{20, 1, 19, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 21}, false},
 		// PerPage == 0
-		{0, 0, ResultInfo{Page: 1, PerPage: 0, TotalPages: 1, Count: 0, Total: 0}, false},
+		{0, 1, 0, ResultInfo{Page: 1, PerPage: 0, TotalPages: 1, Count: 0, Total: 0}, false},
 		// Special case when #items == 0
-		{20, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 0, Total: 0}, true},
+		{20, 1, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 0, Total: 0}, true},
 		// Total #items == 0, but #pages > 0
-		{20, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 0, Total: 0}, false},
+		{20, 1, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 0, Total: 0}, false},
 		// Total #items > 0, but #pages == 0
-		{20, 1, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 1, Total: 1}, false},
+		{20, 1, 1, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 1, Total: 1}, false},
 		// Too many total #items (one more page is needed)
-		{20, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 21}, false},
+		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 21}, false},
 		// Too few total #items (the second page would be empty)
-		{20, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 20}, false},
+		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 20}, false},
 		// Page number cannot be zero
-		{20, 20, ResultInfo{Page: 0, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
+		{20, 0, 20, ResultInfo{Page: 0, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
 		// Page number cannot go beyond #pages
-		{20, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
+		{20, 2, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
 		// The last page is full, which is okay
-		{20, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, true},
+		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, true},
 		// We are not on the last page, so it should be full
-		{20, 19, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, false},
+		{20, 1, 19, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, false},
 		// The last page only has 19 items, not 20.
-		{20, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 20, Total: 39}, false},
+		{20, 2, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 20, Total: 39}, false},
 		// Looking good
-		{20, 19, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, true},
+		{20, 2, 19, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, true},
 	}
 
 	for _, c := range cases {
-		assert.Equalf(t, c.Verdict, checkResultInfo(c.PerPage, c.Count, &c.ResultInfo), "Failed case: %+v", c)
+		assert.Equalf(t, c.Verdict, checkResultInfo(c.PerPage, c.Page, c.Count, &c.ResultInfo), "Failed case: %+v", c)
 	}
 }

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -504,45 +504,33 @@ func TestContextTimeout(t *testing.T) {
 
 func TestCheckResultInfo(t *testing.T) {
 	for _, c := range [...]struct {
+		TestName   string
 		PerPage    int
 		Page       int
 		Count      int
 		ResultInfo ResultInfo
 		Verdict    bool
 	}{
-		// PerPage's do not match
-		{20, 1, 0, ResultInfo{Page: 1, PerPage: 30, TotalPages: 0, Count: 0, Total: 0}, false},
-		// Page's do not match
-		{20, 2, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 40}, false},
-		// Count's do not match
-		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 19, Total: 21}, false},
-		// Count's do not match
-		{20, 1, 19, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 21}, false},
-		// PerPage == 0
-		{0, 1, 0, ResultInfo{Page: 1, PerPage: 0, TotalPages: 1, Count: 0, Total: 0}, false},
-		// Special case when #items == 0
-		{20, 1, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 0, Total: 0}, true},
-		// Total #items == 0, but #pages > 0
-		{20, 1, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 0, Total: 0}, false},
-		// Total #items > 0, but #pages == 0
-		{20, 1, 1, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 1, Total: 1}, false},
-		// Too many total #items (one more page is needed)
-		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 21}, false},
-		// Too few total #items (the second page would be empty)
-		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 20}, false},
-		// Page number cannot be zero
-		{20, 0, 20, ResultInfo{Page: 0, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
-		// Page number cannot go beyond #pages
-		{20, 2, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
-		// The last page is full, which is okay
-		{20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, true},
-		// We are not on the last page, so it should be full
-		{20, 1, 19, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, false},
-		// The last page only has 19 items, not 20.
-		{20, 2, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 20, Total: 39}, false},
-		// Looking good
-		{20, 2, 19, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, true},
+		{"per_page do not match", 20, 1, 0, ResultInfo{Page: 1, PerPage: 30, TotalPages: 0, Count: 0, Total: 0}, false},
+		{"page counts do not match", 20, 2, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 40}, false},
+		{"counts do not match", 20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 19, Total: 21}, false},
+		{"counts do not match", 20, 1, 19, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 21}, false},
+		{"per_page 0", 0, 1, 0, ResultInfo{Page: 1, PerPage: 0, TotalPages: 1, Count: 0, Total: 0}, false},
+		{"number of items is zero", 20, 1, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 0, Total: 0}, true},
+		{"number of items is 0 but number of pages is greater than 0", 20, 1, 0, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 0, Total: 0}, false},
+		{"total number of items greater than 0 but number of pages is 0", 20, 1, 1, ResultInfo{Page: 1, PerPage: 20, TotalPages: 0, Count: 1, Total: 1}, false},
+		{"too many total number of items (one more page is needed)", 20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 21}, false},
+		{"too few total number of items (the second page would be empty)", 20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 20, Total: 20}, false},
+		{"page number cannot be zero", 20, 0, 20, ResultInfo{Page: 0, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
+		{"page number cannot go beyond number of pages", 20, 2, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, false},
+		{"the last page is full of results", 20, 1, 20, ResultInfo{Page: 1, PerPage: 20, TotalPages: 1, Count: 20, Total: 20}, true},
+		{"we are not on the last page so it should be full of results", 20, 1, 19, ResultInfo{Page: 1, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, false},
+		{"last page only has 19 items not 20", 20, 2, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 20, Total: 39}, false},
+		{"fully working result info", 20, 2, 19, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, true},
 	} {
-		assert.Equalf(t, c.Verdict, checkResultInfo(c.PerPage, c.Page, c.Count, &c.ResultInfo), "Failed case: %+v", c)
+
+		t.Run(c.TestName, func(t *testing.T) {
+			assert.Equal(t, c.Verdict, checkResultInfo(c.PerPage, c.Page, c.Count, &c.ResultInfo))
+		})
 	}
 }

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -503,7 +503,7 @@ func TestContextTimeout(t *testing.T) {
 }
 
 func TestCheckResultInfo(t *testing.T) {
-	cases := [...]struct {
+	for _, c := range [...]struct {
 		PerPage    int
 		Page       int
 		Count      int
@@ -542,9 +542,7 @@ func TestCheckResultInfo(t *testing.T) {
 		{20, 2, 20, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 20, Total: 39}, false},
 		// Looking good
 		{20, 2, 19, ResultInfo{Page: 2, PerPage: 20, TotalPages: 2, Count: 19, Total: 39}, true},
-	}
-
-	for _, c := range cases {
+	} {
 		assert.Equalf(t, c.Verdict, checkResultInfo(c.PerPage, c.Page, c.Count, &c.ResultInfo), "Failed case: %+v", c)
 	}
 }


### PR DESCRIPTION
This PR is to add a debugging tool to check pagination information. It seems to be useful for developing parallel fetchers of results across different pages. Related issue: #619.

## Description

Currently, pagination information provided in many unit test cases is wrong. This could lead to confusion when developing and debugging parallel fetchers. The new function checks whether the unit tests themselves (not the functions under testing) are at fault.

## Has your change been tested?

Yes.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.