### PR TITLE
rulesets: make downstream life easier for Terraform

### DIFF
--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -164,7 +164,7 @@ func TestGetRuleset_WAF(t *testing.T) {
 		Version: "1",
 		Action:  string(RulesetRuleActionRewrite),
 		ActionParameters: &RulesetRuleActionParameters{
-			URI: RulesetRuleActionParametersURI{
+			URI: &RulesetRuleActionParametersURI{
 				Path: RulesetRuleActionParametersURIPath{
 					Expression: "normalize_url_path(raw.http.request.uri.path)",
 				},


### PR DESCRIPTION
Updates the support for Rulesets to include new methods and struct values that are used within API calls.