### PR TITLE
lint: fix all violations on master

### DIFF
--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -48,7 +48,7 @@ func TestClient_Headers(t *testing.T) {
 		assert.Equal(t, "deadbeef", r.Header.Get("X-Auth-Key"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 	})
-	client.UserDetails(context.Background())
+	client.UserDetails(context.Background()) //nolint
 	teardown()
 
 	// it should override appropriate default headers when custom headers given
@@ -63,7 +63,7 @@ func TestClient_Headers(t *testing.T) {
 		assert.Equal(t, "application/xhtml+xml", r.Header.Get("Content-Type"))
 		assert.Equal(t, "a random header", r.Header.Get("X-Random"))
 	})
-	client.UserDetails(context.Background())
+	client.UserDetails(context.Background()) //nolint
 	teardown()
 
 	// it should set X-Auth-User-Service-Key and omit X-Auth-Email and X-Auth-Key when client.authType is AuthUserService
@@ -78,7 +78,7 @@ func TestClient_Headers(t *testing.T) {
 		assert.Equal(t, "userservicekey", r.Header.Get("X-Auth-User-Service-Key"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 	})
-	client.UserDetails(context.Background())
+	client.UserDetails(context.Background()) //nolint
 	teardown()
 
 	// it should set X-Auth-User-Service-Key and omit X-Auth-Email and X-Auth-Key when using NewWithUserServiceKey
@@ -94,7 +94,7 @@ func TestClient_Headers(t *testing.T) {
 		assert.Equal(t, "userservicekey", r.Header.Get("X-Auth-User-Service-Key"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 	})
-	client.UserDetails(context.Background())
+	client.UserDetails(context.Background()) //nolint
 	teardown()
 
 	// it should set Authorization and omit others credential headers when using NewWithAPIToken
@@ -110,7 +110,7 @@ func TestClient_Headers(t *testing.T) {
 		assert.Equal(t, "Bearer my-api-token", r.Header.Get("Authorization"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 	})
-	client.UserDetails(context.Background())
+	client.UserDetails(context.Background()) //nolint
 	teardown()
 }
 
@@ -458,7 +458,7 @@ func TestClient_ContextIsPassedToRequest(t *testing.T) {
 
 	cfClient, _ := New("deadbeef", "cloudflare@example.org", HTTPClient(httpClient))
 
-	cfClient.ListZonesContext(ctx)
+	cfClient.ListZonesContext(ctx) //nolint
 }
 
 func TestErrorFromResponseWithUnmarshalingError(t *testing.T) {

--- a/cmd/flarectl/firewall.go
+++ b/cmd/flarectl/firewall.go
@@ -169,19 +169,19 @@ func firewallAccessRuleUpdate(c *cli.Context) error {
 	case accountID != "":
 		resp, err := api.UpdateAccountAccessRule(context.Background(), accountID, id, rule)
 		if err != nil {
-			errors.Wrap(err, errUpdating)
+			errors.Wrap(err, errUpdating) //nolint
 		}
 		rules = append(rules, resp.Result)
 	case zoneID != "":
 		resp, err := api.UpdateZoneAccessRule(context.Background(), zoneID, id, rule)
 		if err != nil {
-			errors.Wrap(err, errUpdating)
+			errors.Wrap(err, errUpdating) //nolint
 		}
 		rules = append(rules, resp.Result)
 	default:
 		resp, err := api.UpdateUserAccessRule(context.Background(), id, rule)
 		if err != nil {
-			errors.Wrap(err, errUpdating)
+			errors.Wrap(err, errUpdating) //nolint
 		}
 		rules = append(rules, resp.Result)
 	}
@@ -285,19 +285,19 @@ func firewallAccessRuleDelete(c *cli.Context) error {
 	case accountID != "":
 		resp, err := api.DeleteAccountAccessRule(context.Background(), accountID, ruleID)
 		if err != nil {
-			errors.Wrap(err, errDeleting)
+			errors.Wrap(err, errDeleting) //nolint
 		}
 		rules = append(rules, resp.Result)
 	case zoneID != "":
 		resp, err := api.DeleteZoneAccessRule(context.Background(), zoneID, ruleID)
 		if err != nil {
-			errors.Wrap(err, errDeleting)
+			errors.Wrap(err, errDeleting) //nolint
 		}
 		rules = append(rules, resp.Result)
 	default:
 		resp, err := api.DeleteUserAccessRule(context.Background(), ruleID)
 		if err != nil {
-			errors.Wrap(err, errDeleting)
+			errors.Wrap(err, errDeleting) //nolint
 		}
 		rules = append(rules, resp.Result)
 	}

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -8,10 +8,10 @@ import (
 )
 
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-	builtBy = "unknown"
+	version = "dev"     //nolint
+	commit  = "none"    //nolint
+	date    = "unknown" //nolint
+	builtBy = "unknown" //nolint
 )
 
 var api *cloudflare.API

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -45,7 +45,7 @@ func initializeAPI(c *cli.Context) error {
 	}
 
 	if c.IsSet("accountid") {
-		cloudflare.UsingAccount(c.String("accountid"))(api)
+		cloudflare.UsingAccount(c.String("accountid"))(api) //nolint
 	}
 
 	return nil
@@ -92,7 +92,7 @@ func writeTable(c *cli.Context, data [][]string, cols ...string) {
 func checkFlags(c *cli.Context, flags ...string) error {
 	for _, flag := range flags {
 		if c.String(flag) == "" {
-			cli.ShowSubcommandHelp(c)
+			cli.ShowSubcommandHelp(c) //nolint
 			err := errors.Errorf("error: the required flag %q was empty or not provided", flag)
 			fmt.Fprintln(os.Stderr, err)
 			return err
@@ -122,14 +122,14 @@ func _getIps(ipType string, showMsgType bool) {
 
 	switch ipType {
 	case "ipv4":
-		if showMsgType != true {
+		if showMsgType {
 			fmt.Println("IPv4 ranges:")
 		}
 		for _, r := range ips.IPv4CIDRs {
 			fmt.Println(" ", r)
 		}
 	case "ipv6":
-		if showMsgType != true {
+		if showMsgType {
 			fmt.Println("IPv6 ranges:")
 		}
 		for _, r := range ips.IPv6CIDRs {
@@ -193,7 +193,7 @@ func pageRules(c *cli.Context) error {
 			case map[string]interface{}:
 				s = fmt.Sprintf("%s: %.f - %s", cloudflare.PageRuleActions[a.ID], v["status_code"], v["url"])
 			case nil:
-				s = fmt.Sprintf("%s", cloudflare.PageRuleActions[a.ID])
+				s = cloudflare.PageRuleActions[a.ID]
 			default:
 				vs := fmt.Sprintf("%s", v)
 				s = fmt.Sprintf("%s: %s", cloudflare.PageRuleActions[a.ID], strings.Title(strings.Replace(vs, "_", " ", -1)))

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -42,7 +42,7 @@ func zoneCreate(c *cli.Context) error {
 
 	_, err := api.CreateZone(context.Background(), zone, jumpstart, account, zoneType)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s", err))
+		fmt.Fprintf(os.Stderr, err.Error()+"\n")
 		return err
 	}
 
@@ -104,7 +104,7 @@ func zoneDelete(c *cli.Context) error {
 
 	_, err = api.DeleteZone(context.Background(), zoneID)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("%s", err))
+		fmt.Fprintf(os.Stderr, err.Error()+"\n")
 		return err
 	}
 
@@ -123,7 +123,7 @@ func zoneCreateLockdown(c *cli.Context) error {
 	targets := c.StringSlice("targets")
 	values := c.StringSlice("values")
 	if len(targets) != len(values) {
-		cli.ShowCommandHelp(c, "targets and values does not match")
+		cli.ShowCommandHelp(c, "targets and values does not match") //nolint
 		return nil
 	}
 	var zonelockdownconfigs = []cloudflare.ZoneLockdownConfig{}
@@ -161,7 +161,7 @@ func zoneInfo(c *cli.Context) error {
 	} else if c.String("zone") != "" {
 		zone = c.String("zone")
 	} else {
-		cli.ShowSubcommandHelp(c)
+		cli.ShowSubcommandHelp(c) //nolint
 		return nil
 	}
 	zones, err := api.ListZones(context.Background(), zone)
@@ -202,7 +202,7 @@ func zoneSettings(*cli.Context) error {
 
 func zoneCachePurge(c *cli.Context) error {
 	if err := checkFlags(c, "zone"); err != nil {
-		cli.ShowSubcommandHelp(c)
+		cli.ShowSubcommandHelp(c) //nolint
 		return err
 	}
 
@@ -263,7 +263,7 @@ func zoneRecords(c *cli.Context) error {
 	} else if c.String("zone") != "" {
 		zone = c.String("zone")
 	} else {
-		cli.ShowSubcommandHelp(c)
+		cli.ShowSubcommandHelp(c) //nolint
 		return nil
 	}
 
@@ -318,7 +318,7 @@ func zoneRecords(c *cli.Context) error {
 			r.Type,
 			r.Name,
 			r.Content,
-			fmt.Sprintf("%s", strconv.FormatBool(*r.Proxied)),
+			strconv.FormatBool(*r.Proxied),
 			fmt.Sprintf("%d", r.TTL),
 		})
 	}
@@ -346,7 +346,7 @@ func zoneExport(c *cli.Context) error {
 	} else if c.String("zone") != "" {
 		zone = c.String("zone")
 	} else {
-		cli.ShowSubcommandHelp(c)
+		cli.ShowSubcommandHelp(c) //nolint
 		return nil
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -39,7 +39,7 @@ func (e APIRequestError) Error() string {
 	for _, err := range e.Errors {
 		m := ""
 		if err.Message != "" {
-			m += fmt.Sprintf("%s", err.Message)
+			m += err.Message
 		}
 
 		if err.Code != 0 {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,7 +1,6 @@
 package cloudflare
 
 import (
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -136,7 +135,7 @@ func TestAPIRequestError_ServiceError(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		t.Run(fmt.Sprintf("%s", strconv.Itoa(name)), func(t *testing.T) {
+		t.Run(strconv.Itoa(name), func(t *testing.T) {
 			got := &APIRequestError{StatusCode: name}
 			assert.Equal(t, got.ServiceError(), tc.want)
 		})
@@ -153,7 +152,7 @@ func TestAPIRequestError_ClientError(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		t.Run(fmt.Sprintf("%s", strconv.Itoa(name)), func(t *testing.T) {
+		t.Run(strconv.Itoa(name), func(t *testing.T) {
 			got := &APIRequestError{StatusCode: name}
 			assert.Equal(t, got.ClientError(), tc.want)
 		})
@@ -170,7 +169,7 @@ func TestAPIRequestError_ClientRateLimited(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		t.Run(fmt.Sprintf("%s", strconv.Itoa(name)), func(t *testing.T) {
+		t.Run(strconv.Itoa(name), func(t *testing.T) {
 			got := &APIRequestError{StatusCode: name}
 			assert.Equal(t, got.ClientRateLimited(), tc.want)
 		})

--- a/filter.go
+++ b/filter.go
@@ -220,10 +220,9 @@ func (api *API) DeleteFilters(ctx context.Context, zoneID string, filterIDs []st
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-filters/validation/
 func (api *API) ValidateFilterExpression(ctx context.Context, expression string) error {
-	uri := fmt.Sprintf("/filters/validate-expr")
 	expressionPayload := FilterValidateExpression{Expression: expression}
 
-	_, err := api.makeRequestContext(ctx, http.MethodPost, uri, expressionPayload)
+	_, err := api.makeRequestContext(ctx, http.MethodPost, "/filters/validate-expr", expressionPayload)
 	if err != nil {
 		var filterValidationResponse FilterValidateExpressionResponse
 
@@ -232,7 +231,7 @@ func (api *API) ValidateFilterExpression(ctx context.Context, expression string)
 			return errors.Wrap(jsonErr, errUnmarshalError)
 		}
 
-		if filterValidationResponse.Success != true {
+		if !filterValidationResponse.Success {
 			// Unsure why but the API returns `errors` as an array but it only
 			// ever shows the issue with one problem at a time ¯\_(ツ)_/¯
 			return errors.Errorf(filterValidationResponse.Errors[0].Message)

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -58,22 +58,6 @@ var (
 		Valid:    true,
 		Message:  "",
 	}
-	expectedLogpushGetOwnershipChallengeInvalidResponseStruct = LogpushGetOwnershipChallenge{
-		Filename: "logs/challenge-filename.txt",
-		Valid:    false,
-		Message:  "destination is invalid",
-	}
-	expectedUpdatedLogpushJobStruct = LogpushJob{
-		ID:              jobID,
-		Dataset:         "http_requests",
-		Enabled:         true,
-		Name:            "updated.com",
-		LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp",
-		DestinationConf: "gs://mybucket/logs",
-		LastComplete:    &testLogpushTimestamp,
-		LastError:       &testLogpushTimestamp,
-		ErrorMessage:    "test",
-	}
 )
 
 func TestLogpushJobs(t *testing.T) {

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -42,7 +42,7 @@ func TestGetEligibleNotificationDestinations(t *testing.T) {
   "errors": [],
   "messages": [],
   "result":%s
-}`, fmt.Sprintf(string(b)))
+}`, string(b))
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/alerting/v3/destinations/eligible", handler)
@@ -74,7 +74,7 @@ func TestGetAvailableNotificationTypes(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/alerting/v3/available_alerts", handler)
@@ -102,7 +102,7 @@ func TestListPagerDutyDestinations(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -164,7 +164,7 @@ func TestCreateNotificationPolicy(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -205,7 +205,7 @@ func TestGetNotificationPolicy(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -253,7 +253,7 @@ func TestListNotificationPolicies(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -297,7 +297,7 @@ func TestUpdateNotificationPolicy(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -328,7 +328,7 @@ func TestDeleteNotificationPolicy(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -366,7 +366,7 @@ func TestCreateNotificationWebhooks(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -406,7 +406,7 @@ func TestListNotificationWebhooks(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -445,7 +445,7 @@ func TestGetNotificationWebhooks(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -482,7 +482,7 @@ func TestUpdateNotificationWebhooks(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 
@@ -514,7 +514,7 @@ func TestDeleteNotificationWebhooks(t *testing.T) {
   									"messages": [],
   									"result":%s
 								}`,
-			fmt.Sprintf(string(b)))
+			string(b))
 		require.NoError(t, err)
 	}
 

--- a/rate_limiting_test.go
+++ b/rate_limiting_test.go
@@ -69,30 +69,6 @@ var expectedRateLimitStruct = RateLimit{
 		By: "nat",
 	},
 }
-var expectedRateLimitStructUpdated = RateLimit{
-	ID:          "72dae2fc158942f2adb1dd2a3d4143bc",
-	Disabled:    false,
-	Description: "test",
-	Match: RateLimitTrafficMatcher{
-		Request: RateLimitRequestMatcher{
-			Methods:    []string{"_ALL_"},
-			Schemes:    []string{"_ALL_"},
-			URLPattern: "exampledomain.com/test-rate-limit",
-		},
-		Response: RateLimitResponseMatcher{
-			OriginTraffic: &expectedOriginTraffic,
-		},
-	},
-	Threshold: 50,
-	Period:    1,
-	Action: RateLimitAction{
-		Mode:    "ban",
-		Timeout: 60,
-	},
-	Correlate: &RateLimitCorrelate{
-		By: "nat",
-	},
-}
 
 func TestListRateLimits(t *testing.T) {
 	setup()

--- a/registrar_example_test.go
+++ b/registrar_example_test.go
@@ -4,51 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
-)
-
-var (
-	createdAndModifiedTimestamp, _ = time.Parse(time.RFC3339, "2018-08-28T17:26:26Z")
-	expiresAtTimestamp, _          = time.Parse(time.RFC3339, "2019-08-28T23:59:59Z")
-	expectedRegistrarTransferIn    = cloudflare.RegistrarTransferIn{
-		UnlockDomain:      "ok",
-		DisablePrivacy:    "ok",
-		EnterAuthCode:     "needed",
-		ApproveTransfer:   "unknown",
-		AcceptFoa:         "needed",
-		CanCancelTransfer: true,
-	}
-	expectedRegistrarContact = cloudflare.RegistrantContact{
-		ID:           "ea95132c15732412d22c1476fa83f27a",
-		FirstName:    "John",
-		LastName:     "Appleseed",
-		Organization: "Cloudflare, Inc.",
-		Address:      "123 Sesame St.",
-		Address2:     "Suite 430",
-		City:         "Austin",
-		State:        "TX",
-		Zip:          "12345",
-		Country:      "US",
-		Phone:        "+1 123-123-1234",
-		Email:        "user@example.com",
-		Fax:          "123-867-5309",
-	}
-	expectedRegistrarDomain = cloudflare.RegistrarDomain{
-		ID:                "ea95132c15732412d22c1476fa83f27a",
-		Available:         false,
-		SupportedTLD:      true,
-		CanRegister:       false,
-		TransferIn:        expectedRegistrarTransferIn,
-		CurrentRegistrar:  "Cloudflare",
-		ExpiresAt:         expiresAtTimestamp,
-		RegistryStatuses:  "ok,serverTransferProhibited",
-		Locked:            false,
-		CreatedAt:         createdAndModifiedTimestamp,
-		UpdatedAt:         createdAndModifiedTimestamp,
-		RegistrantContact: expectedRegistrarContact,
-	}
 )
 
 func ExampleAPI_RegistrarDomain() {
@@ -58,6 +15,12 @@ func ExampleAPI_RegistrarDomain() {
 	}
 
 	domain, err := api.RegistrarDomain(context.Background(), "01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Printf("%+v\n", domain)
 }
@@ -69,6 +32,9 @@ func ExampleAPI_RegistrarDomains() {
 	}
 
 	domains, err := api.RegistrarDomains(context.Background(), "01a7362d577a6c3019a474fd6f485823")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Printf("%+v\n", domains)
 }
@@ -80,6 +46,9 @@ func ExampleAPI_TransferRegistrarDomain() {
 	}
 
 	domain, err := api.TransferRegistrarDomain(context.Background(), "01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Printf("%+v\n", domain)
 }
@@ -91,6 +60,9 @@ func ExampleAPI_CancelRegistrarDomainTransfer() {
 	}
 
 	domains, err := api.CancelRegistrarDomainTransfer(context.Background(), "01a7362d577a6c3019a474fd6f485823", "cloudflare.com")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Printf("%+v\n", domains)
 }
@@ -105,6 +77,9 @@ func ExampleAPI_UpdateRegistrarDomain() {
 		NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
 		Locked:      false,
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	fmt.Printf("%+v\n", domain)
 }

--- a/registrar_test.go
+++ b/registrar_test.go
@@ -10,45 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	registrarDomainPayload = `{
-		"id": "ea95132c15732412d22c1476fa83f27a",
-		"available": false,
-		"supported_tld": true,
-		"can_register": false,
-		"transfer_in": {
-			"unlock_domain": "ok",
-			"disable_privacy": "ok",
-			"enter_auth_code": "needed",
-			"approve_transfer": "unknown",
-			"accept_foa": "needed",
-			"can_cancel_transfer": true
-		},
-		"current_registrar": "Cloudflare",
-		"expires_at": "2019-08-28T23:59:59Z",
-		"registry_statuses": "ok,serverTransferProhibited",
-		"locked": false,
-		"created_at": "2018-08-28T17:26:26Z",
-		"updated_at": "2018-08-28T17:26:26Z",
-		"registrant_contact": {
-			"id": "ea95132c15732412d22c1476fa83f27a",
-			"first_name": "John",
-			"last_name": "Appleseed",
-			"organization": "Cloudflare, Inc.",
-			"address": "123 Sesame St.",
-			"address2": "Suite 430",
-			"city": "Austin",
-			"state": "TX",
-			"zip": "12345",
-			"country": "US",
-			"phone": "+1 123-123-1234",
-			"email": "user@example.com",
-			"fax": "123-867-5309"
-		}
-	}
-`
-)
-
 var (
 	createdAndModifiedTimestamp, _ = time.Parse(time.RFC3339, "2018-08-28T17:26:26Z")
 	expiresAtTimestamp, _          = time.Parse(time.RFC3339, "2019-08-28T23:59:59Z")

--- a/spectrum.go
+++ b/spectrum.go
@@ -134,7 +134,7 @@ func (a *SpectrumApplication) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if spp, ok := body["spp"]; ok && spp.(bool) == true {
+	if spp, ok := body["spp"]; ok && spp.(bool) {
 		app.ProxyProtocol = "simple"
 	}
 

--- a/workers.go
+++ b/workers.go
@@ -735,14 +735,14 @@ func (api *API) UpdateWorkerRoute(ctx context.Context, zoneID string, routeID st
 }
 
 func getRouteEndpoint(api *API, route WorkerRoute) (string, error) {
-	if route.Script != "" && route.Enabled == true {
+	if route.Script != "" && route.Enabled {
 		return "", errors.New("Only `Script` or `Enabled` may be specified for a WorkerRoute, not both")
 	}
 
 	// For backwards-compatibility, fallback to the deprecated filter
 	// endpoint if Enabled == true
 	// https://api.cloudflare.com/#worker-filters-deprecated--properties
-	if route.Enabled == true {
+	if route.Enabled {
 		return "filters", nil
 	}
 

--- a/workers_kv_test.go
+++ b/workers_kv_test.go
@@ -29,7 +29,7 @@ func TestWorkersKV_CreateWorkersKVNamespace(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/storage/kv/namespaces", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.CreateWorkersKVNamespace(context.Background(), &WorkersKVNamespaceRequest{Title: "Namespace"})
@@ -60,7 +60,7 @@ func TestWorkersKV_DeleteWorkersKVNamespace(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s", namespace), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.DeleteWorkersKVNamespace(context.Background(), namespace)
@@ -96,10 +96,10 @@ func TestWorkersKV_ListWorkersKVNamespace(t *testing.T) {
 		}
 	}`
 
-	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces"), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/accounts/foo/storage/kv/namespaces", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.ListWorkersKVNamespaces(context.Background())
@@ -165,15 +165,15 @@ func TestWorkersKV_ListWorkersKVNamespaceMultiplePages(t *testing.T) {
 		}
 	}`
 
-	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces"), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/accounts/foo/storage/kv/namespaces", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
 
 		if r.URL.Query().Get("page") == "1" {
-			fmt.Fprintf(w, response1)
+			fmt.Fprintf(w, response1) //nolint
 			return
 		} else if r.URL.Query().Get("page") == "2" {
-			fmt.Fprintf(w, response2)
+			fmt.Fprintf(w, response2) //nolint
 			return
 		} else {
 			panic(errors.New("Got a request for an unexpected page"))
@@ -218,7 +218,7 @@ func TestWorkersKV_UpdateWorkersKVNamespace(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s", namespace), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.UpdateWorkersKVNamespace(context.Background(), namespace, &WorkersKVNamespaceRequest{Title: "Namespace"})
@@ -246,7 +246,7 @@ func TestWorkersKV_WriteWorkersKV(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/values/%s", namespace, key), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application/octet-stream")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	want := successResponse
@@ -274,7 +274,7 @@ func TestWorkersKV_WriteWorkersKVBulk(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/bulk", namespace), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	want := successResponse
@@ -320,7 +320,7 @@ func TestWorkersKV_DeleteWorkersKV(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/values/%s", namespace, key), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.DeleteWorkersKV(context.Background(), namespace, key)
@@ -348,7 +348,7 @@ func TestWorkersKV_DeleteWorkersKVBulk(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/bulk", namespace), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	want := successResponse
@@ -382,7 +382,7 @@ func TestWorkersKV_ListStorageKeys(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/keys", namespace), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.ListWorkersKVs(context.Background(), namespace)
@@ -452,7 +452,7 @@ func TestWorkersKV_ListStorageKeysWithOptions(t *testing.T) {
 	mux.HandleFunc(fmt.Sprintf("/accounts/foo/storage/kv/namespaces/%s/keys", namespace), func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	limit, prefix := 25, "test-prefix"

--- a/workers_secrets_test.go
+++ b/workers_secrets_test.go
@@ -26,7 +26,7 @@ func TestWorkers_SetWorkersSecret(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/workers/scripts/test-script/secrets", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 	req := &WorkersPutSecretRequest{
 		Name: "my-secret",
@@ -63,7 +63,7 @@ func TestWorkers_DeleteWorkersSecret(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/workers/scripts/test-script/secrets/my-secret", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.DeleteWorkersSecret(context.Background(), "test-script", "my-secret")
@@ -91,7 +91,7 @@ func TestWorkers_ListWorkersSecret(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/workers/scripts/test-script/secrets", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, response)
+		fmt.Fprintf(w, response) //nolint
 	})
 
 	res, err := client.ListWorkersSecrets(context.Background(), "test-script")

--- a/workers_test.go
+++ b/workers_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -162,7 +161,6 @@ var (
 	successResponse               = Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}}
 	workerScript                  = "addEventListener('fetch', event => {\n    event.passThroughOnException()\nevent.respondWith(handleRequest(event.request))\n})\n\nasync function handleRequest(request) {\n    return fetch(request)\n}"
 	deleteWorkerRouteResponseData = createWorkerRouteResponse
-	formDataContentTypeRegex      = regexp.MustCompile("^multipart/form-data; boundary=")
 )
 
 func getFormValue(r *http.Request, key string) ([]byte, error) {
@@ -243,7 +241,7 @@ func TestWorkers_DeleteWorker(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/script", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, deleteWorkerResponseData)
+		fmt.Fprintf(w, deleteWorkerResponseData) //nolint
 	})
 	res, err := client.DeleteWorker(context.Background(), &WorkerRequestParams{ZoneID: "foo"})
 	want := WorkerScriptResponse{
@@ -261,7 +259,7 @@ func TestWorkers_DeleteWorkerWithName(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, deleteWorkerResponseData)
+		fmt.Fprintf(w, deleteWorkerResponseData) //nolint
 	})
 	res, err := client.DeleteWorker(context.Background(), &WorkerRequestParams{ScriptName: "bar"})
 	want := WorkerScriptResponse{
@@ -287,7 +285,7 @@ func TestWorkers_DownloadWorker(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/script", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, workerScript)
+		fmt.Fprintf(w, workerScript) //nolint
 	})
 	res, err := client.DownloadWorker(context.Background(), &WorkerRequestParams{ZoneID: "foo"})
 	want := WorkerScriptResponse{
@@ -307,7 +305,7 @@ func TestWorkers_DownloadWorkerWithName(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application/javascript")
-		fmt.Fprintf(w, workerScript)
+		fmt.Fprintf(w, workerScript) //nolint
 	})
 	res, err := client.DownloadWorker(context.Background(), &WorkerRequestParams{ScriptName: "bar"})
 	want := WorkerScriptResponse{
@@ -335,7 +333,7 @@ func TestWorkers_ListWorkerScripts(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/workers/scripts", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, listWorkersResponseData)
+		fmt.Fprintf(w, listWorkersResponseData) //nolint
 	})
 
 	res, err := client.ListWorkerScripts(context.Background())
@@ -368,7 +366,7 @@ func TestWorkers_UploadWorker(t *testing.T) {
 		contentTypeHeader := r.Header.Get("content-type")
 		assert.Equal(t, "application/javascript", contentTypeHeader, "Expected content-type request header to be 'application/javascript', got %s", contentTypeHeader)
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	})
 	res, err := client.UploadWorker(context.Background(), &WorkerRequestParams{ZoneID: "foo"}, workerScript)
 	formattedTime, _ := time.Parse(time.RFC3339Nano, "2018-06-09T15:17:01.989141Z")
@@ -396,7 +394,7 @@ func TestWorkers_UploadWorkerWithName(t *testing.T) {
 		contentTypeHeader := r.Header.Get("content-type")
 		assert.Equal(t, "application/javascript", contentTypeHeader, "Expected content-type request header to be 'application/javascript', got %s", contentTypeHeader)
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	})
 	res, err := client.UploadWorker(context.Background(), &WorkerRequestParams{ScriptName: "bar"}, workerScript)
 	formattedTime, _ := time.Parse(time.RFC3339Nano, "2018-06-09T15:17:01.989141Z")
@@ -424,7 +422,7 @@ func TestWorkers_UploadWorkerSingleScriptWithAccount(t *testing.T) {
 		contentTypeHeader := r.Header.Get("content-type")
 		assert.Equal(t, "application/javascript", contentTypeHeader, "Expected content-type request header to be 'application/javascript', got %s", contentTypeHeader)
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	})
 	res, err := client.UploadWorker(context.Background(), &WorkerRequestParams{ZoneID: "foo"}, workerScript)
 	formattedTime, _ := time.Parse(time.RFC3339Nano, "2018-06-09T15:17:01.989141Z")
@@ -477,7 +475,7 @@ func TestWorkers_UploadWorkerWithInheritBinding(t *testing.T) {
 		assert.Equal(t, expectedBindings, mpUpload.BindingMeta)
 
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	}
 	mux.HandleFunc("/zones/foo/workers/script", handler)
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", handler)
@@ -539,7 +537,7 @@ func TestWorkers_UploadWorkerWithKVBinding(t *testing.T) {
 		assert.Equal(t, expectedBindings, mpUpload.BindingMeta)
 
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	}
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", handler)
 
@@ -581,7 +579,7 @@ func TestWorkers_UploadWorkerWithWasmBinding(t *testing.T) {
 		assert.Equal(t, []byte("fake-wasm"), wasmContent)
 
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	}
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", handler)
 
@@ -618,7 +616,7 @@ func TestWorkers_UploadWorkerWithPlainTextBinding(t *testing.T) {
 		assert.Equal(t, expectedBindings, mpUpload.BindingMeta)
 
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	}
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", handler)
 
@@ -655,7 +653,7 @@ func TestWorkers_UploadWorkerWithSecretTextBinding(t *testing.T) {
 		assert.Equal(t, expectedBindings, mpUpload.BindingMeta)
 
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
 	}
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", handler)
 
@@ -678,7 +676,7 @@ func TestWorkers_CreateWorkerRoute(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/filters", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, createWorkerRouteResponse)
+		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app1.example.com/*", Enabled: true}
 	res, err := client.CreateWorkerRoute(context.Background(), "foo", route)
@@ -695,7 +693,7 @@ func TestWorkers_CreateWorkerRouteEnt(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, createWorkerRouteResponse)
+		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app1.example.com/*", Script: "test_script"}
 	res, err := client.CreateWorkerRoute(context.Background(), "foo", route)
@@ -712,7 +710,7 @@ func TestWorkers_CreateWorkerRouteSingleScriptWithAccount(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/filters", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, createWorkerRouteResponse)
+		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app1.example.com/*", Enabled: true}
 	res, err := client.CreateWorkerRoute(context.Background(), "foo", route)
@@ -737,7 +735,7 @@ func TestWorkers_CreateWorkerRouteWithNoScript(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, createWorkerRouteResponse)
+		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 
 	route := WorkerRoute{Pattern: "app1.example.com/*"}
@@ -752,7 +750,7 @@ func TestWorkers_DeleteWorkerRoute(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, deleteWorkerRouteResponseData)
+		fmt.Fprintf(w, deleteWorkerRouteResponseData) //nolint
 	})
 	res, err := client.DeleteWorkerRoute(context.Background(), "foo", "e7a57d8746e74ae49c25994dadb421b1")
 	want := WorkerRouteResponse{successResponse,
@@ -771,7 +769,7 @@ func TestWorkers_DeleteWorkerRouteEnt(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, deleteWorkerRouteResponseData)
+		fmt.Fprintf(w, deleteWorkerRouteResponseData) //nolint
 	})
 	res, err := client.DeleteWorkerRoute(context.Background(), "foo", "e7a57d8746e74ae49c25994dadb421b1")
 	want := WorkerRouteResponse{successResponse,
@@ -790,7 +788,7 @@ func TestWorkers_ListWorkerRoutes(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/filters", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, listRouteResponseData)
+		fmt.Fprintf(w, listRouteResponseData) //nolint
 	})
 
 	res, err := client.ListWorkerRoutes(context.Background(), "foo")
@@ -812,7 +810,7 @@ func TestWorkers_ListWorkerRoutesEnt(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, listRouteEntResponseData)
+		fmt.Fprintf(w, listRouteEntResponseData) //nolint
 	})
 
 	res, err := client.ListWorkerRoutes(context.Background(), "foo")
@@ -835,7 +833,7 @@ func TestWorkers_GetWorkerRoute(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes/1234", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, getRouteResponseData)
+		fmt.Fprintf(w, getRouteResponseData) //nolint
 	})
 
 	res, err := client.GetWorkerRoute(context.Background(), "foo", "1234")
@@ -857,7 +855,7 @@ func TestWorkers_UpdateWorkerRoute(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/filters/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, updateWorkerRouteResponse)
+		fmt.Fprintf(w, updateWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app3.example.com/*", Enabled: true}
 	res, err := client.UpdateWorkerRoute(context.Background(), "foo", "e7a57d8746e74ae49c25994dadb421b1", route)
@@ -879,7 +877,7 @@ func TestWorkers_UpdateWorkerRouteEnt(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, updateWorkerRouteEntResponse)
+		fmt.Fprintf(w, updateWorkerRouteEntResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app3.example.com/*", Script: "test_script_1"}
 	res, err := client.UpdateWorkerRoute(context.Background(), "foo", "e7a57d8746e74ae49c25994dadb421b1", route)
@@ -901,7 +899,7 @@ func TestWorkers_UpdateWorkerRouteSingleScriptWithAccount(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/filters/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, updateWorkerRouteEntResponse)
+		fmt.Fprintf(w, updateWorkerRouteEntResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app3.example.com/*", Enabled: true}
 	res, err := client.UpdateWorkerRoute(context.Background(), "foo", "e7a57d8746e74ae49c25994dadb421b1", route)
@@ -923,7 +921,7 @@ func TestWorkers_ListWorkerBindingsMultiScript(t *testing.T) {
 	mux.HandleFunc("/accounts/foo/workers/scripts/my-script/bindings", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, listBindingsResponseData)
+		fmt.Fprintf(w, listBindingsResponseData) //nolint
 	})
 
 	mux.HandleFunc("/accounts/foo/workers/scripts/my-script/bindings/MY_WASM/content", func(w http.ResponseWriter, r *http.Request) {
@@ -991,7 +989,7 @@ func TestWorkers_UpdateWorkerRouteWithNoScript(t *testing.T) {
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application-json")
-		fmt.Fprintf(w, updateWorkerRouteEntResponse)
+		fmt.Fprintf(w, updateWorkerRouteEntResponse) //nolint
 	})
 
 	route := WorkerRoute{Pattern: "app1.example.com/*"}


### PR DESCRIPTION
Following the implementation of `golangci-lint` we have more comprehensive checks. This updates the repository to match the recommendations and suppress a few we don't care about or are false positives.