### PR TITLE
feat(dns): normalize DNS record names

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -58,9 +58,6 @@ var nontransitionalLookup = idna.New(
 // from Unicode form to Punycode, using non-transitional process specified
 // in UTS 46.
 //
-// Confusinigly, this is in the opposite direction of normalizeZoneName
-// to work around the current quirks of the Cloudflare servers.
-//
 // Note: conversion errors are silently discarded and partial conversion
 // results are used.
 func normalizeDomainName(name string) string {

--- a/dns.go
+++ b/dns.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/idna"
 )
 
 // DNSRecord represents a DNS record in a zone.
@@ -45,10 +46,34 @@ type DNSListResponse struct {
 	ResultInfo `json:"result_info"`
 }
 
+// nontransitionalLookup implements the nontransitional processing as specified in
+// Unicode Technical Standard 46 with almost all checkings off to maximize user freedom.
+var nontransitionalLookup = idna.New(
+	idna.MapForLookup(),
+	idna.StrictDomainName(false),
+	idna.ValidateLabels(false),
+)
+
+// normalizeDomainName tries to convert IDNs (international domain names)
+// from Unicode form to Punycode, using non-transitional process specified
+// in UTS 46.
+//
+// Confusinigly, this is in the opposite direction of normalizeZoneName
+// to work around the current quirks of the Cloudflare servers.
+//
+// Note: conversion errors are silently discarded and partial conversion
+// results are used.
+func normalizeDomainName(name string) string {
+	name, _ = nontransitionalLookup.ToASCII(name)
+	return name
+}
+
 // CreateDNSRecord creates a DNS record for the zone identifier.
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
 func (api *API) CreateDNSRecord(ctx context.Context, zoneID string, rr DNSRecord) (*DNSRecordResponse, error) {
+	rr.Name = normalizeDomainName(rr.Name)
+
 	uri := fmt.Sprintf("/zones/%s/dns_records", zoneID)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, rr)
 	if err != nil {
@@ -75,7 +100,7 @@ func (api *API) DNSRecords(ctx context.Context, zoneID string, rr DNSRecord) ([]
 	// Request as many records as possible per page - API max is 100
 	v.Set("per_page", "100")
 	if rr.Name != "" {
-		v.Set("name", rr.Name)
+		v.Set("name", normalizeDomainName(rr.Name))
 	}
 	if rr.Type != "" {
 		v.Set("type", rr.Type)
@@ -133,6 +158,8 @@ func (api *API) DNSRecord(ctx context.Context, zoneID, recordID string) (DNSReco
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
 func (api *API) UpdateDNSRecord(ctx context.Context, zoneID, recordID string, rr DNSRecord) error {
+	rr.Name = normalizeDomainName(rr.Name)
+
 	// Populate the record name from the existing one if the update didn't
 	// specify it.
 	if rr.Name == "" || rr.Type == "" {

--- a/dns.go
+++ b/dns.go
@@ -54,13 +54,13 @@ var nontransitionalLookup = idna.New(
 	idna.ValidateLabels(false),
 )
 
-// normalizeDomainName tries to convert IDNs (international domain names)
+// toUTS46ASCII tries to convert IDNs (international domain names)
 // from Unicode form to Punycode, using non-transitional process specified
 // in UTS 46.
 //
 // Note: conversion errors are silently discarded and partial conversion
 // results are used.
-func normalizeDomainName(name string) string {
+func toUTS46ASCII(name string) string {
 	name, _ = nontransitionalLookup.ToASCII(name)
 	return name
 }
@@ -69,7 +69,7 @@ func normalizeDomainName(name string) string {
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
 func (api *API) CreateDNSRecord(ctx context.Context, zoneID string, rr DNSRecord) (*DNSRecordResponse, error) {
-	rr.Name = normalizeDomainName(rr.Name)
+	rr.Name = toUTS46ASCII(rr.Name)
 
 	uri := fmt.Sprintf("/zones/%s/dns_records", zoneID)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, rr)
@@ -97,7 +97,7 @@ func (api *API) DNSRecords(ctx context.Context, zoneID string, rr DNSRecord) ([]
 	// Request as many records as possible per page - API max is 100
 	v.Set("per_page", "100")
 	if rr.Name != "" {
-		v.Set("name", normalizeDomainName(rr.Name))
+		v.Set("name", toUTS46ASCII(rr.Name))
 	}
 	if rr.Type != "" {
 		v.Set("type", rr.Type)
@@ -155,7 +155,7 @@ func (api *API) DNSRecord(ctx context.Context, zoneID, recordID string) (DNSReco
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
 func (api *API) UpdateDNSRecord(ctx context.Context, zoneID, recordID string, rr DNSRecord) error {
-	rr.Name = normalizeDomainName(rr.Name)
+	rr.Name = toUTS46ASCII(rr.Name)
 
 	// Populate the record name from the existing one if the update didn't
 	// specify it.

--- a/dns_test.go
+++ b/dns_test.go
@@ -68,9 +68,17 @@ func TestCreateDNSRecord(t *testing.T) {
 
 	priority := uint16(10)
 	proxied := false
-	input := DNSRecord{
+	unicodeInput := DNSRecord{
 		Type:     "A",
-		Name:     "example.com",
+		Name:     "😺.example.com",
+		Content:  "198.51.100.4",
+		TTL:      120,
+		Priority: &priority,
+		Proxied:  &proxied,
+	}
+	asciiInput := DNSRecord{
+		Type:     "A",
+		Name:     "xn--138h.example.com",
 		Content:  "198.51.100.4",
 		TTL:      120,
 		Priority: &priority,
@@ -83,7 +91,7 @@ func TestCreateDNSRecord(t *testing.T) {
 		var v DNSRecord
 		err := json.NewDecoder(r.Body).Decode(&v)
 		require.NoError(t, err)
-		assert.Equal(t, input, v)
+		assert.Equal(t, asciiInput, v)
 
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprint(w, `{
@@ -93,7 +101,7 @@ func TestCreateDNSRecord(t *testing.T) {
 			"result": {
 				"id": "372e67954025e0ba6aaa6d586b9e0b59",
 				"type": "A",
-				"name": "example.com",
+				"name": "xn--138h.example.com",
 				"content": "198.51.100.4",
 				"proxiable": true,
 				"proxied": false,
@@ -119,12 +127,12 @@ func TestCreateDNSRecord(t *testing.T) {
 	want := &DNSRecordResponse{
 		Result: DNSRecord{
 			ID:         "372e67954025e0ba6aaa6d586b9e0b59",
-			Type:       input.Type,
-			Name:       input.Name,
-			Content:    input.Content,
+			Type:       asciiInput.Type,
+			Name:       asciiInput.Name,
+			Content:    asciiInput.Content,
 			Proxiable:  true,
-			Proxied:    input.Proxied,
-			TTL:        input.TTL,
+			Proxied:    asciiInput.Proxied,
+			TTL:        asciiInput.TTL,
 			ZoneID:     testZoneID,
 			ZoneName:   "example.com",
 			CreatedOn:  createdOn,
@@ -138,7 +146,7 @@ func TestCreateDNSRecord(t *testing.T) {
 		Response: Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}},
 	}
 
-	actual, err := client.CreateDNSRecord(context.Background(), testZoneID, input)
+	actual, err := client.CreateDNSRecord(context.Background(), testZoneID, unicodeInput)
 	require.NoError(t, err)
 
 	assert.Equal(t, want, actual)
@@ -148,8 +156,13 @@ func TestDNSRecords(t *testing.T) {
 	setup()
 	defer teardown()
 
-	input := DNSRecord{
-		Name:    "example.com",
+	unicodeInput := DNSRecord{
+		Name:    "😺.example.com",
+		Type:    "A",
+		Content: "198.51.100.4",
+	}
+	asciiInput := DNSRecord{
+		Name:    "xn--138h.example.com",
 		Type:    "A",
 		Content: "198.51.100.4",
 	}
@@ -157,9 +170,9 @@ func TestDNSRecords(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
 		assert.Equal(t, "100", r.URL.Query().Get("per_page"))
-		assert.Equal(t, input.Name, r.URL.Query().Get("name"))
-		assert.Equal(t, input.Type, r.URL.Query().Get("type"))
-		assert.Equal(t, input.Content, r.URL.Query().Get("content"))
+		assert.Equal(t, asciiInput.Name, r.URL.Query().Get("name"))
+		assert.Equal(t, asciiInput.Type, r.URL.Query().Get("type"))
+		assert.Equal(t, asciiInput.Content, r.URL.Query().Get("content"))
 
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprint(w, `{
@@ -170,7 +183,7 @@ func TestDNSRecords(t *testing.T) {
 				{
 					"id": "372e67954025e0ba6aaa6d586b9e0b59",
 					"type": "A",
-					"name": "example.com",
+					"name": "xn--138h.example.com",
 					"content": "198.51.100.4",
 					"proxiable": true,
 					"proxied": false,
@@ -202,8 +215,8 @@ func TestDNSRecords(t *testing.T) {
 	want := []DNSRecord{{
 		ID:         "372e67954025e0ba6aaa6d586b9e0b59",
 		Type:       "A",
-		Name:       input.Name,
-		Content:    input.Content,
+		Name:       asciiInput.Name,
+		Content:    asciiInput.Content,
 		Proxiable:  true,
 		Proxied:    &proxied,
 		TTL:        120,
@@ -219,7 +232,7 @@ func TestDNSRecords(t *testing.T) {
 		},
 	}}
 
-	actual, err := client.DNSRecords(context.Background(), testZoneID, input)
+	actual, err := client.DNSRecords(context.Background(), testZoneID, unicodeInput)
 	require.NoError(t, err)
 
 	assert.Equal(t, want, actual)
@@ -352,15 +365,17 @@ func TestUpdateDNSRecordWithoutName(t *testing.T) {
 	defer teardown()
 
 	proxied := false
-	input := DNSRecord{
+
+	asciiInput := DNSRecord{
+		Name:    "xn--138h.example.com",
 		Type:    "A",
 		Content: "198.51.100.4",
 		TTL:     120,
 		Proxied: &proxied,
 	}
 
-	completedInput := DNSRecord{
-		Name:    "example.com",
+	unicodeInput := DNSRecord{
+		Name:    "😺.example.com",
 		Type:    "A",
 		Content: "198.51.100.4",
 		TTL:     120,
@@ -373,7 +388,7 @@ func TestUpdateDNSRecordWithoutName(t *testing.T) {
 		var v DNSRecord
 		err := json.NewDecoder(r.Body).Decode(&v)
 		require.NoError(t, err)
-		assert.Equal(t, completedInput, v)
+		assert.Equal(t, asciiInput, v)
 
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprint(w, `{
@@ -383,7 +398,7 @@ func TestUpdateDNSRecordWithoutName(t *testing.T) {
 			"result": {
 				"id": "372e67954025e0ba6aaa6d586b9e0b59",
 				"type": "A",
-				"name": "example.com",
+				"name": "xn--138h.example.com",
 				"content": "198.51.100.4",
 				"proxiable": true,
 				"proxied": false,
@@ -413,7 +428,7 @@ func TestUpdateDNSRecordWithoutName(t *testing.T) {
 			"result": {
 				"id": "372e67954025e0ba6aaa6d586b9e0b59",
 				"type": "A",
-				"name": "example.com",
+				"name": "xn--138h.example.com",
 				"content": "198.51.100.4",
 				"proxiable": true,
 				"proxied": false,
@@ -450,7 +465,7 @@ func TestUpdateDNSRecordWithoutName(t *testing.T) {
 
 	mux.HandleFunc("/zones/"+testZoneID+"/dns_records/"+dnsRecordID, handler)
 
-	err := client.UpdateDNSRecord(context.Background(), testZoneID, dnsRecordID, input)
+	err := client.UpdateDNSRecord(context.Background(), testZoneID, dnsRecordID, unicodeInput)
 	require.NoError(t, err)
 }
 
@@ -459,15 +474,16 @@ func TestUpdateDNSRecordWithoutType(t *testing.T) {
 	defer teardown()
 
 	proxied := false
-	input := DNSRecord{
-		Name:    "example.com",
+
+	unicodeInput := DNSRecord{
+		Name:    "😺.example.com",
 		Content: "198.51.100.4",
 		TTL:     120,
 		Proxied: &proxied,
 	}
 
-	completedInput := DNSRecord{
-		Name:    "example.com",
+	completedASCIIInput := DNSRecord{
+		Name:    "xn--138h.example.com",
 		Type:    "A",
 		Content: "198.51.100.4",
 		TTL:     120,
@@ -480,7 +496,7 @@ func TestUpdateDNSRecordWithoutType(t *testing.T) {
 		var v DNSRecord
 		err := json.NewDecoder(r.Body).Decode(&v)
 		require.NoError(t, err)
-		assert.Equal(t, completedInput, v)
+		assert.Equal(t, completedASCIIInput, v)
 
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprint(w, `{
@@ -557,7 +573,7 @@ func TestUpdateDNSRecordWithoutType(t *testing.T) {
 
 	mux.HandleFunc("/zones/"+testZoneID+"/dns_records/"+dnsRecordID, handler)
 
-	err := client.UpdateDNSRecord(context.Background(), testZoneID, dnsRecordID, input)
+	err := client.UpdateDNSRecord(context.Background(), testZoneID, dnsRecordID, unicodeInput)
 	require.NoError(t, err)
 }
 

--- a/dns_test.go
+++ b/dns_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_normalizeDomainName(t *testing.T) {
+func Test_toUTS46ASCII(t *testing.T) {
 	tests := map[string]struct {
 		domain   string
 		expected string
@@ -56,7 +56,7 @@ func Test_normalizeDomainName(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := normalizeDomainName(tt.domain)
+			actual := toUTS46ASCII(tt.domain)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}

--- a/zone.go
+++ b/zone.go
@@ -855,6 +855,9 @@ func (api *API) UpdateFallbackOrigin(ctx context.Context, zoneID string, fbo Fal
 // names. However, there should be no harm calling this function other than
 // potential performance penality.
 //
+// Confusinigly, this is in the opposite direction of normalizeDomainName
+// to work around the current quirks of the Cloudflare servers.
+//
 // Note: conversion errors are silently discarded.
 func normalizeZoneName(name string) string {
 	if n, err := idna.ToUnicode(name); err == nil {

--- a/zone.go
+++ b/zone.go
@@ -849,6 +849,12 @@ func (api *API) UpdateFallbackOrigin(ctx context.Context, zoneID string, fbo Fal
 // as Punycode, or converting fails (for invalid representations), it
 // is returned unchanged.
 //
+// Because all the zone name comparison is currently done on the server side
+// (except for comparison with the empty string), theoretically, we could
+// remove this function and let the server decide equivalence between zone
+// names. However, there should be no harm calling this function other than
+// potential performance penality.
+//
 // Note: conversion errors are silently discarded.
 func normalizeZoneName(name string) string {
 	if n, err := idna.ToUnicode(name); err == nil {

--- a/zone.go
+++ b/zone.go
@@ -849,14 +849,10 @@ func (api *API) UpdateFallbackOrigin(ctx context.Context, zoneID string, fbo Fal
 // as Punycode, or converting fails (for invalid representations), it
 // is returned unchanged.
 //
-// Because all the zone name comparison is currently done on the server side
+// Because all the zone name comparison is currently done using the API service
 // (except for comparison with the empty string), theoretically, we could
-// remove this function and let the server decide equivalence between zone
-// names. However, there should be no harm calling this function other than
-// potential performance penality.
-//
-// Confusinigly, this is in the opposite direction of normalizeDomainName
-// to work around the current quirks of the Cloudflare servers.
+// remove this function from the Go library. However, there should be no harm
+// calling this function other than gelable performance penalty.
 //
 // Note: conversion errors are silently discarded.
 func normalizeZoneName(name string) string {


### PR DESCRIPTION
This is a **proof of concept** of the proposed workaround in #688. We may or may not want this, depending on the discussion in #688. (I did not use the "Close" keyword because, in my opinion, a proper solution is to fix the API server instead of working around it.)

## Description

See #688 and cloudflare/cloudflare-docs#1991. The current API server has trouble handling Unicode forms of IDNs.

## Has your change been tested?

`CreateDNSRecord`, `DNSRecords`, and `UpdateDNSRecord` now call `normalizeDomainName` before accessing the API.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.