### PR TITLE
AUTH-3696 Purpose justification config for Access policies

### DIFF
--- a/access_policy.go
+++ b/access_policy.go
@@ -22,6 +22,9 @@ type AccessPolicy struct {
 	UpdatedAt  *time.Time `json:"updated_at"`
 	Name       string     `json:"name"`
 
+	PurposeJustificationRequired *bool   `json:"purpose_justification_required,omitempty"`
+	PurposeJustificationPrompt   *string `json:"purpose_justification_prompt,omitempty"`
+
 	// The include policy works like an OR logical operator. The user must
 	// satisfy one of the rules.
 	Include []interface{} `json:"include"`

--- a/access_policy_test.go
+++ b/access_policy_test.go
@@ -19,6 +19,9 @@ var (
 	updatedAt, _ = time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	expiresAt, _ = time.Parse(time.RFC3339, "2015-01-01T05:20:00.12345Z")
 
+	purposeJustificationRequired = true
+	purposeJustificationPrompt   = "Please provide a business reason for your need to access before continuing."
+
 	expectedAccessPolicy = AccessPolicy{
 		ID:         "699d98642c564d2e855e9661899b7252",
 		Precedence: 1,
@@ -35,6 +38,8 @@ var (
 		Require: []interface{}{
 			map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
 		},
+		PurposeJustificationRequired: &purposeJustificationRequired,
+		PurposeJustificationPrompt:   &purposeJustificationPrompt,
 	}
 )
 
@@ -77,7 +82,9 @@ func TestAccessPolicies(t *testing.T) {
 								"email": "test@example.com"
 							}
 						}
-					]
+					],
+					"purpose_justification_required": true,
+					"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing."
 				}
 			],
 			"result_info": {
@@ -145,7 +152,9 @@ func TestAccessPolicy(t *testing.T) {
 							"email": "test@example.com"
 						}
 					}
-				]
+				],
+				"purpose_justification_required": true,
+				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing."
 			}
 		}
 		`)
@@ -206,7 +215,9 @@ func TestCreateAccessPolicy(t *testing.T) {
 							"email": "test@example.com"
 						}
 					}
-				]
+				],
+				"purpose_justification_required": true,
+				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing."
 			}
 		}
 		`)
@@ -229,7 +240,9 @@ func TestCreateAccessPolicy(t *testing.T) {
 				Email string `json:"email"`
 			}{Email: "test@example.com"}},
 		},
-		Decision: "allow",
+		Decision:                     "allow",
+		PurposeJustificationRequired: &purposeJustificationRequired,
+		PurposeJustificationPrompt:   &purposeJustificationPrompt,
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/apps/"+accessApplicationID+"/policies", handler)
@@ -287,7 +300,9 @@ func TestUpdateAccessPolicy(t *testing.T) {
 							"email": "test@example.com"
 						}
 					}
-				]
+				],
+				"purpose_justification_required": true,
+				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing."
 			}
 		}
 		`)


### PR DESCRIPTION
## Description

Adds two new optional config options to Access policies, called `purpose_justification_required` and `purpose_justification_prompt`, in order to support the new [purpose justification](https://developers.cloudflare.com/cloudflare-one/policies/zero-trust/require-purpose-justification) feature.

## Has your change been tested?

Tested by updating the automated tests.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Let me know if you think this warrants a few godoc comments for the new struct fields.