### PR TITLE
ruleset: make RulesetRuleActionParametersURI pointers

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -171,14 +171,15 @@ type RulesetRuleActionParameters struct {
 
 // RulesetRuleActionParametersURI holds the URI struct for an action parameter.
 type RulesetRuleActionParametersURI struct {
-	Path   RulesetRuleActionParametersURIPath  `json:"path,omitempty"`
-	Query  RulesetRuleActionParametersURIQuery `json:"query,omitempty"`
-	Origin bool                                `json:"origin,omitempty"`
+	Path   *RulesetRuleActionParametersURIPath  `json:"path,omitempty"`
+	Query  *RulesetRuleActionParametersURIQuery `json:"query,omitempty"`
+	Origin bool                                 `json:"origin,omitempty"`
 }
 
 // RulesetRuleActionParametersURIPath holds the path specific portion of a URI
 // action parameter.
 type RulesetRuleActionParametersURIPath struct {
+	Value      string `json:"value,omitempty"`
 	Expression string `json:"expression,omitempty"`
 }
 

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -165,7 +165,7 @@ func TestGetRuleset_WAF(t *testing.T) {
 		Action:  string(RulesetRuleActionRewrite),
 		ActionParameters: &RulesetRuleActionParameters{
 			URI: &RulesetRuleActionParametersURI{
-				Path: RulesetRuleActionParametersURIPath{
+				Path: &RulesetRuleActionParametersURIPath{
 					Expression: "normalize_url_path(raw.http.request.uri.path)",
 				},
 				Origin: false,


### PR DESCRIPTION
Allows us to conditionally leave off fields that aren't set.