### PR TITLE
GATE-2043: Adds function to fetch teams rules values as string slice

### DIFF
--- a/teams_rules.go
+++ b/teams_rules.go
@@ -66,6 +66,23 @@ const (
 	L4Override   TeamsGatewayAction = "l4_override"
 )
 
+func TeamsRulesActionValues() []string {
+	return []string{
+		string(Allow),
+		string(Block),
+		string(SafeSearch),
+		string(YTRestricted),
+		string(On),
+		string(Off),
+		string(Scan),
+		string(NoScan),
+		string(Isolate),
+		string(NoIsolate),
+		string(Override),
+		string(L4Override),
+	}
+}
+
 // TeamsRule represents an Teams wirefilter rule.
 type TeamsRule struct {
 	ID           string             `json:"id,omitempty"`


### PR DESCRIPTION
## Description
Adds function to fetch teams rules values as string slice to be used by terraform for field validation.

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
