### PR TITLE
remove feature for deleting Notification PagerDuty destinations

### DIFF
--- a/notifications.go
+++ b/notifications.go
@@ -346,25 +346,6 @@ func (api *API) ListPagerDutyNotificationDestinations(ctx context.Context, accou
 	return r, nil
 }
 
-// DeletePagerDutyNotificationDestinations will delete the pagerduty
-// destination connected for an account.
-//
-// API Reference: https://api.cloudflare.com/#notification-destinations-with-pagerduty-delete-pagerduty-destinations
-func (api *API) DeletePagerDutyNotificationDestinations(ctx context.Context, accountID string) (Response, error) {
-	baseURL := fmt.Sprintf("/accounts/%s/alerting/v3/destinations/pagerduty", accountID)
-
-	res, err := api.makeRequestContext(ctx, http.MethodDelete, baseURL, nil)
-	if err != nil {
-		return Response{}, err
-	}
-	var r Response
-	err = json.Unmarshal(res, &r)
-	if err != nil {
-		return r, err
-	}
-	return r, nil
-}
-
 // GetEligibleNotificationDestinations will return the types of
 // destinations an account is eligible to configure.
 //

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -113,29 +113,7 @@ func TestListPagerDutyDestinations(t *testing.T) {
 	require.NotNil(t, actual)
 	assert.Equal(t, expected, actual.Result)
 }
-func TestDeletePagerDutyDestinations(t *testing.T) {
-	setup()
-	defer teardown()
 
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
-		w.Header().Set("content-type", "application/json")
-		_, err := fmt.Fprintf(w, `{
-  									"success": true,
-  									"errors": [],
-  									"messages": []
-								}`,
-		)
-		require.NoError(t, err)
-	}
-
-	mux.HandleFunc("/accounts/"+testAccountID+"/alerting/v3/destinations/pagerduty", handler)
-
-	actual, err := client.DeletePagerDutyNotificationDestinations(context.Background(), testAccountID)
-	require.Nil(t, err)
-	require.NotNil(t, actual)
-	assert.True(t, actual.Success)
-}
 func TestCreateNotificationPolicy(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description

Remove support for deleting PagerDuty destinations for Notifications.
## Has your change been tested?
Removed the tests corresponding to this endpoint.
## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [✅ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [✅ ] My code follows the code style of this project.
- [❌] My change requires a change to the documentation.
- [NA] I have updated the documentation accordingly.
- [NA] I have added tests to cover my changes.
- [✅] All new and existing tests passed.
- [✅] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
