### PR TITLE
Boolean can't have omitempty or it can never be false

### DIFF
--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -29,12 +29,12 @@ type DevicePostureRuleMatch struct {
 type DevicePostureRuleInput struct {
 	ID         string `json:"id,omitempty"`
 	Path       string `json:"path,omitempty"`
-	Exists     bool   `json:"exists,omitempty"`
+	Exists     bool   `json:"exists"`
 	Thumbprint string `json:"thumbprint,omitempty"`
 	Sha256     string `json:"sha256,omitempty"`
-	Running    bool   `json:"running,omitempty"`
-	RequireAll bool   `json:"requireAll,omitempty"`
-	Enabled    bool   `json:"enabled,omitempty"`
+	Running    bool   `json:"running"`
+	RequireAll bool   `json:"requireAll"`
+	Enabled    bool   `json:"enabled"`
 	Version    string `json:"version,omitempty"`
 	Operator   string `json:"operator,omitempty"`
 	Domain     string `json:"domain,omitempty"`


### PR DESCRIPTION
Need to strip `omitempty` from these `bool` fields or they will never be returned as `false`.

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
