### PR TITLE
Add support for SaaS Access Application configuration

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -18,10 +18,20 @@ type AccessApplicationType string
 // These constants represent all valid application types.
 const (
 	SelfHosted AccessApplicationType = "self_hosted"
+	Saas       AccessApplicationType = "saas"
 	SSH        AccessApplicationType = "ssh"
 	VNC        AccessApplicationType = "vnc"
 	File       AccessApplicationType = "file"
 	Bookmark   AccessApplicationType = "bookmark"
+)
+
+// AccessApplicationType represents the application type.
+type AccessApplicationNameIdFormat string
+
+// These constants represent all valid Name ID formats
+const (
+	Email AccessApplicationNameIdFormat = "email"
+	Id    AccessApplicationNameIdFormat = "id"
 )
 
 // AccessApplication represents an Access application.
@@ -40,6 +50,7 @@ type AccessApplication struct {
 	ID                      string                         `json:"id,omitempty"`
 	PrivateAddress          string                         `json:"private_address"`
 	CorsHeaders             *AccessApplicationCorsHeaders  `json:"cors_headers,omitempty"`
+	SaasApp                 *AccessApplicationSaasApp      `json:"saas_app,omitempty"`
 	CreatedAt               *time.Time                     `json:"created_at,omitempty"`
 	UpdatedAt               *time.Time                     `json:"updated_at,omitempty"`
 	AutoRedirectToIdentity  bool                           `json:"auto_redirect_to_identity,omitempty"`
@@ -64,6 +75,14 @@ type AccessApplicationCorsHeaders struct {
 	AllowAllOrigins  bool     `json:"allow_all_origins,omitempty"`
 	AllowCredentials bool     `json:"allow_credentials,omitempty"`
 	MaxAge           int      `json:"max_age,omitempty"`
+}
+
+// AccessApplicationSaasApp represents the SAML configuration for an Access
+// Application.
+type AccessApplicationSaasApp struct {
+	SpEntityId         string                        `json:"sp_entity_id,omitempty"`
+	ConsumerServiceUrl string                        `json:"consumer_service_url,omitempty"`
+	NameIdFormat       AccessApplicationNameIdFormat `json:"name_id_format,omitempty"`
 }
 
 // AccessApplicationListResponse represents the response from the list


### PR DESCRIPTION
## Description

Add support for SaaS Access Application configuration.

Not sure if this is supported by the API as this is not publicly documented but I tested manual calls with curl and this is working. So I'm not sure if it's an outdated documentation or an unsupported API call.

This would be handy to add support for SaaS App configuration in the terraform provider: https://github.com/cloudflare/terraform-provider-cloudflare/issues/1226

## Has your change been tested?

- Added a unit test.
- Tested the raw JSON query manually.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/

