### PR TITLE
AUTH-3722: Adds http_only and same_site cookie options for access apps

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -25,20 +25,22 @@ const (
 
 // AccessApplication represents an Access application.
 type AccessApplication struct {
-	ID                     string                        `json:"id,omitempty"`
-	CreatedAt              *time.Time                    `json:"created_at,omitempty"`
-	UpdatedAt              *time.Time                    `json:"updated_at,omitempty"`
-	AUD                    string                        `json:"aud,omitempty"`
-	Name                   string                        `json:"name"`
-	Domain                 string                        `json:"domain"`
-	Type                   AccessApplicationType         `json:"type,omitempty"`
-	SessionDuration        string                        `json:"session_duration,omitempty"`
-	AutoRedirectToIdentity bool                          `json:"auto_redirect_to_identity,omitempty"`
-	EnableBindingCookie    bool                          `json:"enable_binding_cookie,omitempty"`
-	AllowedIdps            []string                      `json:"allowed_idps,omitempty"`
-	CorsHeaders            *AccessApplicationCorsHeaders `json:"cors_headers,omitempty"`
-	CustomDenyMessage      string                        `json:"custom_deny_message,omitempty"`
-	CustomDenyURL          string                        `json:"custom_deny_url,omitempty"`
+	ID                      string                        `json:"id,omitempty"`
+	CreatedAt               *time.Time                    `json:"created_at,omitempty"`
+	UpdatedAt               *time.Time                    `json:"updated_at,omitempty"`
+	AUD                     string                        `json:"aud,omitempty"`
+	Name                    string                        `json:"name"`
+	Domain                  string                        `json:"domain"`
+	Type                    AccessApplicationType         `json:"type,omitempty"`
+	SessionDuration         string                        `json:"session_duration,omitempty"`
+	AutoRedirectToIdentity  bool                          `json:"auto_redirect_to_identity,omitempty"`
+	EnableBindingCookie     bool                          `json:"enable_binding_cookie,omitempty"`
+	AllowedIdps             []string                      `json:"allowed_idps,omitempty"`
+	CorsHeaders             *AccessApplicationCorsHeaders `json:"cors_headers,omitempty"`
+	CustomDenyMessage       string                        `json:"custom_deny_message,omitempty"`
+	CustomDenyURL           string                        `json:"custom_deny_url,omitempty"`
+	HttpOnlyCookieAttribute bool                          `json:"http_only_cookie_attribute,omitempty"`
+	SameSiteCookieAttribute string                        `json:"same_site_cookie_attribute,omitempty"`
 }
 
 // AccessApplicationCorsHeaders represents the CORS HTTP headers for an Access

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -35,7 +35,9 @@ func TestAccessApplications(t *testing.T) {
 					"auto_redirect_to_identity": false,
 					"enable_binding_cookie": false,
 					"custom_deny_url": "https://www.cloudflare.com",
-					"custom_deny_message": "denied!"
+					"custom_deny_message": "denied!",
+					"http_only_cookie_attribute": true,
+					"same_site_cookie_attribute": "strict"
 				}
 			],
 			"result_info": {
@@ -52,19 +54,21 @@ func TestAccessApplications(t *testing.T) {
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
 	want := []AccessApplication{{
-		ID:                     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		CreatedAt:              &createdAt,
-		UpdatedAt:              &updatedAt,
-		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-		Name:                   "Admin Site",
-		Domain:                 "test.example.com/admin",
-		Type:                   "self_hosted",
-		SessionDuration:        "24h",
-		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
-		AutoRedirectToIdentity: false,
-		EnableBindingCookie:    false,
-		CustomDenyMessage:      "denied!",
-		CustomDenyURL:          "https://www.cloudflare.com",
+		ID:                      "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		CreatedAt:               &createdAt,
+		UpdatedAt:               &updatedAt,
+		AUD:                     "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		Name:                    "Admin Site",
+		Domain:                  "test.example.com/admin",
+		Type:                    "self_hosted",
+		SessionDuration:         "24h",
+		AllowedIdps:             []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity:  false,
+		EnableBindingCookie:     false,
+		CustomDenyMessage:       "denied!",
+		CustomDenyURL:           "https://www.cloudflare.com",
+		SameSiteCookieAttribute: "strict",
+		HttpOnlyCookieAttribute: true,
 	}}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/apps", handler)


### PR DESCRIPTION
Adds support for http_only_cookie_attribute and same_site_cookie_attribute parameters of access apps.

## Has your change been tested?
Yes, against staging

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
