### PR TITLE
Updated to support latest Cloudflare Registrar responses

### DIFF
--- a/registrar_test.go
+++ b/registrar_test.go
@@ -37,7 +37,14 @@ var (
 		Fax:          "123-867-5309",
 	}
 	expectedRegistrarDomain = RegistrarDomain{
+		RegistrarDomainConfiguration: RegistrarDomainConfiguration{
+			Locked:      false,
+			NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
+			Privacy:     true,
+			AutoRenew:   true,
+		},
 		ID:                "ea95132c15732412d22c1476fa83f27a",
+		Name:              "cloudflare.com",
 		Available:         false,
 		SupportedTLD:      true,
 		CanRegister:       false,
@@ -45,10 +52,10 @@ var (
 		CurrentRegistrar:  "Cloudflare",
 		ExpiresAt:         expiresAtTimestamp,
 		RegistryStatuses:  "ok,serverTransferProhibited",
-		Locked:            false,
 		CreatedAt:         createdAndModifiedTimestamp,
 		UpdatedAt:         createdAndModifiedTimestamp,
 		RegistrantContact: expectedRegistrarContact,
+		Permissions:       []string{"show_private_data"},
 	}
 )
 
@@ -65,8 +72,11 @@ func TestRegistrarDomain(t *testing.T) {
 			"messages": [],
 			"result": {
 				"id": "ea95132c15732412d22c1476fa83f27a",
+				"administrator_contact_id": 12345,
+				"auto_renew": true,
 				"available": false,
 				"supported_tld": true,
+				"billing_contact_id": 12345,
 				"can_register": false,
 				"transfer_in": {
 					"unlock_domain": "ok",
@@ -76,6 +86,16 @@ func TestRegistrarDomain(t *testing.T) {
 					"accept_foa": "needed",
 					"can_cancel_transfer": true
 				},
+				"cloudflare_dns": false,
+				"cloudflare_registration": true,
+				"contacts": {
+					"administrator_id": 12345,
+					"billing_id": 12345,
+					"registrant_id": 12345,
+					"technical_id": 12345
+				},
+				"contacts_updated_at": "2018-08-28T17:26:26Z",
+				"created_registrar": "Cloudflare",
 				"current_registrar": "Cloudflare",
 				"expires_at": "2019-08-28T23:59:59Z",
 				"registry_statuses": "ok,serverTransferProhibited",
@@ -96,6 +116,103 @@ func TestRegistrarDomain(t *testing.T) {
 					"phone": "+1 123-123-1234",
 					"email": "user@example.com",
 					"fax": "123-867-5309"
+				},
+				"dns": [],
+				"ds_records": [],
+				"email_verified": true,
+				"fees": {
+					"icann_fee": 0,
+					"redemption_fee": 0,
+					"registration_fee": 0,
+					"renewal_fee": 0,
+					"transfer_fee": 0
+				},
+				"last_known_status": "registrationActive",
+				"last_transferred_at": "2020-07-26T04:18:28Z",
+				"name": "cloudflare.com",
+				"name_servers": [
+					"ns1.cloudflare.com",
+					"ns2.cloudflare.com"
+				],
+				"payment_expires_at": "2022-09-10T05:16:19Z",
+				"pending_transfer": false,
+				"permissions": [
+					"show_private_data"
+				],
+				"previous_registrar": "",
+				"privacy": true,
+				"registered_at": null,
+				"registrant_contact_id": 12345,
+				"registry_object_id": "SOME_ID_FROM_REGISTRY",
+				"technical_contact_id": 12345,
+				"transfer_conditions": {
+					"exists": true,
+					"not_premium": true,
+					"not_secure": true,
+					"not_started": true,
+					"not_waiting": true,
+					"supported_tld": true
+				},
+				"updated_registrar": "Cloudflare",
+				"using_created_registrar_nameservers": false,
+				"using_current_registrar_nameservers": false,
+				"using_previous_registrar_nameservers": false,
+				"using_updated_registrar_nameservers": false,
+				"whois": {
+					"administrator": {
+						"address": "DATA REDACTED",
+						"city": "DATA REDACTED",
+						"country": "US",
+						"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+						"fax": "DATA REDACTED",
+						"first_name": "DATA REDACTED",
+						"last_name": "DATA REDACTED",
+						"organization": "DATA REDACTED",
+						"phone": "DATA REDACTED",
+						"state": "TX",
+						"zip": "DATA REDACTED"
+					},
+					"billing": {
+						"address": "DATA REDACTED",
+						"city": "DATA REDACTED",
+						"country": "US",
+						"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+						"fax": "DATA REDACTED",
+						"first_name": "DATA REDACTED",
+						"last_name": "DATA REDACTED",
+						"organization": "DATA REDACTED",
+						"phone": "DATA REDACTED",
+						"state": "TX",
+						"zip": "DATA REDACTED"
+					},
+					"privacy": true,
+					"raw": "A really long string with all the WHOIS data in a pretty format",
+					"registrant": {
+						"address": "DATA REDACTED",
+						"city": "DATA REDACTED",
+						"country": "US",
+						"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+						"fax": "DATA REDACTED",
+						"first_name": "DATA REDACTED",
+						"last_name": "DATA REDACTED",
+						"organization": "DATA REDACTED",
+						"phone": "DATA REDACTED",
+						"state": "TX",
+						"zip": "DATA REDACTED"
+					},
+					"technical": {
+						"address": "DATA REDACTED",
+						"city": "DATA REDACTED",
+						"country": "US",
+						"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+						"fax": "DATA REDACTED",
+						"first_name": "DATA REDACTED",
+						"last_name": "DATA REDACTED",
+						"organization": "DATA REDACTED",
+						"phone": "DATA REDACTED",
+						"state": "TX",
+						"zip": "DATA REDACTED"
+					}
 				}
 			}
 		}
@@ -125,8 +242,11 @@ func TestRegistrarDomains(t *testing.T) {
 			"result": [
 				{
 					"id": "ea95132c15732412d22c1476fa83f27a",
+					"administrator_contact_id": 12345,
+					"auto_renew": true,
 					"available": false,
 					"supported_tld": true,
+					"billing_contact_id": 12345,
 					"can_register": false,
 					"transfer_in": {
 						"unlock_domain": "ok",
@@ -136,6 +256,16 @@ func TestRegistrarDomains(t *testing.T) {
 						"accept_foa": "needed",
 						"can_cancel_transfer": true
 					},
+					"cloudflare_dns": false,
+					"cloudflare_registration": true,
+					"contacts": {
+						"administrator_id": 12345,
+						"billing_id": 12345,
+						"registrant_id": 12345,
+						"technical_id": 12345
+					},
+					"contacts_updated_at": "2018-08-28T17:26:26Z",
+					"created_registrar": "Cloudflare",
 					"current_registrar": "Cloudflare",
 					"expires_at": "2019-08-28T23:59:59Z",
 					"registry_statuses": "ok,serverTransferProhibited",
@@ -156,6 +286,103 @@ func TestRegistrarDomains(t *testing.T) {
 						"phone": "+1 123-123-1234",
 						"email": "user@example.com",
 						"fax": "123-867-5309"
+					},
+					"dns": [],
+					"ds_records": [],
+					"email_verified": true,
+					"fees": {
+						"icann_fee": 0,
+						"redemption_fee": 0,
+						"registration_fee": 0,
+						"renewal_fee": 0,
+						"transfer_fee": 0
+					},
+					"last_known_status": "registrationActive",
+					"last_transferred_at": "2020-07-26T04:18:28Z",
+					"name": "cloudflare.com",
+					"name_servers": [
+						"ns1.cloudflare.com",
+						"ns2.cloudflare.com"
+					],
+					"payment_expires_at": "2022-09-10T05:16:19Z",
+					"pending_transfer": false,
+					"permissions": [
+						"show_private_data"
+					],
+					"previous_registrar": "",
+					"privacy": true,
+					"registered_at": null,
+					"registrant_contact_id": 12345,
+					"registry_object_id": "SOME_ID_FROM_REGISTRY",
+					"technical_contact_id": 12345,
+					"transfer_conditions": {
+						"exists": true,
+						"not_premium": true,
+						"not_secure": true,
+						"not_started": true,
+						"not_waiting": true,
+						"supported_tld": true
+					},
+					"updated_registrar": "Cloudflare",
+					"using_created_registrar_nameservers": false,
+					"using_current_registrar_nameservers": false,
+					"using_previous_registrar_nameservers": false,
+					"using_updated_registrar_nameservers": false,
+					"whois": {
+						"administrator": {
+							"address": "DATA REDACTED",
+							"city": "DATA REDACTED",
+							"country": "US",
+							"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+							"fax": "DATA REDACTED",
+							"first_name": "DATA REDACTED",
+							"last_name": "DATA REDACTED",
+							"organization": "DATA REDACTED",
+							"phone": "DATA REDACTED",
+							"state": "TX",
+							"zip": "DATA REDACTED"
+						},
+						"billing": {
+							"address": "DATA REDACTED",
+							"city": "DATA REDACTED",
+							"country": "US",
+							"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+							"fax": "DATA REDACTED",
+							"first_name": "DATA REDACTED",
+							"last_name": "DATA REDACTED",
+							"organization": "DATA REDACTED",
+							"phone": "DATA REDACTED",
+							"state": "TX",
+							"zip": "DATA REDACTED"
+						},
+						"privacy": true,
+						"raw": "A really long string with all the WHOIS data in a pretty format",
+						"registrant": {
+							"address": "DATA REDACTED",
+							"city": "DATA REDACTED",
+							"country": "US",
+							"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+							"fax": "DATA REDACTED",
+							"first_name": "DATA REDACTED",
+							"last_name": "DATA REDACTED",
+							"organization": "DATA REDACTED",
+							"phone": "DATA REDACTED",
+							"state": "TX",
+							"zip": "DATA REDACTED"
+						},
+						"technical": {
+							"address": "DATA REDACTED",
+							"city": "DATA REDACTED",
+							"country": "US",
+							"email": "https://domaincontact.cloudflareregistrar.com/cloudflare.com",
+							"fax": "DATA REDACTED",
+							"first_name": "DATA REDACTED",
+							"last_name": "DATA REDACTED",
+							"organization": "DATA REDACTED",
+							"phone": "DATA REDACTED",
+							"state": "TX",
+							"zip": "DATA REDACTED"
+						}
 					}
 				}
 			],
@@ -223,7 +450,14 @@ func TestTransferRegistrarDomain(t *testing.T) {
 						"phone": "+1 123-123-1234",
 						"email": "user@example.com",
 						"fax": "123-867-5309"
-					}
+					},
+					"name": "cloudflare.com",
+					"name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+					"privacy": true,
+					"auto_renew": true,
+					"permissions": [
+						"show_private_data"
+					]
 				}
 			],
 			"result_info": {
@@ -290,7 +524,14 @@ func TestCancelRegistrarDomainTransfer(t *testing.T) {
 						"phone": "+1 123-123-1234",
 						"email": "user@example.com",
 						"fax": "123-867-5309"
-					}
+					},
+					"name": "cloudflare.com",
+					"name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+					"privacy": true,
+					"auto_renew": true,
+					"permissions": [
+						"show_private_data"
+					]
 				}
 			],
 			"result_info": {
@@ -356,7 +597,14 @@ func TestUpdateRegistrarDomain(t *testing.T) {
 					"phone": "+1 123-123-1234",
 					"email": "user@example.com",
 					"fax": "123-867-5309"
-				}
+				},
+				"name": "cloudflare.com",
+				"name_servers": ["ns1.cloudflare.com", "ns2.cloudflare.com"],
+				"privacy": true,
+				"auto_renew": true,
+				"permissions": [
+					"show_private_data"
+				]
 			}
 		}
 		`)
@@ -366,10 +614,88 @@ func TestUpdateRegistrarDomain(t *testing.T) {
 
 	actual, err := client.UpdateRegistrarDomain(context.Background(), "01a7362d577a6c3019a474fd6f485823", "cloudflare.com", RegistrarDomainConfiguration{
 		NameServers: []string{"ns1.cloudflare.com", "ns2.cloudflare.com"},
-		Locked:      false,
+		Locked:      true,
 	})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, expectedRegistrarDomain, actual)
+	}
+}
+
+func TestGetRegistrarContact(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "ea95132c15732412d22c1476fa83f27a",
+				"first_name": "John",
+				"last_name": "Appleseed",
+				"organization": "Cloudflare, Inc.",
+				"address": "123 Sesame St.",
+				"address2": "Suite 430",
+				"city": "Austin",
+				"state": "TX",
+				"zip": "12345",
+				"country": "US",
+				"phone": "+1 123-123-1234",
+				"email": "user@example.com",
+				"fax": "123-867-5309"
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/registrar/contacts/01a7362d577a6c3019a474fd6f485823", handler)
+
+	actual, err := client.RegistrarContact(context.Background(), "01a7362d577a6c3019a474fd6f485823", "01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedRegistrarContact, actual)
+	}
+}
+
+func TestGetRegistrarContacts(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [{
+				"id": "ea95132c15732412d22c1476fa83f27a",
+				"first_name": "John",
+				"last_name": "Appleseed",
+				"organization": "Cloudflare, Inc.",
+				"address": "123 Sesame St.",
+				"address2": "Suite 430",
+				"city": "Austin",
+				"state": "TX",
+				"zip": "12345",
+				"country": "US",
+				"phone": "+1 123-123-1234",
+				"email": "user@example.com",
+				"fax": "123-867-5309"
+			}]
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/01a7362d577a6c3019a474fd6f485823/registrar/contacts", handler)
+
+	actual, err := client.RegistrarContacts(context.Background(), "01a7362d577a6c3019a474fd6f485823")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, []RegistrantContact{expectedRegistrarContact}, actual)
 	}
 }


### PR DESCRIPTION
## Description

It appears that the /registrar API has been through some improvements since this module was written.  I want to support cloudflare as a registrar in [dnscontrol](https://github.com/StackExchange/dnscontrol) but the existing code doesn't return nameservers and other data.  The publicly documented API does not match response being returned from the API at this time.

e.g.

This is the `accounts/[id]/registrar/domain` output for a domain I currently control (I've censored the domain, but everything else is real)

```json
{
    "errors": [],
    "messages": [],
    "result": {
        "administrator_contact_id": 526506,
        "auto_renew": true,
        "available": false,
        "billing_contact_id": 1081360,
        "can_register": false,
        "cloudflare_dns": false,
        "cloudflare_registration": true,
        "contacts": {
            "administrator_id": 526506,
            "billing_id": 1081360,
            "registrant_id": 249079,
            "technical_id": 803933
        },
        "contacts_updated_at": "2020-07-26T04:18:28Z",
        "created_at": "2018-09-10T05:16:19Z",
        "created_registrar": "Unknown (Verisign-sbscorp)",
        "current_registrar": "Cloudflare",
        "dns": [],
        "ds_records": [],
        "email_verified": true,
        "expires_at": "2022-09-10T05:16:19Z",
        "fees": {
            "icann_fee": 0.18,
            "redemption_fee": 40.0,
            "registration_fee": 9.77,
            "renewal_fee": 9.77,
            "transfer_fee": 9.77
        },
        "last_known_status": "registrationActive",
        "last_transferred_at": "2020-07-26T04:18:28Z",
        "locked": true,
        "name": "THISISNOTTHEREAL.COM",
        "name_servers": [
            "daisy.ns.cloudflare.com",
            "vin.ns.cloudflare.com"
        ],
        "payment_expires_at": "2022-09-10T05:16:19Z",
        "pending_transfer": false,
        "permissions": [
            "show_private_data",
            "modify_contacts",
            "renew",
            "transfer_out",
            "change_nameservers",
            "delete"
        ],
        "previous_registrar": "Internet Domain Service BS",
        "privacy": true,
        "registered_at": null,
        "registrant_contact_id": 249079,
        "registry_object_id": "######_DOMAIN_NET-VRSN",
        "registry_statuses": "clienttransferprohibited",
        "supported_tld": true,
        "technical_contact_id": 803933,
        "transfer_conditions": {
            "exists": true,
            "not_premium": true,
            "not_secure": true,
            "not_started": true,
            "not_waiting": true,
            "supported_tld": true
        },
        "updated_at": "2021-08-12T05:06:21Z",
        "updated_registrar": "Cloudflare",
        "using_created_registrar_nameservers": false,
        "using_current_registrar_nameservers": false,
        "using_previous_registrar_nameservers": false,
        "using_updated_registrar_nameservers": false,
        "whois": {
            "administrator": {
                "address": "DATA REDACTED",
                "city": "DATA REDACTED",
                "country": "US",
                "email": "https://domaincontact.cloudflareregistrar.com/THISISNOTTHEREAL.COM",
                "fax": "DATA REDACTED",
                "first_name": "DATA REDACTED",
                "last_name": "DATA REDACTED",
                "organization": "DATA REDACTED",
                "phone": "DATA REDACTED",
                "state": "ID",
                "zip": "DATA REDACTED"
            },
            "billing": {
                "address": "DATA REDACTED",
                "city": "DATA REDACTED",
                "country": "US",
                "email": "https://domaincontact.cloudflareregistrar.com/THISISNOTTHEREAL.COM",
                "fax": "DATA REDACTED",
                "first_name": "DATA REDACTED",
                "last_name": "DATA REDACTED",
                "organization": "DATA REDACTED",
                "phone": "DATA REDACTED",
                "state": "ID",
                "zip": "DATA REDACTED"
            },
            "privacy": true,
            "raw": "Domain name: THISISNOTTHEREAL.COM\nRegistry Domain ID: \nRegistrar WHOIS Server: whois.cloudflare.com\nRegistrar URL: https://www.cloudflare.com/\nUpdated Date: 2021-08-12T05:06:21Z\nCreation Date: 2018-09-10T05:16:19Z\nRegistrar Registration Expiration Date: 2022-09-10T05:16:19Z\nRegistrar: Cloudflare, Inc.\nRegistrar IANA ID: 1910\nRegistrar Abuse Contact Email: support@cloudflare.com\nRegistrar Abuse Contact Phone: +1-650-319-8936\nDomain Status: clienttransferprohibited (https://www.icann.org/epp#clienttransferprohibited)\nRegistry Registrant ID: \nRegistrant Name: DATA REDACTED DATA REDACTED\nRegistrant Organization: DATA REDACTED\nRegistrant Street: DATA REDACTED \nRegistrant City: DATA REDACTED\nRegistrant State/Province: ID\nRegistrant Postal Code: DATA REDACTED\nRegistrant Country: US\nRegistrant Phone: DATA REDACTED\nRegistrant Phone Ext: \nRegistrant Fax: DATA REDACTED\nRegistrant Fax Ext: \nRegistrant Email: https://domaincontact.cloudflareregistrar.com/THISISNOTTHEREAL.COM\nRegistry Admin ID: \nAdmin Name: DATA REDACTED DATA REDACTED\nAdmin Organization: DATA REDACTED\nAdmin Street: DATA REDACTED \nAdmin City: DATA REDACTED\nAdmin State/Province: ID\nAdmin Postal Code: DATA REDACTED\nAdmin Country: US\nAdmin Phone: DATA REDACTED\nAdmin Phone Ext: \nAdmin Fax: DATA REDACTED\nAdmin Fax Ext: \nAdmin Email: https://domaincontact.cloudflareregistrar.com/THISISNOTTHEREAL.COM\nRegistry Tech ID: \nTech Name: DATA REDACTED DATA REDACTED\nTech Organization: DATA REDACTED\nTech Street: DATA REDACTED \nTech City: DATA REDACTED\nTech State/Province: ID\nTech Postal Code: DATA REDACTED\nTech Country: US\nTech Phone: DATA REDACTED\nTech Phone Ext: \nTech Fax: DATA REDACTED\nTech Fax Ext: \nTech Email: https://domaincontact.cloudflareregistrar.com/THISISNOTTHEREAL.COM\nName Server: DAISY.NS.CLOUDFLARE.COM\nName Server: VIN.NS.CLOUDFLARE.COM\nDNSSEC: unsigned\nURL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/\n>>> Last update of WHOIS database: 2020-07-26T04:18:28Z <<<\n\nThe Data in Cloudflare's WHOIS database is provided by Cloudflare for\ninformation purposes, and to assist persons in obtaining information about or\nrelated to a domain name registration record.  Cloudflare does not guarantee\nits accuracy.  By submitting a WHOIS query, you agree that you will use this Data\nonly for lawful purposes and that, under no circumstances will you use this Data to:\n (1) allow, enable, or otherwise support the transmission of mass unsolicited,\n     commercial advertising or solicitations via e-mail (spam); or\n (2) enable high volume, automated, electronic processes that apply to\n     Cloudflare (or its systems).\nCloudflare reserves the right to modify these terms at any time.\nBy submitting this query, you agree to abide by this policy.",
            "registrant": {
                "address": "DATA REDACTED",
                "city": "DATA REDACTED",
                "country": "US",
                "email": "https://domaincontact.cloudflareregistrar.com/THISISNOTTHEREAL.COM",
                "fax": "DATA REDACTED",
                "first_name": "DATA REDACTED",
                "last_name": "DATA REDACTED",
                "organization": "DATA REDACTED",
                "phone": "DATA REDACTED",
                "state": "ID",
                "zip": "DATA REDACTED"
            },
            "technical": {
                "address": "DATA REDACTED",
                "city": "DATA REDACTED",
                "country": "US",
                "email": "https://domaincontact.cloudflareregistrar.com/THISISNOTTHEREAL.COM",
                "fax": "DATA REDACTED",
                "first_name": "DATA REDACTED",
                "last_name": "DATA REDACTED",
                "organization": "DATA REDACTED",
                "phone": "DATA REDACTED",
                "state": "ID",
                "zip": "DATA REDACTED"
            }
        }
    },
    "success": true
}
```

A bunch of things from the documented API are missing (e.g. registrant_contact, id, transfer_in) and a ton of new (and useful) fields have been added.  So the existing documentation doesn't match the current implementation.

## Has your change been tested?

I added new tests and have used this with my personal account.  I was unable to test transfers as they are no longer documented on the API page and I don't have a domain to transfer in at the moment.

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.