### PR TITLE
Current version of cloudflare-go library do not respect pagination fo…

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -84,33 +84,45 @@ func (api *API) Filter(ctx context.Context, zoneID, filterID string) (Filter, er
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-filters/get/#get-all-filters
 func (api *API) Filters(ctx context.Context, zoneID string, pageOpts PaginationOptions) ([]Filter, error) {
-	uri := fmt.Sprintf("/zones/%s/filters", zoneID)
+	// Construct a query string
 	v := url.Values{}
+	// Request as many as possible per page - API max is 100
+	v.Set("per_page", "50")
 
-	if pageOpts.PerPage > 0 {
-		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
+	var filters []Filter
+	page := 1
+
+	// Loop over makeRequest until what we've fetched all records
+	for {
+		v.Set("page", strconv.Itoa(page))
+		uri := fmt.Sprintf("/zones/%s/filters?%s", zoneID, v.Encode())
+
+		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+		if err != nil {
+			return []Filter{}, err
+		}
+
+		var f FiltersDetailResponse
+		err = json.Unmarshal(res, &f)
+		if err != nil {
+			return []Filter{}, errors.Wrap(err, errUnmarshalError)
+		}
+
+		if !f.Success {
+			// TODO: Provide an actual error message instead of always returning nil
+			return []Filter{}, err
+		}
+
+		filters = append(filters, f.Result...)
+		if f.ResultInfo.Page >= f.ResultInfo.TotalPages {
+			break
+		}
+
+		// Loop around and fetch the next page
+		page++
 	}
 
-	if pageOpts.Page > 0 {
-		v.Set("page", strconv.Itoa(pageOpts.Page))
-	}
-
-	if len(v) > 0 {
-		uri = fmt.Sprintf("%s?%s", uri, v.Encode())
-	}
-
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return []Filter{}, err
-	}
-
-	var filtersResponse FiltersDetailResponse
-	err = json.Unmarshal(res, &filtersResponse)
-	if err != nil {
-		return []Filter{}, errors.Wrap(err, errUnmarshalError)
-	}
-
-	return filtersResponse.Result, nil
+	return filters, nil
 }
 
 // CreateFilters creates new filters.


### PR DESCRIPTION
## Description

Fix pagination for filter / firewall_rules API

The current version of cloudflare-go library does not respect pagination for filter / firewall_rules API, so cf-terraforming utility generates and imports records for this kind of resources incorrectly.

## Has your change been tested?

There is an internal project in my current company the main goal of which is to terraform Cloudflare accounts. I have revealed that cf-terraforming utility imports firewall_rules and filters for them incorrectly. During the research I have found out some troubles with pagination for this kind of resources in cloudflare-go library. With the help of this patch I have succesfully imported the large amount of firewalls & filters for our domains from Cloudflare API.

NEW cf-terraforming with patched cloudflare-go library:

```bash
$ grep 'resource "cloudflare_filter"' cloudflare_filter.tf_ | wc -l
94
```

OLD without patch (0.4.0):

```bash
$ grep 'resource "cloudflare_filter"' cloudflare_filter.tf | wc -l
25
```

## Screenshots (if appropriate):

N/A

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
