### PR TITLE
Support for LoadBalancerOriginSteering

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -12,19 +12,20 @@ import (
 
 // LoadBalancerPool represents a load balancer pool's properties.
 type LoadBalancerPool struct {
-	ID                string                    `json:"id,omitempty"`
-	CreatedOn         *time.Time                `json:"created_on,omitempty"`
-	ModifiedOn        *time.Time                `json:"modified_on,omitempty"`
-	Description       string                    `json:"description"`
-	Name              string                    `json:"name"`
-	Enabled           bool                      `json:"enabled"`
-	MinimumOrigins    int                       `json:"minimum_origins,omitempty"`
-	Monitor           string                    `json:"monitor,omitempty"`
-	Origins           []LoadBalancerOrigin      `json:"origins"`
-	NotificationEmail string                    `json:"notification_email,omitempty"`
-	Latitude          *float32                  `json:"latitude,omitempty"`
-	Longitude         *float32                  `json:"longitude,omitempty"`
-	LoadShedding      *LoadBalancerLoadShedding `json:"load_shedding,omitempty"`
+	ID                string                      `json:"id,omitempty"`
+	CreatedOn         *time.Time                  `json:"created_on,omitempty"`
+	ModifiedOn        *time.Time                  `json:"modified_on,omitempty"`
+	Description       string                      `json:"description"`
+	Name              string                      `json:"name"`
+	Enabled           bool                        `json:"enabled"`
+	MinimumOrigins    int                         `json:"minimum_origins,omitempty"`
+	Monitor           string                      `json:"monitor,omitempty"`
+	Origins           []LoadBalancerOrigin        `json:"origins"`
+	NotificationEmail string                      `json:"notification_email,omitempty"`
+	Latitude          *float32                    `json:"latitude,omitempty"`
+	Longitude         *float32                    `json:"longitude,omitempty"`
+	LoadShedding      *LoadBalancerLoadShedding   `json:"load_shedding,omitempty"`
+	OriginSteering    *LoadBalancerOriginSteering `json:"origin_steering,omitempty"`
 
 	// CheckRegions defines the geographic region(s) from where to run health-checks from - e.g. "WNAM", "WEU", "SAF", "SAM".
 	// Providing a null/empty value means "all regions", which may not be available to all plan types.
@@ -38,6 +39,12 @@ type LoadBalancerOrigin struct {
 	Enabled bool                `json:"enabled"`
 	Weight  float64             `json:"weight"`
 	Header  map[string][]string `json:"header"`
+}
+
+// LoadBalancerOriginSteering controls origin selection for new sessions and traffic without session affinity.
+type LoadBalancerOriginSteering struct {
+	// Policy defaults to "random" (weighted) when empty or unspecified.
+	Policy string `json:"policy,omitempty"`
 }
 
 // LoadBalancerMonitor represents a load balancer monitor's properties.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -26,32 +26,35 @@ func TestCreateLoadBalancerPool(t *testing.T) {
               "name": "primary-dc-1",
               "enabled": true,
               "monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
-			  "latitude": 55,
-			  "longitude": -12.5,
-			  "load_shedding": {
-				"default_percent": 50,
-				"default_policy": "random",
-				"session_percent": 10,
-				"session_policy": "hash"
-			  },
+              "latitude": 55,
+              "longitude": -12.5,
+              "load_shedding": {
+                "default_percent": 50,
+                "default_policy": "random",
+                "session_percent": 10,
+                "session_policy": "hash"
+              },
+              "origin_steering": {
+                "policy": "random"
+              },
               "origins": [
                 {
                   "name": "app-server-1",
                   "address": "0.0.0.0",
                   "enabled": true,
                   "weight": 1,
-				  "header": {
-					  "Host": [
-						  "example.com"
-					  ]
-				  }
-				}
+                  "header": {
+                      "Host": [
+                          "example.com"
+                      ]
+                  }
+                }
               ],
               "notification_email": "someone@example.com",
               "check_regions": [
                 "WEU"
               ]
-						}`, string(b))
+            }`, string(b))
 		}
 		fmt.Fprint(w, `{
             "success": true,
@@ -66,26 +69,29 @@ func TestCreateLoadBalancerPool(t *testing.T) {
               "enabled": true,
               "minimum_origins": 1,
               "monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
-			  "latitude": 55,
-			  "longitude": -12.5,
-			  "load_shedding": {
-				"default_percent": 50,
-				"default_policy": "random",
-				"session_percent": 10,
-				"session_policy": "hash"
-			  },
+              "latitude": 55,
+              "longitude": -12.5,
+              "load_shedding": {
+                "default_percent": 50,
+                "default_policy": "random",
+                "session_percent": 10,
+                "session_policy": "hash"
+              },
+              "origin_steering": {
+                "policy": "random"
+              },
               "origins": [
                 {
                   "name": "app-server-1",
                   "address": "0.0.0.0",
                   "enabled": true,
                   "weight": 1,
-				  "header": {
-					  "Host": [
-						  "example.com"
-					  ]
-				  }
-				}
+                  "header": {
+                      "Host": [
+                          "example.com"
+                      ]
+                  }
+                }
               ],
               "notification_email": "someone@example.com",
               "check_regions": [
@@ -119,6 +125,9 @@ func TestCreateLoadBalancerPool(t *testing.T) {
 			SessionPercent: 10,
 			SessionPolicy:  "hash",
 		},
+		OriginSteering: &LoadBalancerOriginSteering{
+			Policy: "random",
+		},
 		Origins: []LoadBalancerOrigin{
 			{
 				Name:    "app-server-1",
@@ -147,6 +156,9 @@ func TestCreateLoadBalancerPool(t *testing.T) {
 			DefaultPolicy:  "random",
 			SessionPercent: 10,
 			SessionPolicy:  "hash",
+		},
+		OriginSteering: &LoadBalancerOriginSteering{
+			Policy: "random",
 		},
 		Origins: []LoadBalancerOrigin{
 			{
@@ -191,6 +203,9 @@ func TestListLoadBalancerPools(t *testing.T) {
                     "name": "primary-dc-1",
                     "enabled": true,
                     "monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+                    "origin_steering": {
+                      "policy": "random"
+                    },
                     "origins": [
                       {
                         "name": "app-server-1",
@@ -223,6 +238,9 @@ func TestListLoadBalancerPools(t *testing.T) {
 			Name:        "primary-dc-1",
 			Enabled:     true,
 			Monitor:     "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			OriginSteering: &LoadBalancerOriginSteering{
+				Policy: "random",
+			},
 			Origins: []LoadBalancerOrigin{
 				{
 					Name:    "app-server-1",
@@ -260,6 +278,9 @@ func TestLoadBalancerPoolDetails(t *testing.T) {
               "name": "primary-dc-1",
               "enabled": true,
               "monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+              "origin_steering": {
+                "policy": "random"
+              },
               "origins": [
                 {
                   "name": "app-server-1",
@@ -284,6 +305,9 @@ func TestLoadBalancerPoolDetails(t *testing.T) {
 		Name:        "primary-dc-1",
 		Enabled:     true,
 		Monitor:     "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		OriginSteering: &LoadBalancerOriginSteering{
+			Policy: "random",
+		},
 		Origins: []LoadBalancerOrigin{
 			{
 				Name:    "app-server-1",
@@ -341,17 +365,20 @@ func TestModifyLoadBalancerPool(t *testing.T) {
               "description": "Primary data center - Provider XYZZY",
               "name": "primary-dc-2",
               "enabled": false,
+              "origin_steering": {
+                "policy": "random"
+              },
               "origins": [
                 {
                   "name": "app-server-2",
                   "address": "0.0.0.1",
                   "enabled": false,
                   "weight": 1,
-				  "header": {
-					  "Host": [
-						  "example.com"
-					  ]
-				  }
+                  "header": {
+                      "Host": [
+                          "example.com"
+                      ]
+                  }
                 }
               ],
               "notification_email": "nobody@example.com",
@@ -371,17 +398,20 @@ func TestModifyLoadBalancerPool(t *testing.T) {
               "description": "Primary data center - Provider XYZZY",
               "name": "primary-dc-2",
               "enabled": false,
+              "origin_steering": {
+                "policy": "random"
+              },
               "origins": [
                 {
                   "name": "app-server-2",
                   "address": "0.0.0.1",
                   "enabled": false,
                   "weight": 1,
-				  "header": {
-					  "Host": [
-						  "example.com"
-					  ]
-				  }
+                  "header": {
+                      "Host": [
+                          "example.com"
+                      ]
+                  }
                 }
               ],
               "notification_email": "nobody@example.com",
@@ -402,6 +432,9 @@ func TestModifyLoadBalancerPool(t *testing.T) {
 		Description: "Primary data center - Provider XYZZY",
 		Name:        "primary-dc-2",
 		Enabled:     false,
+		OriginSteering: &LoadBalancerOriginSteering{
+			Policy: "random",
+		},
 		Origins: []LoadBalancerOrigin{
 			{
 				Name:    "app-server-2",
@@ -423,6 +456,9 @@ func TestModifyLoadBalancerPool(t *testing.T) {
 		Description: "Primary data center - Provider XYZZY",
 		Name:        "primary-dc-2",
 		Enabled:     false,
+		OriginSteering: &LoadBalancerOriginSteering{
+			Policy: "random",
+		},
 		Origins: []LoadBalancerOrigin{
 			{
 				Name:    "app-server-2",


### PR DESCRIPTION
Initial support for load balancer pool origin steering policies.

## Description

Origin steering controls selection of origins within a pool to serve load balancing requests that initiate a new session or for requests without session affinity enabled. The default policy remains random weighted and can be specified explicitly as "random". A new "hash" policy is also defined to distribute traffic to weighted origins based on a hash of the source IP address (e.g. CF-Connecting-IP). This supports eliminating dependencies on the "ip_cookie" session affinity (persistence) type, which is now deprecated.

https://api.cloudflare.com/#load-balancer-pools-properties

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.