### PR TITLE
AS-7353: Add cloudflare-go integration for alert history API

### DIFF
--- a/notifications.go
+++ b/notifications.go
@@ -413,7 +413,7 @@ func (api *API) GetAvailableNotificationTypes(ctx context.Context, accountID str
 // Ent = 90 days
 //
 // API Reference: https://api.cloudflare.com/#notification-history-list-history
-func (api *API) ListNotificationHistory(ctx context.Context, pageOpts PaginationOptions, accountID string) ([]NotificationHistory, ResultInfo, error) {
+func (api *API) ListNotificationHistory(ctx context.Context, accountID string, pageOpts PaginationOptions) ([]NotificationHistory, ResultInfo, error) {
 	v := url.Values{}
 	if pageOpts.PerPage > 0 {
 		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -560,7 +560,7 @@ func TestListNotificationHistory(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/alerting/v3/history", handler)
 
-	actualResult, actualResultInfo, err := client.ListNotificationHistory(context.Background(), pageOptions, testAccountID)
+	actualResult, actualResultInfo, err := client.ListNotificationHistory(context.Background(), testAccountID, pageOptions)
 	require.Nil(t, err)
 	require.NotNil(t, actualResult)
 	require.Equal(t, expected, actualResult)


### PR DESCRIPTION
Adding cloudflare-go integration for alert history API to notifications.go