### PR TITLE
feat: add HTTP3 parameter to `CustomHostnameSSLSettings`

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -29,6 +29,7 @@ const (
 // CustomHostnameSSLSettings represents the SSL settings for a custom hostname.
 type CustomHostnameSSLSettings struct {
 	HTTP2         string   `json:"http2,omitempty"`
+	HTTP3         string   `json:"http3,omitempty"`
 	TLS13         string   `json:"tls_1_3,omitempty"`
 	MinTLSVersion string   `json:"min_tls_version,omitempty"`
 	Ciphers       []string `json:"ciphers,omitempty"`


### PR DESCRIPTION
## Description

According to https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname we can provide a `ssl.settings.http3` parameter. This was missing currently in this client.

## Has your change been tested?

I looked into the tests, and they don't seem to cover all combinations of parameters. This is only a small change that matches what the docs say.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
