### PR TITLE
fix reference to account-id command line flag

### DIFF
--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -44,8 +44,8 @@ func initializeAPI(c *cli.Context) error {
 		return err
 	}
 
-	if c.IsSet("accountid") {
-		cloudflare.UsingAccount(c.String("accountid"))(api) //nolint
+	if c.IsSet("account-id") {
+		cloudflare.UsingAccount(c.String("account-id"))(api) //nolint
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fix an issue where the flarectl CLI doesn't take into account the --account-id flag.
closes #736

## Has your change been tested?

Yes, the test was conducted by using the updated code to create and delete some cloudflare zones across multiple accounts. I also executed the tests available in the repository, and they passed (but I didn't touch the coudflare-go api code anyway.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

My thought here is that there may be people using the CLI today who will be *expecting* the CLI to honour the parameter, and may be manipulating resources in different accounts as a result.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
