### PR TITLE
Add app_launcher_visible to Access Application

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -43,6 +43,7 @@ type AccessApplication struct {
 	SameSiteCookieAttribute string                        `json:"same_site_cookie_attribute,omitempty"`
 	LogoURL                 string                        `json:"logo_url,omitempty"`
 	SkipInterstitial        bool                          `json:"skip_interstitial,omitempty"`
+	AppLauncherVisible    bool                            `json:"app_launcher_visible,omitempty"`
 }
 
 // AccessApplicationCorsHeaders represents the CORS HTTP headers for an Access

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -39,7 +39,8 @@ func TestAccessApplications(t *testing.T) {
 					"http_only_cookie_attribute": true,
 					"same_site_cookie_attribute": "strict",
 					"logo_url": "https://www.cloudflare.com/example.png",
-					"skip_interstitial": true
+					"skip_interstitial": true,
+					"app_launcher_visible": true
 				}
 			],
 			"result_info": {
@@ -67,6 +68,7 @@ func TestAccessApplications(t *testing.T) {
 		AllowedIdps:             []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity:  false,
 		EnableBindingCookie:     false,
+		AppLauncherVisible:     true,
 		CustomDenyMessage:       "denied!",
 		CustomDenyURL:           "https://www.cloudflare.com",
 		SameSiteCookieAttribute: "strict",
@@ -118,7 +120,8 @@ func TestAccessApplication(t *testing.T) {
 				"custom_deny_url": "https://www.cloudflare.com",
 				"custom_deny_message": "denied!",
 				"logo_url": "https://www.cloudflare.com/example.png",
-				"skip_interstitial": true
+				"skip_interstitial": true,
+				"app_launcher_visible": true
 			}
 		}
 		`)
@@ -139,6 +142,7 @@ func TestAccessApplication(t *testing.T) {
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
 		EnableBindingCookie:    false,
+		AppLauncherVisible:     true,
 		CustomDenyMessage:      "denied!",
 		CustomDenyURL:          "https://www.cloudflare.com",
 		LogoURL:                "https://www.cloudflare.com/example.png",
@@ -188,7 +192,8 @@ func TestCreateAccessApplications(t *testing.T) {
 				"custom_deny_url": "https://www.cloudflare.com",
 				"custom_deny_message": "denied!",
 				"logo_url": "https://www.cloudflare.com/example.png",
-				"skip_interstitial": true
+				"skip_interstitial": true,
+				"app_launcher_visible": true
 			}
 		}
 		`)
@@ -206,6 +211,7 @@ func TestCreateAccessApplications(t *testing.T) {
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
 		EnableBindingCookie:    false,
+		AppLauncherVisible:     true,
 		CustomDenyMessage:      "denied!",
 		CustomDenyURL:          "https://www.cloudflare.com",
 		LogoURL:                "https://www.cloudflare.com/example.png",
@@ -265,7 +271,8 @@ func TestUpdateAccessApplication(t *testing.T) {
 				"custom_deny_url": "https://www.cloudflare.com",
 				"custom_deny_message": "denied!",
 				"logo_url": "https://www.cloudflare.com/example.png",
-				"skip_interstitial": true
+				"skip_interstitial": true,
+				"app_launcher_visible": true
 			}
 		}
 		`)
@@ -283,6 +290,7 @@ func TestUpdateAccessApplication(t *testing.T) {
 		AllowedIdps:            []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity: false,
 		EnableBindingCookie:    false,
+		AppLauncherVisible:     true,
 		CustomDenyMessage:      "denied!",
 		CustomDenyURL:          "https://www.cloudflare.com",
 		LogoURL:                "https://www.cloudflare.com/example.png",


### PR DESCRIPTION
Description
Adds the app_launcher_visible field to Access applications. This optional field will allow the ability to show/hide applications in App Launcher. 

Related PR: https://github.com/cloudflare/terraform-provider-cloudflare/pull/1303

Has your change been tested?

Here is a cURL request with the new field:
```
curl --request PUT \
  --url https://api.cloudflare.com/client/v4/accounts/<ACCOUNT_ID>/access/apps/<APP_ID> \
  --header 'authorization: Bearer <TOKEN>' \
  --header 'content-type: application/json' \
  --header 'x-auth-email: <EMAIL>' \
  --header 'x-auth-key: <KEY>' \
  --data '{
        "aud": REDACTED,
        "domain": "asdf.fans",
        "id": REDACTED,
        "name": "asdf-fans",
        "policies": [],
        "allowed_idps": [],
        "session_duration": "24h",
        "uid": REDACTED,
        "auto_redirect_to_identity": false,
        "app_launcher_visible": true
}'
{
  "result": {
    "aud": REDACTED,
    "created_at": "2020-09-03T20:27:02Z",
    "domain": "asdf.fans",
    "id": REDACTED,
    "name": "asdf-fans",
    "policies": [],
    "allowed_idps": [],
    "auto_redirect_to_identity": false,
    "session_duration": "24h",
    "uid": REDACTED,
    "updated_at": "2021-11-08T14:33:13Z",
     "app_launcher_visible": true
  },
  "success": true,
  "errors": [],
  "messages": []
}
```

Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
