### PR TITLE
GATE-2256: Add FIPS api field to Cloudflare for Teams Account Settings

### DIFF
--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -42,12 +42,17 @@ type TeamsAccountSettings struct {
 	TLSDecrypt  *TeamsTLSDecrypt  `json:"tls_decrypt,omitempty"`
 	ActivityLog *TeamsActivityLog `json:"activity_log,omitempty"`
 	BlockPage   *TeamsBlockPage   `json:"block_page,omitempty"`
+	FIPS        *TeamsFIPS        `json:"fips,omitempty"`
 }
 
 type TeamsAntivirus struct {
 	EnabledDownloadPhase bool `json:"enabled_download_phase"`
 	EnabledUploadPhase   bool `json:"enabled_upload_phase"`
 	FailClosed           bool `json:"fail_closed"`
+}
+
+type TeamsFIPS struct {
+	TLS bool `json:"tls"`
 }
 
 type TeamsTLSDecrypt struct {

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -59,6 +59,9 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 					"tls_decrypt": {
 						"enabled": true
 					},
+					"fips": {
+						"tls": true
+					},
 					"activity_log": {
 						"enabled": true
 					}
@@ -77,6 +80,7 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 			Antivirus:   &TeamsAntivirus{EnabledDownloadPhase: true},
 			ActivityLog: &TeamsActivityLog{Enabled: true},
 			TLSDecrypt:  &TeamsTLSDecrypt{Enabled: true},
+			FIPS:        &TeamsFIPS{TLS: true},
 		})
 	}
 }


### PR DESCRIPTION
## Description

Teams API has added a new field, which we'd like users to access via API client.

## Has your change been tested?

I added the field to the existing unit tests

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

The endpoint is unfortunately not documented on api.cloudflare.com yet, but it is used in our Terraform provider.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
