### PR TITLE
Add ValidationRecords and some other fields to CertificatePack

### DIFF
--- a/certificate_packs.go
+++ b/certificate_packs.go
@@ -33,13 +33,24 @@ type CertificatePackCertificate struct {
 	Priority        int                            `json:"priority"`
 }
 
+// TxtValidationRecord is the structure of the TXT validation record for certificate packss pending validation
+type TxtValidationRecord struct {
+	Name  string `json:"txt_name"`
+	Value string `json:"txt_value"`
+}
+
 // CertificatePack is the overarching structure of a certificate pack response.
 type CertificatePack struct {
-	ID                 string                       `json:"id"`
-	Type               string                       `json:"type"`
-	Hosts              []string                     `json:"hosts"`
-	Certificates       []CertificatePackCertificate `json:"certificates"`
-	PrimaryCertificate string                       `json:"primary_certificate"`
+	ID                   string                       `json:"id"`
+	Type                 string                       `json:"type"`
+	Hosts                []string                     `json:"hosts"`
+	Certificates         []CertificatePackCertificate `json:"certificates"`
+	PrimaryCertificate   string                       `json:"primary_certificate"`
+	Status               string                       `json:"status"`
+	ValidityDays         int                          `json:"validity_days,omitempty"`
+	ValidationMethod     string                       `json:"validation_method,omitempty"`
+	CertificateAuthority string                       `json:"certificate_authority,omitempty"`
+	ValidationRecords    []TxtValidationRecord        `json:"validation_records,omitempty"`
 }
 
 // CertificatePackRequest is used for requesting a new certificate.

--- a/certificate_packs.go
+++ b/certificate_packs.go
@@ -62,13 +62,14 @@ type CertificatePackRequest struct {
 // CertificatePackAdvancedCertificate is the structure of the advanced
 // certificate pack certificate.
 type CertificatePackAdvancedCertificate struct {
-	ID                   string   `json:"id"`
-	Type                 string   `json:"type"`
-	Hosts                []string `json:"hosts"`
-	ValidationMethod     string   `json:"validation_method"`
-	ValidityDays         int      `json:"validity_days"`
-	CertificateAuthority string   `json:"certificate_authority"`
-	CloudflareBranding   bool     `json:"cloudflare_branding"`
+	ID                   string                `json:"id"`
+	Type                 string                `json:"type"`
+	Hosts                []string              `json:"hosts"`
+	ValidationMethod     string                `json:"validation_method"`
+	ValidityDays         int                   `json:"validity_days"`
+	CertificateAuthority string                `json:"certificate_authority"`
+	CloudflareBranding   bool                  `json:"cloudflare_branding"`
+	ValidationRecords    []TxtValidationRecord `json:"validation_records,omitempty"`
 }
 
 // CertificatePacksResponse is for responses where multiple certificates are

--- a/certificate_packs_test.go
+++ b/certificate_packs_test.go
@@ -334,7 +334,13 @@ func TestRestartAdvancedCertificateValidation(t *testing.T) {
     "validation_method": "txt",
     "validity_days": 365,
     "certificate_authority": "digicert",
-    "cloudflare_branding": false
+    "cloudflare_branding": false,
+    "validation_records": [
+      {
+        "txt_name": "example.com",
+        "txt_value": "ca3-1234567890abcdef"
+      }
+    ]
   }
 }`)
 	}
@@ -349,6 +355,10 @@ func TestRestartAdvancedCertificateValidation(t *testing.T) {
 		ValidationMethod:     "txt",
 		CertificateAuthority: "digicert",
 		CloudflareBranding:   false,
+		ValidationRecords: []TxtValidationRecord{{
+			Name:  "example.com",
+			Value: "ca3-1234567890abcdef",
+		}},
 	}
 
 	actual, err := client.RestartAdvancedCertificateValidation(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353", "3822ff90-ea29-44df-9e55-21300bb9419b")

--- a/certificate_packs_test.go
+++ b/certificate_packs_test.go
@@ -93,7 +93,7 @@ func TestListCertificatePacks(t *testing.T) {
 	}
 }
 
-func TestListCertificatePack(t *testing.T) {
+func TestGetCertificatePack(t *testing.T) {
 	setup()
 	defer teardown()
 


### PR DESCRIPTION
## Description

Exposes the `validation_records` field returned by the [get certificate](https://api.cloudflare.com/#certificate-packs-get-certificate-pack) call.

The `ValidationRecords` field (and some other ones) was added to the relevant structs

## Has your change been tested?

Yes, with `go test`

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

Fixes: #741 
