### PR TITLE
account_roles: get all roles using `per_page` attribute

### DIFF
--- a/account_roles.go
+++ b/account_roles.go
@@ -45,7 +45,7 @@ type AccountRoleDetailResponse struct {
 //
 // API reference: https://api.cloudflare.com/#account-roles-list-roles
 func (api *API) AccountRoles(ctx context.Context, accountID string) ([]AccountRole, error) {
-	uri := fmt.Sprintf("/accounts/%s/roles", accountID)
+	uri := fmt.Sprintf("/accounts/%s/roles?per_page=50", accountID)
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {


### PR DESCRIPTION
Allows fetching all the roles by default.

Closes cloudflare/terraform-provider-cloudflare#1334