### PR TITLE
closes #750 - support account-level logpush jobs

### DIFF
--- a/logpush.go
+++ b/logpush.go
@@ -92,9 +92,29 @@ type LogpushDestinationExistsRequest struct {
 	DestinationConf string `json:"destination_conf"`
 }
 
-// CreateLogpushJob creates a new LogpushJob for a zone.
+// CreateAccountLogpushJob creates a new account-level Logpush Job.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-create-logpush-job
+func (api *API) CreateAccountLogpushJob(ctx context.Context, accountID string, job LogpushJob) (*LogpushJob, error) {
+	return api.createLogpushJob(ctx, AccountRouteRoot, accountID, job)
+}
+
+// CreateZoneLogpushJob creates a new zone-level Logpush Job.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-create-logpush-job
+func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
+	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
+}
+
+// CreateLogpushJob creates a new zone-level Logpush Job.
+//
+// Deprecated: Renamed to CreateZoneLogpushJob.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-create-logpush-job
+func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
+	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
+}
+
 func (api *API) createLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, job LogpushJob) (*LogpushJob, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/jobs", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, job)
@@ -108,20 +128,30 @@ func (api *API) createLogpushJob(ctx context.Context, identifierType RouteRoot, 
 	}
 	return &r.Result, nil
 }
-func (api *API) CreateAccountLogpushJob(ctx context.Context, accountID string, job LogpushJob) (*LogpushJob, error) {
-	return api.createLogpushJob(ctx, AccountRouteRoot, accountID, job)
-}
-func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
-	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
-}
-// Eventually deprecate this
-func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
-	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
-}
 
-// LogpushJobs returns all Logpush Jobs for a zone.
+// ListAccountLogpushJobs returns all account-level Logpush Jobs for all datasets.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([]LogpushJob, error) {
+	return api.listLogpushJobs(ctx, AccountRouteRoot, accountID, job)
+}
+
+// ListZoneLogpushJobs returns all zone-level Logpush Jobs for all datasets.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
+	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
+}
+
+// LogpushJobs returns all zone-level Logpush Jobs for all datasets.
+//
+// Deprecated: Renamed to ListZoneLogpushJobs.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
+	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
+}
+
 func (api *API) listLogpushJobs(ctx context.Context, identifierType RouteRoot, identifier string) ([]LogpushJob, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/jobs", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
@@ -135,20 +165,30 @@ func (api *API) listLogpushJobs(ctx context.Context, identifierType RouteRoot, i
 	}
 	return r.Result, nil
 }
-func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([]LogpushJob, error) {
-	return api.listLogpushJobs(ctx, AccountRouteRoot, accountID, job)
-}
-func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
-}
-// Eventually deprecate this
-func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
-}
 
-// LogpushJobsForDataset returns all Logpush Jobs for a dataset in a zone.
+// ListAccountLogpushJobsForDataset returns all account-level Logpush Jobs for a dataset.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
+func (api *API) ListAccountLogpushJobsForDataset(ctx context.Context, accountID, dataset string) ([]LogpushJob, error) {
+	return api.listLogpushJobsForDataset(ctx, AccountRouteRoot, accountID, dataset)
+}
+
+// ListZoneLogpushJobsForDataset returns all zone-level Logpush Jobs for a dataset.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
+func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
+	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
+}
+
+// LogpushJobsForDataset returns all zone-level Logpush Jobs for a dataset.
+//
+// Deprecated: Renamed to ListZoneLogpushJobsForDataset.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
+func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
+	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
+}
+
 func (api *API) listLogpushJobsForDataset(ctx context.Context, identifierType RouteRoot, identifier, dataset string) ([]LogpushJob, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/jobs", identifierType, identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
@@ -162,20 +202,30 @@ func (api *API) listLogpushJobsForDataset(ctx context.Context, identifierType Ro
 	}
 	return r.Result, nil
 }
-func (api *API) ListAccountLogpushJobsForDataset(ctx context.Context, accountID, dataset string) ([]LogpushJob, error) {
-	return api.listLogpushJobsForDataset(ctx, AccountRouteRoot, accountID, dataset)
+
+// GetAccountLogpushFields returns fields for a given account-level dataset.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
+	return api.getLogpushFields(ctx, AccountRouteRoot, accountID, dataset)
 }
-func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
-}
-// Eventually deprecate this
-func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
+
+// GetZoneLogpushFields returns fields for a given zone-level dataset.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
+	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 
 // LogpushFields returns fields for a given dataset.
 //
+// Deprecated: Renamed to GetZoneLogpushFields.
+//
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
+	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
+}
+
 func (api *API) getLogpushFields(ctx context.Context, identifierType RouteRoot, identifier, dataset string) (LogpushFields, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/fields", identifierType, identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
@@ -189,20 +239,30 @@ func (api *API) getLogpushFields(ctx context.Context, identifierType RouteRoot, 
 	}
 	return r.Result, nil
 }
-func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
-	return api.getLogpushFields(ctx, AccountRouteRoot, accountID, dataset)
+
+// GetAccountLogpushJob fetches detail about one account-level Logpush Job.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
+func (api *API) GetAccountLogpushJob(ctx context.Context, accountID string, jobID int) (LogpushJob, error) {
+	return api.getLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
 }
-func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
-}
-// Eventually deprecate this
-func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
+
+// GetZoneLogpushJob fetches detail about one Logpush Job for a zone.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
+func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
+	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 
 // LogpushJob fetches detail about one Logpush Job for a zone.
 //
+// Deprecated: Renamed to GetZoneLogpushJob.
+//
 // API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
+func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
+	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
+}
+
 func (api *API) getLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int) (LogpushJob, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", identifierType, identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
@@ -216,20 +276,30 @@ func (api *API) getLogpushJob(ctx context.Context, identifierType RouteRoot, ide
 	}
 	return r.Result, nil
 }
-func (api *API) GetAccountLogpushJob(ctx context.Context, accountID string, jobID int) (LogpushJob, error) {
-	return api.getLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
+
+// UpdateAccountLogpushJob lets you update an account-level Logpush Job.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
+func (api *API) UpdateAccountLogpushJob(ctx context.Context, accountID string, jobID int, job LogpushJob) error {
+	return api.updateLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
 }
-func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
-}
-// Eventually deprecate this
-func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
+
+// UpdateZoneLogpushJob lets you update a Logpush Job for a zone.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
+func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
+	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
 }
 
 // UpdateLogpushJob lets you update a Logpush Job.
 //
+// Deprecated: Renamed to UpdateZoneLogpushJob.
+//
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
+func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
+	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
+}
+
 func (api *API) updateLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int, job LogpushJob) error {
 	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", identifierType, identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, job)
@@ -243,20 +313,30 @@ func (api *API) updateLogpushJob(ctx context.Context, identifierType RouteRoot, 
 	}
 	return nil
 }
-func (api *API) UpdateAccountLogpushJob(ctx context.Context, accountID string, jobID int, job LogpushJob) error {
-	return api.updateLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
+
+// DeleteAccountLogpushJob deletes an account-level Logpush Job.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-delete-logpush-job
+func (api *API) DeleteAccountLogpushJob(ctx context.Context, accountID string, jobID int) error {
+	return api.deleteLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
 }
-func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
-	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
-}
-// Eventually deprecate this
-func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
-	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
+
+// DeleteZoneLogpushJob deletes a Logpush Job for a zone.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-delete-logpush-job
+func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID int) error {
+	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 
 // DeleteLogpushJob deletes a Logpush Job for a zone.
 //
+// Deprecated: Renamed to DeleteZoneLogpushJob.
+//
 // API reference: https://api.cloudflare.com/#logpush-jobs-delete-logpush-job
+func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
+	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
+}
+
 func (api *API) deleteLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int) error {
 	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", identifierType, identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
@@ -270,20 +350,30 @@ func (api *API) deleteLogpushJob(ctx context.Context, identifierType RouteRoot, 
 	}
 	return nil
 }
-func (api *API) DeleteAccountLogpushJob(ctx context.Context, accountID string, jobID int) error {
-	return api.deleteLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
+
+// GetAccountLogpushOwnershipChallenge returns ownership challenge.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-get-ownership-challenge
+func (api *API) GetAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
+	return api.getLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf)
 }
-func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID int) error {
-	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
-}
-// Eventually deprecate this
-func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
-	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
+
+// GetZoneLogpushOwnershipChallenge returns ownership challenge.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-get-ownership-challenge
+func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
+	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
 
 // GetLogpushOwnershipChallenge returns ownership challenge.
 //
+// Deprecated: Renamed to GetZoneLogpushOwnershipChallenge.
+//
 // API reference: https://api.cloudflare.com/#logpush-jobs-get-ownership-challenge
+func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
+	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
+}
+
 func (api *API) getLogpushOwnershipChallenge(ctx context.Context, identifierType RouteRoot, identifier, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/ownership", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushGetOwnershipChallengeRequest{
@@ -304,20 +394,30 @@ func (api *API) getLogpushOwnershipChallenge(ctx context.Context, identifierType
 
 	return &r.Result, nil
 }
-func (api *API) GetAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.getLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf)
-}
-func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
-}
-// Eventually deprecate this
-func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
-}
 
-// ValidateLogpushOwnershipChallenge returns ownership challenge validation result.
+// ValidateAccountLogpushOwnershipChallenge returns account-level ownership challenge validation result.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
+func (api *API) ValidateAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf, ownershipChallenge string) (bool, error) {
+	return api.validateLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf)
+}
+
+// ValidateZoneLogpushOwnershipChallenge returns zone-level ownership challenge validation result.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
+func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
+	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
+}
+
+// ValidateLogpushOwnershipChallenge returns zone-level ownership challenge validation result.
+//
+// Deprecated: Renamed to ValidateZoneLogpushOwnershipChallenge.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
+func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
+	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
+}
+
 func (api *API) validateLogpushOwnershipChallenge(ctx context.Context, identifierType RouteRoot, identifier, destinationConf, ownershipChallenge string) (bool, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/ownership/validate", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushValidateOwnershipChallengeRequest{
@@ -334,20 +434,30 @@ func (api *API) validateLogpushOwnershipChallenge(ctx context.Context, identifie
 	}
 	return r.Result.Valid, nil
 }
-func (api *API) ValidateAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.validateLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf)
-}
-func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
-}
-// Eventually deprecate this
-func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
-}
 
-// CheckLogpushDestinationExists returns destination exists check result.
+// CheckAccountLogpushDestinationExists returns account-level destination exists check result.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-check-destination-exists
+func (api *API) CheckAccountLogpushDestinationExists(ctx context.Context, accountID, destinationConf string) (bool, error) {
+	return api.checkLogpushDestinationExists(ctx, AccountRouteRoot, accountID, destinationConf)
+}
+
+// CheckZoneLogpushDestinationExists returns zone-level destination exists check result.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-check-destination-exists
+func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
+	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
+}
+
+// CheckLogpushDestinationExists returns zone-level destination exists check result.
+//
+// Deprecated: Renamed to CheckZoneLogpushDestinationExists.
+//
+// API reference: https://api.cloudflare.com/#logpush-jobs-check-destination-exists
+func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
+	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
+}
+
 func (api *API) checkLogpushDestinationExists(ctx context.Context, identifierType RouteRoot, identifier, destinationConf string) (bool, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/validate/destination/exists", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushDestinationExistsRequest{
@@ -362,14 +472,4 @@ func (api *API) checkLogpushDestinationExists(ctx context.Context, identifierTyp
 		return false, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result.Exists, nil
-}
-func (api *API) CheckAccountLogpushDestinationExists(ctx context.Context, accountID, destinationConf string) (bool, error) {
-	return api.checkLogpushDestinationExists(ctx, AccountRouteRoot, accountID, destinationConf)
-}
-func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
-	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
-}
-// Eventually deprecate this
-func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
-	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }

--- a/logpush.go
+++ b/logpush.go
@@ -110,7 +110,8 @@ func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job Log
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-create-logpush-job
 //
-// Deprecated: Renamed to CreateZoneLogpushJob.
+// Deprecated: Use `CreateZoneLogpushJob` or `CreateAccountLogpushJob` depending 
+// on the desired resource to target.
 func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
 	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
 }
@@ -147,7 +148,8 @@ func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]Logpu
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
 //
-// Deprecated: Renamed to ListZoneLogpushJobs.
+// Deprecated: Use `ListZoneLogpushJobs` or `ListAccountLogpushJobs`
+// depending on the desired resource to target.
 func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
 	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID)
 }
@@ -184,7 +186,9 @@ func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, datas
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
 //
-// Deprecated: Renamed to ListZoneLogpushJobsForDataset.
+// Deprecated: Use `ListZoneLogpushJobsForDataset` or 
+// `ListAccountLogpushJobsForDataset` depending on the desired resource
+// to target.
 func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
 	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
@@ -205,16 +209,18 @@ func (api *API) listLogpushJobsForDataset(ctx context.Context, identifierType Ro
 
 // GetAccountLogpushFields returns fields for a given account-level dataset.
 //
+// Account fields documentation: https://developers.cloudflare.com/logs/reference/log-fields/account
+//
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-// Account Fields: https://developers.cloudflare.com/logs/reference/log-fields/account
 func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
 	return api.getLogpushFields(ctx, AccountRouteRoot, accountID, dataset)
 }
 
 // GetZoneLogpushFields returns fields for a given zone-level dataset.
 //
+// Zone fields documentation: https://developers.cloudflare.com/logs/reference/log-fields/zone
+//
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-// Zone Fields: https://developers.cloudflare.com/logs/reference/log-fields/zone
 func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
 	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
@@ -223,7 +229,8 @@ func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
 //
-// Deprecated: Renamed to GetZoneLogpushFields.
+// Deprecated: Use `GetZoneLogpushFields` or `GetAccountLogpushFields` 
+// depending on the desired resource to target.
 func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
 	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
@@ -260,7 +267,8 @@ func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int)
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
 //
-// Deprecated: Renamed to GetZoneLogpushJob.
+// Deprecated: Use `GetZoneLogpushJob` or `GetAccountLogpushJob` 
+// depending on the desired resource to target.
 func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
 	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
@@ -297,7 +305,8 @@ func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID i
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
 //
-// Deprecated: Renamed to UpdateZoneLogpushJob.
+// Deprecated: Use `UpdateZoneLogpushJob` or `UpdateAccountLogpushJob` 
+// depending on the desired resource to target.
 func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
 	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
 }
@@ -334,7 +343,8 @@ func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID i
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-delete-logpush-job
 //
-// Deprecated: Renamed to DeleteZoneLogpushJob.
+// Deprecated: Use `DeleteZoneLogpushJob` or `DeleteAccountLogpushJob` 
+// depending on the desired resource to target.
 func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
 	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
@@ -371,7 +381,9 @@ func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, de
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-get-ownership-challenge
 //
-// Deprecated: Renamed to GetZoneLogpushOwnershipChallenge.
+// Deprecated: Use `GetZoneLogpushOwnershipChallenge` or
+// `GetAccountLogpushOwnershipChallenge` depending on the 
+// desired resource to target.
 func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
 	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
@@ -415,7 +427,9 @@ func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneI
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
 //
-// Deprecated: Renamed to ValidateZoneLogpushOwnershipChallenge.
+// Deprecated: Use `ValidateZoneLogpushOwnershipChallenge` or
+// `ValidateAccountLogpushOwnershipChallenge` depending on the 
+// desired resource to target.
 func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
 	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
 }
@@ -455,7 +469,9 @@ func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, d
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-check-destination-exists
 //
-// Deprecated: Renamed to CheckZoneLogpushDestinationExists.
+// Deprecated: Use `CheckZoneLogpushDestinationExists` or
+// `CheckAccountLogpushDestinationExists` depending 
+// on the desired resource to target.
 func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
 	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }

--- a/logpush.go
+++ b/logpush.go
@@ -92,19 +92,11 @@ type LogpushDestinationExistsRequest struct {
 	DestinationConf string `json:"destination_conf"`
 }
 
-func getRouteRoot (identifierType string) {
-	if identifierType == "account" {
-		return AccountRouteRoot
-	} else {
-		return ZoneRouteRoot
-	}
-}
-
 // CreateLogpushJob creates a new LogpushJob for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-create-logpush-job
-func (api *API) CreateLogpushJob(ctx context.Context, identifier string, job LogpushJob, identifierType string) (*LogpushJob, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/jobs", getRouteRoot(identifierType), identifier)
+func (api *API) createLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, job LogpushJob) (*LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, job)
 	if err != nil {
 		return nil, err
@@ -117,17 +109,20 @@ func (api *API) CreateLogpushJob(ctx context.Context, identifier string, job Log
 	return &r.Result, nil
 }
 func (api *API) CreateAccountLogpushJob(ctx context.Context, accountID string, job LogpushJob) (*LogpushJob, error) {
-	return api.CreateLogpushJob(ctx, accountID, job, "account")
+	return api.createLogpushJob(ctx, accountID, job, "account")
 }
 func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
-	return api.CreateLogpushJob(ctx, zoneID, job, "zone")
+	return api.createLogpushJob(ctx, zoneID, job, "zone")
+}
+func (api *API) CreateLogpushJob(ctx context.Context, zoneId string, job LogpushJob) (*LogpushJob, error) {
+        return api.createLogpushJob(ctx, zoneID, job, "zone")
 }
 
 // LogpushJobs returns all Logpush Jobs for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-func (api *API) LogpushJobs(ctx context.Context, identifier string, identifierType string) ([]LogpushJob, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/jobs", getRouteRoot(identifierType), identifier)
+func (api *API) logpushJobs(ctx context.Context, identifierType RouteRoot, identifier string) ([]LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []LogpushJob{}, err
@@ -140,17 +135,20 @@ func (api *API) LogpushJobs(ctx context.Context, identifier string, identifierTy
 	return r.Result, nil
 }
 func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([]LogpushJob, error) {
-	return api.LogpushJobs(ctx, accountID, job, "account")
+	return api.logpushJobs(ctx, accountID, job, "account")
 }
 func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.LogpushJobs(ctx, zoneID, job, "zone")
+	return api.logpushJobs(ctx, zoneID, job, "zone")
+}
+func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
+	return api.logpushJobs(ctx, zoneID, job, "zone")
 }
 
 // LogpushJobsForDataset returns all Logpush Jobs for a dataset in a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
-func (api *API) LogpushJobsForDataset(ctx context.Context, identifier, dataset string, identifierType string) ([]LogpushJob, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/jobs", getRouteRoot(identifierType), identifier, dataset)
+func (api *API) logpushJobsForDataset(ctx context.Context, identifierType RouteRoot, identifier, dataset string) ([]LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/jobs", identifierType, identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []LogpushJob{}, err
@@ -163,17 +161,20 @@ func (api *API) LogpushJobsForDataset(ctx context.Context, identifier, dataset s
 	return r.Result, nil
 }
 func (api *API) ListAccountLogpushJobsForDataset(ctx context.Context, accountID, dataset string) ([]LogpushJob, error) {
-	return api.LogpushJobsForDataset(ctx, accountID, dataset, "account")
+	return api.logpushJobsForDataset(ctx, accountID, dataset, "account")
 }
 func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	return api.LogpushJobsForDataset(ctx, zoneID, dataset, "zone")
+	return api.logpushJobsForDataset(ctx, zoneID, dataset, "zone")
+}
+func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
+	return api.logpushJobsForDataset(ctx, zoneID, dataset, "zone")
 }
 
 // LogpushFields returns fields for a given dataset.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-func (api *API) LogpushFields(ctx context.Context, identifier, dataset string, identifierType string) (LogpushFields, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/fields", getRouteRoot(identifierType), identifier, dataset)
+func (api *API) logpushFields(ctx context.Context, identifierType RouteRoot, identifier, dataset string) (LogpushFields, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/fields", identifierType, identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return LogpushFields{}, err
@@ -186,17 +187,20 @@ func (api *API) LogpushFields(ctx context.Context, identifier, dataset string, i
 	return r.Result, nil
 }
 func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
-	return api.LogpushFields(ctx, accountID, dataset, "account")
+	return api.logpushFields(ctx, accountID, dataset, "account")
 }
 func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	return api.LogpushFields(ctx, zoneID, dataset, "zone")
+	return api.logpushFields(ctx, zoneID, dataset, "zone")
+}
+func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
+	return api.logpushFields(ctx, zoneID, dataset, "zone")
 }
 
 // LogpushJob fetches detail about one Logpush Job for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
-func (api *API) LogpushJob(ctx context.Context, identifier string, jobID int, identifierType string) (LogpushJob, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", getRouteRoot(identifierType), identifier, jobID)
+func (api *API) logpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int) (LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", identifierType, identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return LogpushJob{}, err
@@ -209,17 +213,20 @@ func (api *API) LogpushJob(ctx context.Context, identifier string, jobID int, id
 	return r.Result, nil
 }
 func (api *API) GetAccountLogpushJob(ctx context.Context, accountID string, jobID int) (LogpushJob, error) {
-	return api.LogpushJob(ctx, accountID, jobID, "account")
+	return api.logpushJob(ctx, accountID, jobID, "account")
 }
 func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	return api.LogpushJob(ctx, zoneID, jobID, "zone")
+	return api.logpushJob(ctx, zoneID, jobID, "zone")
+}
+func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
+	return api.logpushJob(ctx, zoneID, jobID, "zone")
 }
 
 // UpdateLogpushJob lets you update a Logpush Job.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
-func (api *API) UpdateLogpushJob(ctx context.Context, identifier string, jobID int, job LogpushJob, identifierType string) error {
-	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", getRouteRoot(identifierType), identifier, jobID)
+func (api *API) updateLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int, job LogpushJob) error {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", identifierType, identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, job)
 	if err != nil {
 		return err
@@ -232,17 +239,20 @@ func (api *API) UpdateLogpushJob(ctx context.Context, identifier string, jobID i
 	return nil
 }
 func (api *API) UpdateAccountLogpushJob(ctx context.Context, accountID string, jobID int, job LogpushJob) error {
-	return api.UpdateLogpushJob(ctx, accountID, jobID, job, "account")
+	return api.updateLogpushJob(ctx, accountID, jobID, job, "account")
 }
 func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
-	return api.UpdateLogpushJob(ctx, zoneID, jobID, job, "zone")
+	return api.updateLogpushJob(ctx, zoneID, jobID, job, "zone")
+}
+func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
+	return api.updateLogpushJob(ctx, zoneID, jobID, job, "zone")
 }
 
 // DeleteLogpushJob deletes a Logpush Job for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-delete-logpush-job
-func (api *API) DeleteLogpushJob(ctx context.Context, identifier string, jobID int, identifierType string) error {
-	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", getRouteRoot(identifierType), identifier, jobID)
+func (api *API) deleteLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int) error {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", identifierType, identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {
 		return err
@@ -255,17 +265,20 @@ func (api *API) DeleteLogpushJob(ctx context.Context, identifier string, jobID i
 	return nil
 }
 func (api *API) DeleteAccountLogpushJob(ctx context.Context, accountID string, jobID int) error {
-	return api.DeleteLogpushJob(ctx, accountID, jobID, "account")
+	return api.deleteLogpushJob(ctx, accountID, jobID, "account")
 }
 func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID int) error {
-	return api.DeleteLogpushJob(ctx, zoneID, jobID, "zone")
+	return api.deleteLogpushJob(ctx, zoneID, jobID, "zone")
+}
+func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
+	return api.deleteLogpushJob(ctx, zoneID, jobID, "zone")
 }
 
 // GetLogpushOwnershipChallenge returns ownership challenge.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-get-ownership-challenge
-func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, identifier, destinationConf string, identifierType string) (*LogpushGetOwnershipChallenge, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/ownership", getRouteRoot(identifierType), identifier)
+func (api *API) getLogpushOwnershipChallenge(ctx context.Context, identifierType RouteRoot, identifier, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/ownership", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushGetOwnershipChallengeRequest{
 		DestinationConf: destinationConf,
 	})
@@ -285,17 +298,20 @@ func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, identifier, de
 	return &r.Result, nil
 }
 func (api *API) GetAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.GetLogpushOwnershipChallenge(ctx, accountID, destinationConf, "account")
+	return api.getLogpushOwnershipChallenge(ctx, accountID, destinationConf, "account")
 }
 func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.GetLogpushOwnershipChallenge(ctx, zoneID, destinationConf, "zone")
+	return api.getLogpushOwnershipChallenge(ctx, zoneID, destinationConf, "zone")
+}
+func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
+	return api.getLogpushOwnershipChallenge(ctx, zoneID, destinationConf, "zone")
 }
 
 // ValidateLogpushOwnershipChallenge returns ownership challenge validation result.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
-func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, identifier, destinationConf, ownershipChallenge string, identifierType string) (bool, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/ownership/validate", getRouteRoot(identifierType), identifier)
+func (api *API) validateLogpushOwnershipChallenge(ctx context.Context, identifierType RouteRoot, identifier, destinationConf, ownershipChallenge string) (bool, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/ownership/validate", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushValidateOwnershipChallengeRequest{
 		DestinationConf:    destinationConf,
 		OwnershipChallenge: ownershipChallenge,
@@ -311,17 +327,20 @@ func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, identifie
 	return r.Result.Valid, nil
 }
 func (api *API) ValidateAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.ValidateLogpushOwnershipChallenge(ctx, accountID, destinationConf, ownershipChallenge, "account")
+	return api.validateLogpushOwnershipChallenge(ctx, accountID, destinationConf, ownershipChallenge, "account")
 }
 func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.ValidateLogpushOwnershipChallenge(ctx, zoneID, destinationConf, ownershipChallenge, "zone")
+	return api.validateLogpushOwnershipChallenge(ctx, zoneID, destinationConf, ownershipChallenge, "zone")
+}
+func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
+	return api.validateLogpushOwnershipChallenge(ctx, zoneID, destinationConf, ownershipChallenge, "zone")
 }
 
 // CheckLogpushDestinationExists returns destination exists check result.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-check-destination-exists
-func (api *API) CheckLogpushDestinationExists(ctx context.Context, identifier, destinationConf string, identifierType string) (bool, error) {
-	uri := fmt.Sprintf("/%s/%s/logpush/validate/destination/exists", getRouteRoot(identifierType), identifier)
+func (api *API) checkLogpushDestinationExists(ctx context.Context, identifierType RouteRoot, identifier, destinationConf string) (bool, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/validate/destination/exists", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushDestinationExistsRequest{
 		DestinationConf: destinationConf,
 	})
@@ -336,8 +355,11 @@ func (api *API) CheckLogpushDestinationExists(ctx context.Context, identifier, d
 	return r.Result.Exists, nil
 }
 func (api *API) CheckAccountLogpushDestinationExists(ctx context.Context, accountID, destinationConf string) (bool, error) {
-	return api.CheckLogpushDestinationExists(ctx, accountID, destinationConf, "account")
+	return api.checkLogpushDestinationExists(ctx, accountID, destinationConf, "account")
 }
 func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
-	return api.CheckLogpushDestinationExists(ctx, zoneID, destinationConf, "zone")
+	return api.checkLogpushDestinationExists(ctx, zoneID, destinationConf, "zone")
+}
+func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
+	return api.checkLogpushDestinationExists(ctx, zoneID, destinationConf, "zone")
 }

--- a/logpush.go
+++ b/logpush.go
@@ -109,13 +109,13 @@ func (api *API) createLogpushJob(ctx context.Context, identifierType RouteRoot, 
 	return &r.Result, nil
 }
 func (api *API) CreateAccountLogpushJob(ctx context.Context, accountID string, job LogpushJob) (*LogpushJob, error) {
-	return api.createLogpushJob(ctx, accountID, job, "account")
+	return api.createLogpushJob(ctx, AccountRouteRoot, accountID, job)
 }
 func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
-	return api.createLogpushJob(ctx, zoneID, job, "zone")
+	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
 }
 func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
-        return api.createLogpushJob(ctx, zoneID, job, "zone")
+        return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
 }
 
 // LogpushJobs returns all Logpush Jobs for a zone.
@@ -135,13 +135,13 @@ func (api *API) logpushJobs(ctx context.Context, identifierType RouteRoot, ident
 	return r.Result, nil
 }
 func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([]LogpushJob, error) {
-	return api.logpushJobs(ctx, accountID, job, "account")
+	return api.logpushJobs(ctx, AccountRouteRoot, accountID, job)
 }
 func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.logpushJobs(ctx, zoneID, job, "zone")
+	return api.logpushJobs(ctx, ZoneRouteRoot, zoneID, job)
 }
 func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.logpushJobs(ctx, zoneID, job, "zone")
+	return api.logpushJobs(ctx, ZoneRouteRoot, zoneID, job)
 }
 
 // LogpushJobsForDataset returns all Logpush Jobs for a dataset in a zone.
@@ -161,13 +161,13 @@ func (api *API) logpushJobsForDataset(ctx context.Context, identifierType RouteR
 	return r.Result, nil
 }
 func (api *API) ListAccountLogpushJobsForDataset(ctx context.Context, accountID, dataset string) ([]LogpushJob, error) {
-	return api.logpushJobsForDataset(ctx, accountID, dataset, "account")
+	return api.logpushJobsForDataset(ctx, AccountRouteRoot, accountID, dataset)
 }
 func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	return api.logpushJobsForDataset(ctx, zoneID, dataset, "zone")
+	return api.logpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	return api.logpushJobsForDataset(ctx, zoneID, dataset, "zone")
+	return api.logpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 
 // LogpushFields returns fields for a given dataset.
@@ -187,13 +187,13 @@ func (api *API) logpushFields(ctx context.Context, identifierType RouteRoot, ide
 	return r.Result, nil
 }
 func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
-	return api.logpushFields(ctx, accountID, dataset, "account")
+	return api.logpushFields(ctx, AccountRouteRoot, accountID, dataset)
 }
 func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	return api.logpushFields(ctx, zoneID, dataset, "zone")
+	return api.logpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	return api.logpushFields(ctx, zoneID, dataset, "zone")
+	return api.logpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 
 // LogpushJob fetches detail about one Logpush Job for a zone.
@@ -213,13 +213,13 @@ func (api *API) logpushJob(ctx context.Context, identifierType RouteRoot, identi
 	return r.Result, nil
 }
 func (api *API) GetAccountLogpushJob(ctx context.Context, accountID string, jobID int) (LogpushJob, error) {
-	return api.logpushJob(ctx, accountID, jobID, "account")
+	return api.logpushJob(ctx, AccountRouteRoot, accountID, jobID)
 }
 func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	return api.logpushJob(ctx, zoneID, jobID, "zone")
+	return api.logpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	return api.logpushJob(ctx, zoneID, jobID, "zone")
+	return api.logpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 
 // UpdateLogpushJob lets you update a Logpush Job.
@@ -239,13 +239,13 @@ func (api *API) updateLogpushJob(ctx context.Context, identifierType RouteRoot, 
 	return nil
 }
 func (api *API) UpdateAccountLogpushJob(ctx context.Context, accountID string, jobID int, job LogpushJob) error {
-	return api.updateLogpushJob(ctx, accountID, jobID, job, "account")
+	return api.updateLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
 }
 func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
-	return api.updateLogpushJob(ctx, zoneID, jobID, job, "zone")
+	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
 }
 func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
-	return api.updateLogpushJob(ctx, zoneID, jobID, job, "zone")
+	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
 }
 
 // DeleteLogpushJob deletes a Logpush Job for a zone.
@@ -265,13 +265,13 @@ func (api *API) deleteLogpushJob(ctx context.Context, identifierType RouteRoot, 
 	return nil
 }
 func (api *API) DeleteAccountLogpushJob(ctx context.Context, accountID string, jobID int) error {
-	return api.deleteLogpushJob(ctx, accountID, jobID, "account")
+	return api.deleteLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
 }
 func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID int) error {
-	return api.deleteLogpushJob(ctx, zoneID, jobID, "zone")
+	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
-	return api.deleteLogpushJob(ctx, zoneID, jobID, "zone")
+	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 
 // GetLogpushOwnershipChallenge returns ownership challenge.
@@ -298,13 +298,13 @@ func (api *API) getLogpushOwnershipChallenge(ctx context.Context, identifierType
 	return &r.Result, nil
 }
 func (api *API) GetAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.getLogpushOwnershipChallenge(ctx, accountID, destinationConf, "account")
+	return api.getLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf)
 }
 func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.getLogpushOwnershipChallenge(ctx, zoneID, destinationConf, "zone")
+	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
 func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	return api.getLogpushOwnershipChallenge(ctx, zoneID, destinationConf, "zone")
+	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
 
 // ValidateLogpushOwnershipChallenge returns ownership challenge validation result.
@@ -327,13 +327,13 @@ func (api *API) validateLogpushOwnershipChallenge(ctx context.Context, identifie
 	return r.Result.Valid, nil
 }
 func (api *API) ValidateAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.validateLogpushOwnershipChallenge(ctx, accountID, destinationConf, ownershipChallenge, "account")
+	return api.validateLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf)
 }
 func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.validateLogpushOwnershipChallenge(ctx, zoneID, destinationConf, ownershipChallenge, "zone")
+	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
 }
 func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.validateLogpushOwnershipChallenge(ctx, zoneID, destinationConf, ownershipChallenge, "zone")
+	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
 }
 
 // CheckLogpushDestinationExists returns destination exists check result.
@@ -355,11 +355,11 @@ func (api *API) checkLogpushDestinationExists(ctx context.Context, identifierTyp
 	return r.Result.Exists, nil
 }
 func (api *API) CheckAccountLogpushDestinationExists(ctx context.Context, accountID, destinationConf string) (bool, error) {
-	return api.checkLogpushDestinationExists(ctx, accountID, destinationConf, "account")
+	return api.checkLogpushDestinationExists(ctx, AccountRouteRoot, accountID, destinationConf)
 }
 func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
-	return api.checkLogpushDestinationExists(ctx, zoneID, destinationConf, "zone")
+	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
 func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
-	return api.checkLogpushDestinationExists(ctx, zoneID, destinationConf, "zone")
+	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }

--- a/logpush.go
+++ b/logpush.go
@@ -133,14 +133,14 @@ func (api *API) createLogpushJob(ctx context.Context, identifierType RouteRoot, 
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
 func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([]LogpushJob, error) {
-	return api.listLogpushJobs(ctx, AccountRouteRoot, accountID, job)
+	return api.listLogpushJobs(ctx, AccountRouteRoot, accountID)
 }
 
 // ListZoneLogpushJobs returns all zone-level Logpush Jobs for all datasets.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
 func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
+	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID)
 }
 
 // LogpushJobs returns all zone-level Logpush Jobs for all datasets.
@@ -149,7 +149,7 @@ func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]Logpu
 //
 // Deprecated: Renamed to ListZoneLogpushJobs.
 func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
+	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID)
 }
 
 func (api *API) listLogpushJobs(ctx context.Context, identifierType RouteRoot, identifier string) ([]LogpushJob, error) {
@@ -283,7 +283,7 @@ func (api *API) getLogpushJob(ctx context.Context, identifierType RouteRoot, ide
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
 func (api *API) UpdateAccountLogpushJob(ctx context.Context, accountID string, jobID int, job LogpushJob) error {
-	return api.updateLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
+	return api.updateLogpushJob(ctx, AccountRouteRoot, accountID, jobID, job)
 }
 
 // UpdateZoneLogpushJob lets you update a Logpush Job for a zone.
@@ -401,7 +401,7 @@ func (api *API) getLogpushOwnershipChallenge(ctx context.Context, identifierType
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
 func (api *API) ValidateAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf, ownershipChallenge string) (bool, error) {
-	return api.validateLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf)
+	return api.validateLogpushOwnershipChallenge(ctx, AccountRouteRoot, accountID, destinationConf, ownershipChallenge)
 }
 
 // ValidateZoneLogpushOwnershipChallenge returns zone-level ownership challenge validation result.

--- a/logpush.go
+++ b/logpush.go
@@ -114,6 +114,7 @@ func (api *API) CreateAccountLogpushJob(ctx context.Context, accountID string, j
 func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
 	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
 }
+// Eventually deprecate this
 func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
         return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
 }
@@ -140,6 +141,7 @@ func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([
 func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
 	return api.logpushJobs(ctx, ZoneRouteRoot, zoneID, job)
 }
+// Eventually deprecate this
 func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
 	return api.logpushJobs(ctx, ZoneRouteRoot, zoneID, job)
 }
@@ -166,6 +168,7 @@ func (api *API) ListAccountLogpushJobsForDataset(ctx context.Context, accountID,
 func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
 	return api.logpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
+// Eventually deprecate this
 func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
 	return api.logpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
@@ -192,6 +195,7 @@ func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset 
 func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
 	return api.logpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
+// Eventually deprecate this
 func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
 	return api.logpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
@@ -218,6 +222,7 @@ func (api *API) GetAccountLogpushJob(ctx context.Context, accountID string, jobI
 func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
 	return api.logpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
+// Eventually deprecate this
 func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
 	return api.logpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
@@ -244,6 +249,7 @@ func (api *API) UpdateAccountLogpushJob(ctx context.Context, accountID string, j
 func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
 	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
 }
+// Eventually deprecate this
 func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
 	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
 }
@@ -270,6 +276,7 @@ func (api *API) DeleteAccountLogpushJob(ctx context.Context, accountID string, j
 func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID int) error {
 	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
+// Eventually deprecate this
 func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
 	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
@@ -303,6 +310,7 @@ func (api *API) GetAccountLogpushOwnershipChallenge(ctx context.Context, account
 func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
 	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
+// Eventually deprecate this
 func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
 	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
@@ -332,6 +340,7 @@ func (api *API) ValidateAccountLogpushOwnershipChallenge(ctx context.Context, ac
 func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
 	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
 }
+// Eventually deprecate this
 func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
 	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
 }
@@ -360,6 +369,7 @@ func (api *API) CheckAccountLogpushDestinationExists(ctx context.Context, accoun
 func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
 	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
+// Eventually deprecate this
 func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
 	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }

--- a/logpush.go
+++ b/logpush.go
@@ -114,7 +114,7 @@ func (api *API) CreateAccountLogpushJob(ctx context.Context, accountID string, j
 func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
 	return api.createLogpushJob(ctx, zoneID, job, "zone")
 }
-func (api *API) CreateLogpushJob(ctx context.Context, zoneId string, job LogpushJob) (*LogpushJob, error) {
+func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
         return api.createLogpushJob(ctx, zoneID, job, "zone")
 }
 

--- a/logpush.go
+++ b/logpush.go
@@ -92,11 +92,19 @@ type LogpushDestinationExistsRequest struct {
 	DestinationConf string `json:"destination_conf"`
 }
 
+func getRouteRoot (identifierType string) {
+	if identifierType == "account" {
+		return AccountRouteRoot
+	} else {
+		return ZoneRouteRoot
+	}
+}
+
 // CreateLogpushJob creates a new LogpushJob for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-create-logpush-job
-func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/jobs", zoneID)
+func (api *API) CreateLogpushJob(ctx context.Context, identifier string, job LogpushJob, identifierType string) (*LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs", getRouteRoot(identifierType), identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, job)
 	if err != nil {
 		return nil, err
@@ -108,12 +116,18 @@ func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job Logpush
 	}
 	return &r.Result, nil
 }
+func (api *API) CreateAccountLogpushJob(ctx context.Context, accountID string, job LogpushJob) (*LogpushJob, error) {
+	return api.CreateLogpushJob(ctx, accountID, job, "account")
+}
+func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
+	return api.CreateLogpushJob(ctx, zoneID, job, "zone")
+}
 
 // LogpushJobs returns all Logpush Jobs for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/jobs", zoneID)
+func (api *API) LogpushJobs(ctx context.Context, identifier string, identifierType string) ([]LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs", getRouteRoot(identifierType), identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []LogpushJob{}, err
@@ -124,13 +138,19 @@ func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, e
 		return []LogpushJob{}, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result, nil
+}
+func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([]LogpushJob, error) {
+	return api.LogpushJobs(ctx, accountID, job, "account")
+}
+func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
+	return api.LogpushJobs(ctx, zoneID, job, "zone")
 }
 
 // LogpushJobsForDataset returns all Logpush Jobs for a dataset in a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
-func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/datasets/%s/jobs", zoneID, dataset)
+func (api *API) LogpushJobsForDataset(ctx context.Context, identifier, dataset string, identifierType string) ([]LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/jobs", getRouteRoot(identifierType), identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []LogpushJob{}, err
@@ -142,12 +162,18 @@ func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset strin
 	}
 	return r.Result, nil
 }
+func (api *API) ListAccountLogpushJobsForDataset(ctx context.Context, accountID, dataset string) ([]LogpushJob, error) {
+	return api.LogpushJobsForDataset(ctx, accountID, dataset, "account")
+}
+func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
+	return api.LogpushJobsForDataset(ctx, zoneID, dataset, "zone")
+}
 
 // LogpushFields returns fields for a given dataset.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/datasets/%s/fields", zoneID, dataset)
+func (api *API) LogpushFields(ctx context.Context, identifier, dataset string, identifierType string) (LogpushFields, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/fields", getRouteRoot(identifierType), identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return LogpushFields{}, err
@@ -159,12 +185,18 @@ func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (Logp
 	}
 	return r.Result, nil
 }
+func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
+	return api.LogpushFields(ctx, accountID, dataset, "account")
+}
+func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
+	return api.LogpushFields(ctx, zoneID, dataset, "zone")
+}
 
 // LogpushJob fetches detail about one Logpush Job for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
-func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/jobs/%d", zoneID, jobID)
+func (api *API) LogpushJob(ctx context.Context, identifier string, jobID int, identifierType string) (LogpushJob, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", getRouteRoot(identifierType), identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return LogpushJob{}, err
@@ -176,12 +208,18 @@ func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (Logpu
 	}
 	return r.Result, nil
 }
+func (api *API) GetAccountLogpushJob(ctx context.Context, accountID string, jobID int) (LogpushJob, error) {
+	return api.LogpushJob(ctx, accountID, jobID, "account")
+}
+func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
+	return api.LogpushJob(ctx, zoneID, jobID, "zone")
+}
 
 // UpdateLogpushJob lets you update a Logpush Job.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
-func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
-	uri := fmt.Sprintf("/zones/%s/logpush/jobs/%d", zoneID, jobID)
+func (api *API) UpdateLogpushJob(ctx context.Context, identifier string, jobID int, job LogpushJob, identifierType string) error {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", getRouteRoot(identifierType), identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, job)
 	if err != nil {
 		return err
@@ -193,12 +231,18 @@ func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, 
 	}
 	return nil
 }
+func (api *API) UpdateAccountLogpushJob(ctx context.Context, accountID string, jobID int, job LogpushJob) error {
+	return api.UpdateLogpushJob(ctx, accountID, jobID, job, "account")
+}
+func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
+	return api.UpdateLogpushJob(ctx, zoneID, jobID, job, "zone")
+}
 
 // DeleteLogpushJob deletes a Logpush Job for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-delete-logpush-job
-func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
-	uri := fmt.Sprintf("/zones/%s/logpush/jobs/%d", zoneID, jobID)
+func (api *API) DeleteLogpushJob(ctx context.Context, identifier string, jobID int, identifierType string) error {
+	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", getRouteRoot(identifierType), identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {
 		return err
@@ -210,12 +254,18 @@ func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) 
 	}
 	return nil
 }
+func (api *API) DeleteAccountLogpushJob(ctx context.Context, accountID string, jobID int) error {
+	return api.DeleteLogpushJob(ctx, accountID, jobID, "account")
+}
+func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID int) error {
+	return api.DeleteLogpushJob(ctx, zoneID, jobID, "zone")
+}
 
 // GetLogpushOwnershipChallenge returns ownership challenge.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-get-ownership-challenge
-func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/ownership", zoneID)
+func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, identifier, destinationConf string, identifierType string) (*LogpushGetOwnershipChallenge, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/ownership", getRouteRoot(identifierType), identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushGetOwnershipChallengeRequest{
 		DestinationConf: destinationConf,
 	})
@@ -234,12 +284,18 @@ func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destin
 
 	return &r.Result, nil
 }
+func (api *API) GetAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
+	return api.GetLogpushOwnershipChallenge(ctx, accountID, destinationConf, "account")
+}
+func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
+	return api.GetLogpushOwnershipChallenge(ctx, zoneID, destinationConf, "zone")
+}
 
 // ValidateLogpushOwnershipChallenge returns ownership challenge validation result.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
-func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/ownership/validate", zoneID)
+func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, identifier, destinationConf, ownershipChallenge string, identifierType string) (bool, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/ownership/validate", getRouteRoot(identifierType), identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushValidateOwnershipChallengeRequest{
 		DestinationConf:    destinationConf,
 		OwnershipChallenge: ownershipChallenge,
@@ -254,12 +310,18 @@ func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, d
 	}
 	return r.Result.Valid, nil
 }
+func (api *API) ValidateAccountLogpushOwnershipChallenge(ctx context.Context, accountID, destinationConf, ownershipChallenge string) (bool, error) {
+	return api.ValidateLogpushOwnershipChallenge(ctx, accountID, destinationConf, ownershipChallenge, "account")
+}
+func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
+	return api.ValidateLogpushOwnershipChallenge(ctx, zoneID, destinationConf, ownershipChallenge, "zone")
+}
 
 // CheckLogpushDestinationExists returns destination exists check result.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-check-destination-exists
-func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
-	uri := fmt.Sprintf("/zones/%s/logpush/validate/destination/exists", zoneID)
+func (api *API) CheckLogpushDestinationExists(ctx context.Context, identifier, destinationConf string, identifierType string) (bool, error) {
+	uri := fmt.Sprintf("/%s/%s/logpush/validate/destination/exists", getRouteRoot(identifierType), identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, LogpushDestinationExistsRequest{
 		DestinationConf: destinationConf,
 	})
@@ -272,4 +334,10 @@ func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, desti
 		return false, errors.Wrap(err, errUnmarshalError)
 	}
 	return r.Result.Exists, nil
+}
+func (api *API) CheckAccountLogpushDestinationExists(ctx context.Context, accountID, destinationConf string) (bool, error) {
+	return api.CheckLogpushDestinationExists(ctx, accountID, destinationConf, "account")
+}
+func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
+	return api.CheckLogpushDestinationExists(ctx, zoneID, destinationConf, "zone")
 }

--- a/logpush.go
+++ b/logpush.go
@@ -122,7 +122,7 @@ func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job Logpush
 // LogpushJobs returns all Logpush Jobs for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-func (api *API) logpushJobs(ctx context.Context, identifierType RouteRoot, identifier string) ([]LogpushJob, error) {
+func (api *API) listLogpushJobs(ctx context.Context, identifierType RouteRoot, identifier string) ([]LogpushJob, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/jobs", identifierType, identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
@@ -136,20 +136,20 @@ func (api *API) logpushJobs(ctx context.Context, identifierType RouteRoot, ident
 	return r.Result, nil
 }
 func (api *API) ListAccountLogpushJobs(ctx context.Context, accountID string) ([]LogpushJob, error) {
-	return api.logpushJobs(ctx, AccountRouteRoot, accountID, job)
+	return api.listLogpushJobs(ctx, AccountRouteRoot, accountID, job)
 }
 func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.logpushJobs(ctx, ZoneRouteRoot, zoneID, job)
+	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
 }
 // Eventually deprecate this
 func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
-	return api.logpushJobs(ctx, ZoneRouteRoot, zoneID, job)
+	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
 }
 
 // LogpushJobsForDataset returns all Logpush Jobs for a dataset in a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
-func (api *API) logpushJobsForDataset(ctx context.Context, identifierType RouteRoot, identifier, dataset string) ([]LogpushJob, error) {
+func (api *API) listLogpushJobsForDataset(ctx context.Context, identifierType RouteRoot, identifier, dataset string) ([]LogpushJob, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/jobs", identifierType, identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
@@ -163,20 +163,20 @@ func (api *API) logpushJobsForDataset(ctx context.Context, identifierType RouteR
 	return r.Result, nil
 }
 func (api *API) ListAccountLogpushJobsForDataset(ctx context.Context, accountID, dataset string) ([]LogpushJob, error) {
-	return api.logpushJobsForDataset(ctx, AccountRouteRoot, accountID, dataset)
+	return api.listLogpushJobsForDataset(ctx, AccountRouteRoot, accountID, dataset)
 }
 func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	return api.logpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
+	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 // Eventually deprecate this
 func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
-	return api.logpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
+	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 
 // LogpushFields returns fields for a given dataset.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
-func (api *API) logpushFields(ctx context.Context, identifierType RouteRoot, identifier, dataset string) (LogpushFields, error) {
+func (api *API) getLogpushFields(ctx context.Context, identifierType RouteRoot, identifier, dataset string) (LogpushFields, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/datasets/%s/fields", identifierType, identifier, dataset)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
@@ -190,20 +190,20 @@ func (api *API) logpushFields(ctx context.Context, identifierType RouteRoot, ide
 	return r.Result, nil
 }
 func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
-	return api.logpushFields(ctx, AccountRouteRoot, accountID, dataset)
+	return api.getLogpushFields(ctx, AccountRouteRoot, accountID, dataset)
 }
 func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	return api.logpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
+	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 // Eventually deprecate this
 func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
-	return api.logpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
+	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 
 // LogpushJob fetches detail about one Logpush Job for a zone.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
-func (api *API) logpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int) (LogpushJob, error) {
+func (api *API) getLogpushJob(ctx context.Context, identifierType RouteRoot, identifier string, jobID int) (LogpushJob, error) {
 	uri := fmt.Sprintf("/%s/%s/logpush/jobs/%d", identifierType, identifier, jobID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
@@ -217,14 +217,14 @@ func (api *API) logpushJob(ctx context.Context, identifierType RouteRoot, identi
 	return r.Result, nil
 }
 func (api *API) GetAccountLogpushJob(ctx context.Context, accountID string, jobID int) (LogpushJob, error) {
-	return api.logpushJob(ctx, AccountRouteRoot, accountID, jobID)
+	return api.getLogpushJob(ctx, AccountRouteRoot, accountID, jobID)
 }
 func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	return api.logpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
+	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 // Eventually deprecate this
 func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
-	return api.logpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
+	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
 
 // UpdateLogpushJob lets you update a Logpush Job.

--- a/logpush.go
+++ b/logpush.go
@@ -108,9 +108,9 @@ func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job Log
 
 // CreateLogpushJob creates a new zone-level Logpush Job.
 //
-// Deprecated: Renamed to CreateZoneLogpushJob.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-create-logpush-job
+//
+// Deprecated: Renamed to CreateZoneLogpushJob.
 func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
 	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
 }
@@ -145,9 +145,9 @@ func (api *API) ListZoneLogpushJobs(ctx context.Context, zoneID string) ([]Logpu
 
 // LogpushJobs returns all zone-level Logpush Jobs for all datasets.
 //
-// Deprecated: Renamed to ListZoneLogpushJobs.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+//
+// Deprecated: Renamed to ListZoneLogpushJobs.
 func (api *API) LogpushJobs(ctx context.Context, zoneID string) ([]LogpushJob, error) {
 	return api.listLogpushJobs(ctx, ZoneRouteRoot, zoneID, job)
 }
@@ -182,9 +182,9 @@ func (api *API) ListZoneLogpushJobsForDataset(ctx context.Context, zoneID, datas
 
 // LogpushJobsForDataset returns all zone-level Logpush Jobs for a dataset.
 //
-// Deprecated: Renamed to ListZoneLogpushJobsForDataset.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs-for-a-dataset
+//
+// Deprecated: Renamed to ListZoneLogpushJobsForDataset.
 func (api *API) LogpushJobsForDataset(ctx context.Context, zoneID, dataset string) ([]LogpushJob, error) {
 	return api.listLogpushJobsForDataset(ctx, ZoneRouteRoot, zoneID, dataset)
 }
@@ -206,6 +206,7 @@ func (api *API) listLogpushJobsForDataset(ctx context.Context, identifierType Ro
 // GetAccountLogpushFields returns fields for a given account-level dataset.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+// Account Fields: https://developers.cloudflare.com/logs/reference/log-fields/account
 func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset string) (LogpushFields, error) {
 	return api.getLogpushFields(ctx, AccountRouteRoot, accountID, dataset)
 }
@@ -213,15 +214,16 @@ func (api *API) GetAccountLogpushFields(ctx context.Context, accountID, dataset 
 // GetZoneLogpushFields returns fields for a given zone-level dataset.
 //
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+// Zone Fields: https://developers.cloudflare.com/logs/reference/log-fields/zone
 func (api *API) GetZoneLogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
 	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
 
 // LogpushFields returns fields for a given dataset.
 //
-// Deprecated: Renamed to GetZoneLogpushFields.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-list-logpush-jobs
+//
+// Deprecated: Renamed to GetZoneLogpushFields.
 func (api *API) LogpushFields(ctx context.Context, zoneID, dataset string) (LogpushFields, error) {
 	return api.getLogpushFields(ctx, ZoneRouteRoot, zoneID, dataset)
 }
@@ -256,9 +258,9 @@ func (api *API) GetZoneLogpushJob(ctx context.Context, zoneID string, jobID int)
 
 // LogpushJob fetches detail about one Logpush Job for a zone.
 //
-// Deprecated: Renamed to GetZoneLogpushJob.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-logpush-job-details
+//
+// Deprecated: Renamed to GetZoneLogpushJob.
 func (api *API) LogpushJob(ctx context.Context, zoneID string, jobID int) (LogpushJob, error) {
 	return api.getLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
@@ -293,9 +295,9 @@ func (api *API) UpdateZoneLogpushJob(ctx context.Context, zoneID string, jobID i
 
 // UpdateLogpushJob lets you update a Logpush Job.
 //
-// Deprecated: Renamed to UpdateZoneLogpushJob.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-update-logpush-job
+//
+// Deprecated: Renamed to UpdateZoneLogpushJob.
 func (api *API) UpdateLogpushJob(ctx context.Context, zoneID string, jobID int, job LogpushJob) error {
 	return api.updateLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID, job)
 }
@@ -330,9 +332,9 @@ func (api *API) DeleteZoneLogpushJob(ctx context.Context, zoneID string, jobID i
 
 // DeleteLogpushJob deletes a Logpush Job for a zone.
 //
-// Deprecated: Renamed to DeleteZoneLogpushJob.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-delete-logpush-job
+//
+// Deprecated: Renamed to DeleteZoneLogpushJob.
 func (api *API) DeleteLogpushJob(ctx context.Context, zoneID string, jobID int) error {
 	return api.deleteLogpushJob(ctx, ZoneRouteRoot, zoneID, jobID)
 }
@@ -367,9 +369,9 @@ func (api *API) GetZoneLogpushOwnershipChallenge(ctx context.Context, zoneID, de
 
 // GetLogpushOwnershipChallenge returns ownership challenge.
 //
-// Deprecated: Renamed to GetZoneLogpushOwnershipChallenge.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-get-ownership-challenge
+//
+// Deprecated: Renamed to GetZoneLogpushOwnershipChallenge.
 func (api *API) GetLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf string) (*LogpushGetOwnershipChallenge, error) {
 	return api.getLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }
@@ -411,9 +413,9 @@ func (api *API) ValidateZoneLogpushOwnershipChallenge(ctx context.Context, zoneI
 
 // ValidateLogpushOwnershipChallenge returns zone-level ownership challenge validation result.
 //
-// Deprecated: Renamed to ValidateZoneLogpushOwnershipChallenge.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-validate-ownership-challenge
+//
+// Deprecated: Renamed to ValidateZoneLogpushOwnershipChallenge.
 func (api *API) ValidateLogpushOwnershipChallenge(ctx context.Context, zoneID, destinationConf, ownershipChallenge string) (bool, error) {
 	return api.validateLogpushOwnershipChallenge(ctx, ZoneRouteRoot, zoneID, destinationConf, ownershipChallenge)
 }
@@ -451,9 +453,9 @@ func (api *API) CheckZoneLogpushDestinationExists(ctx context.Context, zoneID, d
 
 // CheckLogpushDestinationExists returns zone-level destination exists check result.
 //
-// Deprecated: Renamed to CheckZoneLogpushDestinationExists.
-//
 // API reference: https://api.cloudflare.com/#logpush-jobs-check-destination-exists
+//
+// Deprecated: Renamed to CheckZoneLogpushDestinationExists.
 func (api *API) CheckLogpushDestinationExists(ctx context.Context, zoneID, destinationConf string) (bool, error) {
 	return api.checkLogpushDestinationExists(ctx, ZoneRouteRoot, zoneID, destinationConf)
 }

--- a/logpush.go
+++ b/logpush.go
@@ -116,7 +116,7 @@ func (api *API) CreateZoneLogpushJob(ctx context.Context, zoneID string, job Log
 }
 // Eventually deprecate this
 func (api *API) CreateLogpushJob(ctx context.Context, zoneID string, job LogpushJob) (*LogpushJob, error) {
-        return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
+	return api.createLogpushJob(ctx, ZoneRouteRoot, zoneID, job)
 }
 
 // LogpushJobs returns all Logpush Jobs for a zone.

--- a/logpush_example_test.go
+++ b/logpush_example_test.go
@@ -22,7 +22,7 @@ var exampleUpdatedLogpushJob = cloudflare.LogpushJob{
 	DestinationConf: "gs://mybucket/logs",
 }
 
-func ExampleAPI_CreateLogpushJob() {
+func ExampleAPI_CreateZoneLogpushJob() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -33,7 +33,7 @@ func ExampleAPI_CreateLogpushJob() {
 		log.Fatal(err)
 	}
 
-	job, err := api.CreateLogpushJob(context.Background(), zoneID, exampleNewLogpushJob)
+	job, err := api.CreateZoneLogpushJob(context.Background(), zoneID, exampleNewLogpushJob)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func ExampleAPI_CreateLogpushJob() {
 	fmt.Printf("%+v\n", job)
 }
 
-func ExampleAPI_UpdateLogpushJob() {
+func ExampleAPI_UpdateZoneLogpushJob() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -52,13 +52,13 @@ func ExampleAPI_UpdateLogpushJob() {
 		log.Fatal(err)
 	}
 
-	err = api.UpdateLogpushJob(context.Background(), zoneID, 1, exampleUpdatedLogpushJob)
+	err = api.UpdateZoneLogpushJob(context.Background(), zoneID, 1, exampleUpdatedLogpushJob)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
-func ExampleAPI_LogpushJobs() {
+func ExampleAPI_ListZoneLogpushJobs() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -69,7 +69,7 @@ func ExampleAPI_LogpushJobs() {
 		log.Fatal(err)
 	}
 
-	jobs, err := api.LogpushJobs(context.Background(), zoneID)
+	jobs, err := api.ListZoneLogpushJobs(context.Background(), zoneID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func ExampleAPI_LogpushJobs() {
 	}
 }
 
-func ExampleAPI_LogpushJob() {
+func ExampleAPI_GetZoneLogpushJob() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -91,7 +91,7 @@ func ExampleAPI_LogpushJob() {
 		log.Fatal(err)
 	}
 
-	job, err := api.LogpushJob(context.Background(), zoneID, 1)
+	job, err := api.GetZoneLogpushJob(context.Background(), zoneID, 1)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func ExampleAPI_LogpushJob() {
 	fmt.Printf("%+v\n", job)
 }
 
-func ExampleAPI_DeleteLogpushJob() {
+func ExampleAPI_DeleteZoneLogpushJob() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -110,13 +110,13 @@ func ExampleAPI_DeleteLogpushJob() {
 		log.Fatal(err)
 	}
 
-	err = api.DeleteLogpushJob(context.Background(), zoneID, 1)
+	err = api.DeleteZoneLogpushJob(context.Background(), zoneID, 1)
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
-func ExampleAPI_GetLogpushOwnershipChallenge() {
+func ExampleAPI_GetZoneLogpushOwnershipChallenge() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -127,7 +127,7 @@ func ExampleAPI_GetLogpushOwnershipChallenge() {
 		log.Fatal(err)
 	}
 
-	ownershipChallenge, err := api.GetLogpushOwnershipChallenge(context.Background(), zoneID, "destination_conf")
+	ownershipChallenge, err := api.GetZoneLogpushOwnershipChallenge(context.Background(), zoneID, "destination_conf")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func ExampleAPI_GetLogpushOwnershipChallenge() {
 	fmt.Printf("%+v\n", ownershipChallenge)
 }
 
-func ExampleAPI_ValidateLogpushOwnershipChallenge() {
+func ExampleAPI_ValidateZoneLogpushOwnershipChallenge() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -146,7 +146,7 @@ func ExampleAPI_ValidateLogpushOwnershipChallenge() {
 		log.Fatal(err)
 	}
 
-	isValid, err := api.ValidateLogpushOwnershipChallenge(context.Background(), zoneID, "destination_conf", "ownership_challenge")
+	isValid, err := api.ValidateZoneLogpushOwnershipChallenge(context.Background(), zoneID, "destination_conf", "ownership_challenge")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func ExampleAPI_ValidateLogpushOwnershipChallenge() {
 	fmt.Printf("%+v\n", isValid)
 }
 
-func ExampleAPI_CheckLogpushDestinationExists() {
+func ExampleAPI_CheckZoneLogpushDestinationExists() {
 	api, err := cloudflare.New(apiKey, user)
 	if err != nil {
 		log.Fatal(err)
@@ -165,7 +165,7 @@ func ExampleAPI_CheckLogpushDestinationExists() {
 		log.Fatal(err)
 	}
 
-	exists, err := api.CheckLogpushDestinationExists(context.Background(), zoneID, "destination_conf")
+	exists, err := api.CheckZoneLogpushDestinationExists(context.Background(), zoneID, "destination_conf")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -87,7 +87,7 @@ func TestLogpushJobs(t *testing.T) {
 	mux.HandleFunc("/zones/"+testZoneID+"/logpush/jobs", handler)
 	want := []LogpushJob{expectedLogpushJobStruct}
 
-	actual, err := client.LogpushJobs(context.Background(), testZoneID)
+	actual, err := client.ListZoneLogpushJobs(context.Background(), testZoneID)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -112,7 +112,7 @@ func TestGetLogpushJob(t *testing.T) {
 	mux.HandleFunc("/zones/"+testZoneID+"/logpush/jobs/"+strconv.Itoa(jobID), handler)
 	want := expectedLogpushJobStruct
 
-	actual, err := client.LogpushJob(context.Background(), testZoneID, jobID)
+	actual, err := client.GetZoneLogpushJob(context.Background(), testZoneID, jobID)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -143,7 +143,7 @@ func TestCreateLogpushJob(t *testing.T) {
 	mux.HandleFunc("/zones/"+testZoneID+"/logpush/jobs", handler)
 	want := &expectedLogpushJobStruct
 
-	actual, err := client.CreateLogpushJob(context.Background(), testZoneID, newJob)
+	actual, err := client.CreateZoneLogpushJob(context.Background(), testZoneID, newJob)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -195,7 +195,7 @@ func TestDeleteLogpushJob(t *testing.T) {
 
 	mux.HandleFunc("/zones/"+testZoneID+"/logpush/jobs/"+strconv.Itoa(jobID), handler)
 
-	err := client.DeleteLogpushJob(context.Background(), testZoneID, jobID)
+	err := client.DeleteZoneLogpushJob(context.Background(), testZoneID, jobID)
 	assert.NoError(t, err)
 }
 
@@ -219,7 +219,7 @@ func TestGetLogpushOwnershipChallenge(t *testing.T) {
 
 	want := &expectedLogpushGetOwnershipChallengeStruct
 
-	actual, err := client.GetLogpushOwnershipChallenge(context.Background(), testZoneID, "destination_conf")
+	actual, err := client.GetZoneLogpushOwnershipChallenge(context.Background(), testZoneID, "destination_conf")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -242,7 +242,7 @@ func TestGetLogpushOwnershipChallengeWithInvalidResponse(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/"+testZoneID+"/logpush/ownership", handler)
-	_, err := client.GetLogpushOwnershipChallenge(context.Background(), testZoneID, "destination_conf")
+	_, err := client.GetZoneLogpushOwnershipChallenge(context.Background(), testZoneID, "destination_conf")
 
 	assert.Error(t, err)
 }
@@ -280,7 +280,7 @@ func TestValidateLogpushOwnershipChallenge(t *testing.T) {
 
 			mux.HandleFunc("/zones/"+testZoneID+"/logpush/ownership/validate", handler)
 
-			actual, err := client.ValidateLogpushOwnershipChallenge(context.Background(), testZoneID, "destination_conf", "ownership_challenge")
+			actual, err := client.ValidateZoneLogpushOwnershipChallenge(context.Background(), testZoneID, "destination_conf", "ownership_challenge")
 			if assert.NoError(t, err) {
 				assert.Equal(t, tc.isValid, actual)
 			}
@@ -321,7 +321,7 @@ func TestCheckLogpushDestinationExists(t *testing.T) {
 
 			mux.HandleFunc("/zones/"+testZoneID+"/logpush/validate/destination/exists", handler)
 
-			actual, err := client.CheckLogpushDestinationExists(context.Background(), testZoneID, "destination_conf")
+			actual, err := client.CheckZoneLogpushDestinationExists(context.Background(), testZoneID, "destination_conf")
 			if assert.NoError(t, err) {
 				assert.Equal(t, tc.exists, actual)
 			}


### PR DESCRIPTION
## Description

This closes #750 and changes the logpush functions to use zone and account-specific function names that each take either the zoneID or accountID as an argument.  The previous names remain for compatibility and a deprecation message has been added to their log comment, pointing folks to the new zone-specific names.

## Has your change been tested?

No additional tests have been created.  I've renamed the existing logpush functions and marked the old names as deprecated in the log comments.  I still need to update the tests to test the account-level additions.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
