### PR TITLE
Deprecate virtualdns.go in favor of dns_firewall.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The current feature list includes:
 * [x] [Railgun](https://www.cloudflare.com/railgun/) administration
 * [x] Rate Limiting
 * [x] User Administration (partial)
-* [x] Virtual DNS Management
+* [x] DNS Firewall
 * [x] Web Application Firewall (WAF)
 * [x] Zone Lockdown and User-Agent Block rules
 * [x] Zones

--- a/dns_firewall.go
+++ b/dns_firewall.go
@@ -1,0 +1,197 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// DNSFirewallCluster represents a DNS Firewall configuration.
+type DNSFirewallCluster struct {
+	ID                   string   `json:"id,omitempty"`
+	Name                 string   `json:"name"`
+	OriginIPs            []string `json:"origin_ips"`
+	DNSFirewallIPs       []string `json:"dns_firewall_ips,omitempty"`
+	MinimumCacheTTL      uint     `json:"minimum_cache_ttl,omitempty"`
+	MaximumCacheTTL      uint     `json:"maximum_cache_ttl,omitempty"`
+	DeprecateAnyRequests bool     `json:"deprecate_any_requests"`
+	ModifiedOn           string   `json:"modified_on,omitempty"`
+}
+
+// DNSFirewallAnalyticsMetrics represents a group of aggregated DNS Firewall metrics.
+type DNSFirewallAnalyticsMetrics struct {
+	QueryCount         *int64   `json:"queryCount"`
+	UncachedCount      *int64   `json:"uncachedCount"`
+	StaleCount         *int64   `json:"staleCount"`
+	ResponseTimeAvg    *float64 `json:"responseTimeAvg"`
+	ResponseTimeMedian *float64 `json:"responseTimeMedian"`
+	ResponseTime90th   *float64 `json:"responseTime90th"`
+	ResponseTime99th   *float64 `json:"responseTime99th"`
+}
+
+// DNSFirewallAnalytics represents a set of aggregated DNS Firewall metrics.
+// TODO: Add the queried data and not only the aggregated values.
+type DNSFirewallAnalytics struct {
+	Totals DNSFirewallAnalyticsMetrics `json:"totals"`
+	Min    DNSFirewallAnalyticsMetrics `json:"min"`
+	Max    DNSFirewallAnalyticsMetrics `json:"max"`
+}
+
+// DNSFirewallUserAnalyticsOptions represents range and dimension selection on analytics endpoint
+type DNSFirewallUserAnalyticsOptions struct {
+	Metrics []string
+	Since   *time.Time
+	Until   *time.Time
+}
+
+// dnsFirewallResponse represents a DNS Firewall response.
+type dnsFirewallResponse struct {
+	Response
+	Result *DNSFirewallCluster `json:"result"`
+}
+
+// dnsFirewallListResponse represents an array of DNS Firewall responses.
+type dnsFirewallListResponse struct {
+	Response
+	Result []*DNSFirewallCluster `json:"result"`
+}
+
+// dnsFirewallAnalyticsResponse represents a DNS Firewall analytics response.
+type dnsFirewallAnalyticsResponse struct {
+	Response
+	Result DNSFirewallAnalytics `json:"result"`
+}
+
+// CreateDNSFirewallCluster creates a new DNS Firewall cluster.
+//
+// API reference: https://api.cloudflare.com/#dns-firewall-create-dns-firewall-cluster
+func (api *API) CreateDNSFirewallCluster(ctx context.Context, v DNSFirewallCluster) (*DNSFirewallCluster, error) {
+	uri := fmt.Sprintf("%s/dns_firewall", api.userBaseURL("/user"))
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, v)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &dnsFirewallResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// DNSFirewallCluster fetches a single DNS Firewall cluster.
+//
+// API reference: https://api.cloudflare.com/#dns-firewall-dns-firewall-cluster-details
+func (api *API) DNSFirewallCluster(ctx context.Context, clusterID string) (*DNSFirewallCluster, error) {
+	uri := fmt.Sprintf("%s/dns_firewall/%s", api.userBaseURL("/user"), clusterID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &dnsFirewallResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// ListDNSFirewallClusters lists the DNS Firewall clusters associated with an account.
+//
+// API reference: https://api.cloudflare.com/#dns-firewall-list-dns-firewall-clusters
+func (api *API) ListDNSFirewallClusters(ctx context.Context) ([]*DNSFirewallCluster, error) {
+	uri := fmt.Sprintf("%s/dns_firewall", api.userBaseURL("/user"))
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &dnsFirewallListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// UpdateDNSFirewallCluster updates a DNS Firewall cluster.
+//
+// API reference: https://api.cloudflare.com/#dns-firewall-update-dns-firewall-cluster
+func (api *API) UpdateDNSFirewallCluster(ctx context.Context, clusterID string, vv DNSFirewallCluster) error {
+	uri := fmt.Sprintf("%s/dns_firewall/%s", api.userBaseURL("/user"), clusterID)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, vv)
+	if err != nil {
+		return err
+	}
+
+	response := &dnsFirewallResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}
+
+// DeleteDNSFirewallCluster deletes a DNS Firewall cluster. Note that this cannot be
+// undone, and will stop all traffic to that cluster.
+//
+// API reference: https://api.cloudflare.com/#dns-firewall-delete-dns-firewall-cluster
+func (api *API) DeleteDNSFirewallCluster(ctx context.Context, clusterID string) error {
+	uri := fmt.Sprintf("%s/dns_firewall/%s", api.userBaseURL("/user"), clusterID)
+	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+
+	response := &dnsFirewallResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}
+
+// encode encodes non-nil fields into URL encoded form.
+func (o DNSFirewallUserAnalyticsOptions) encode() string {
+	v := url.Values{}
+	if o.Since != nil {
+		v.Set("since", (*o.Since).UTC().Format(time.RFC3339))
+	}
+	if o.Until != nil {
+		v.Set("until", (*o.Until).UTC().Format(time.RFC3339))
+	}
+	if o.Metrics != nil {
+		v.Set("metrics", strings.Join(o.Metrics, ","))
+	}
+	return v.Encode()
+}
+
+// DNSFirewallUserAnalytics retrieves analytics report for a specified dimension and time range
+func (api *API) DNSFirewallUserAnalytics(ctx context.Context, clusterID string, o DNSFirewallUserAnalyticsOptions) (DNSFirewallAnalytics, error) {
+	uri := fmt.Sprintf("%s/dns_firewall/%s/dns_analytics/report?%s", api.userBaseURL("/user"), clusterID, o.encode())
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return DNSFirewallAnalytics{}, err
+	}
+
+	response := dnsFirewallAnalyticsResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return DNSFirewallAnalytics{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}

--- a/dns_firewall_test.go
+++ b/dns_firewall_test.go
@@ -10,7 +10,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVirtualDNSUserAnalytics(t *testing.T) {
+func float64Ptr(v float64) *float64 {
+	return &v
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+func TestDNSFirewallUserAnalytics(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -46,8 +54,8 @@ func TestVirtualDNSUserAnalytics(t *testing.T) {
 	}
 
 	mux.HandleFunc("/user/dns_firewall/12345/dns_analytics/report", handler)
-	want := VirtualDNSAnalytics{
-		Totals: VirtualDNSAnalyticsMetrics{
+	want := DNSFirewallAnalytics{
+		Totals: DNSFirewallAnalyticsMetrics{
 			QueryCount:         int64Ptr(5),
 			UncachedCount:      int64Ptr(6),
 			StaleCount:         int64Ptr(7),
@@ -58,7 +66,7 @@ func TestVirtualDNSUserAnalytics(t *testing.T) {
 		},
 	}
 
-	params := VirtualDNSUserAnalyticsOptions{
+	params := DNSFirewallUserAnalyticsOptions{
 		Metrics: []string{
 			"queryCount",
 			"uncachedCount",
@@ -71,7 +79,7 @@ func TestVirtualDNSUserAnalytics(t *testing.T) {
 		Since: &since,
 		Until: &until,
 	}
-	actual, err := client.VirtualDNSUserAnalytics(context.Background(), "12345", params)
+	actual, err := client.DNSFirewallUserAnalytics(context.Background(), "12345", params)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}

--- a/virtualdns.go
+++ b/virtualdns.go
@@ -2,17 +2,14 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
-	"strings"
-	"time"
-
-	"github.com/pkg/errors"
 )
 
+// NOTE: Everything in this file is deprecated. See `dns_firewall.go` instead.
+
 // VirtualDNS represents a Virtual DNS configuration.
+//
+// Deprecated: Use DNSFirewallCluster instead.
 type VirtualDNS struct {
 	ID                   string   `json:"id"`
 	Name                 string   `json:"name"`
@@ -25,18 +22,13 @@ type VirtualDNS struct {
 }
 
 // VirtualDNSAnalyticsMetrics represents a group of aggregated Virtual DNS metrics.
-type VirtualDNSAnalyticsMetrics struct {
-	QueryCount         *int64   `json:"queryCount"`
-	UncachedCount      *int64   `json:"uncachedCount"`
-	StaleCount         *int64   `json:"staleCount"`
-	ResponseTimeAvg    *float64 `json:"responseTimeAvg"`
-	ResponseTimeMedian *float64 `json:"responseTimeMedian"`
-	ResponseTime90th   *float64 `json:"responseTime90th"`
-	ResponseTime99th   *float64 `json:"responseTime99th"`
-}
+//
+// Deprecated: Use DNSFirewallAnalyticsMetrics instead.
+type VirtualDNSAnalyticsMetrics DNSFirewallAnalyticsMetrics
 
 // VirtualDNSAnalytics represents a set of aggregated Virtual DNS metrics.
-// TODO: Add the queried data and not only the aggregated values.
+//
+// Deprecated: Use DNSFirewallAnalytics instead.
 type VirtualDNSAnalytics struct {
 	Totals VirtualDNSAnalyticsMetrics `json:"totals"`
 	Min    VirtualDNSAnalyticsMetrics `json:"min"`
@@ -44,25 +36,29 @@ type VirtualDNSAnalytics struct {
 }
 
 // VirtualDNSUserAnalyticsOptions represents range and dimension selection on analytics endpoint
-type VirtualDNSUserAnalyticsOptions struct {
-	Metrics []string
-	Since   *time.Time
-	Until   *time.Time
-}
+//
+// Deprecated: Use DNSFirewallUserAnalyticsOptions instead.
+type VirtualDNSUserAnalyticsOptions DNSFirewallUserAnalyticsOptions
 
 // VirtualDNSResponse represents a Virtual DNS response.
+//
+// Deprecated: This internal type will be removed in the future.
 type VirtualDNSResponse struct {
 	Response
 	Result *VirtualDNS `json:"result"`
 }
 
 // VirtualDNSListResponse represents an array of Virtual DNS responses.
+//
+// Deprecated: This internal type will be removed in the future.
 type VirtualDNSListResponse struct {
 	Response
 	Result []*VirtualDNS `json:"result"`
 }
 
 // VirtualDNSAnalyticsResponse represents a Virtual DNS analytics response.
+//
+// Deprecated: This internal type will be removed in the future.
 type VirtualDNSAnalyticsResponse struct {
 	Response
 	Result VirtualDNSAnalytics `json:"result"`
@@ -70,128 +66,100 @@ type VirtualDNSAnalyticsResponse struct {
 
 // CreateVirtualDNS creates a new Virtual DNS cluster.
 //
-// API reference: https://api.cloudflare.com/#virtual-dns-users--create-a-virtual-dns-cluster
+// Deprecated: Use CreateDNSFirewallCluster instead.
 func (api *API) CreateVirtualDNS(ctx context.Context, v *VirtualDNS) (*VirtualDNS, error) {
-	uri := fmt.Sprintf("%s/virtual_dns", api.userBaseURL("/user"))
-	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, v)
-	if err != nil {
-		return nil, err
+	if v == nil {
+		return nil, fmt.Errorf("cluster must not be nil")
 	}
 
-	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
-	if err != nil {
-		return nil, errors.Wrap(err, errUnmarshalError)
-	}
-
-	return response.Result, nil
+	res, err := api.CreateDNSFirewallCluster(ctx, v.vdnsUpgrade())
+	return res.vdnsDowngrade(), err
 }
 
 // VirtualDNS fetches a single virtual DNS cluster.
 //
-// API reference: https://api.cloudflare.com/#virtual-dns-users--get-a-virtual-dns-cluster
+// Deprecated: Use DNSFirewallCluster instead.
 func (api *API) VirtualDNS(ctx context.Context, virtualDNSID string) (*VirtualDNS, error) {
-	uri := fmt.Sprintf("%s/virtual_dns/%s", api.userBaseURL("/user"), virtualDNSID)
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
-	if err != nil {
-		return nil, errors.Wrap(err, errUnmarshalError)
-	}
-
-	return response.Result, nil
+	res, err := api.DNSFirewallCluster(ctx, virtualDNSID)
+	return res.vdnsDowngrade(), err
 }
 
 // ListVirtualDNS lists the virtual DNS clusters associated with an account.
 //
-// API reference: https://api.cloudflare.com/#virtual-dns-users--get-virtual-dns-clusters
+// Deprecated: Use ListDNSFirewallClusters instead.
 func (api *API) ListVirtualDNS(ctx context.Context) ([]*VirtualDNS, error) {
-	uri := fmt.Sprintf("%s/virtual_dns", api.userBaseURL("/user"))
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
+	res, err := api.ListDNSFirewallClusters(ctx)
+	if res == nil {
 		return nil, err
 	}
 
-	response := &VirtualDNSListResponse{}
-	err = json.Unmarshal(res, &response)
-	if err != nil {
-		return nil, errors.Wrap(err, errUnmarshalError)
+	clusters := make([]*VirtualDNS, 0, len(res))
+	for _, cluster := range res {
+		clusters = append(clusters, cluster.vdnsDowngrade())
 	}
 
-	return response.Result, nil
+	return clusters, err
 }
 
 // UpdateVirtualDNS updates a Virtual DNS cluster.
 //
-// API reference: https://api.cloudflare.com/#virtual-dns-users--modify-a-virtual-dns-cluster
+// Deprecated: Use UpdateDNSFirewallCluster instead.
 func (api *API) UpdateVirtualDNS(ctx context.Context, virtualDNSID string, vv VirtualDNS) error {
-	uri := fmt.Sprintf("%s/virtual_dns/%s", api.userBaseURL("/user"), virtualDNSID)
-	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, vv)
-	if err != nil {
-		return err
-	}
-
-	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
-	if err != nil {
-		return errors.Wrap(err, errUnmarshalError)
-	}
-
-	return nil
+	return api.UpdateDNSFirewallCluster(ctx, virtualDNSID, vv.vdnsUpgrade())
 }
 
 // DeleteVirtualDNS deletes a Virtual DNS cluster. Note that this cannot be
 // undone, and will stop all traffic to that cluster.
 //
-// API reference: https://api.cloudflare.com/#virtual-dns-users--delete-a-virtual-dns-cluster
+// Deprecated: Use DeleteDNSFirewallCluster instead.
 func (api *API) DeleteVirtualDNS(ctx context.Context, virtualDNSID string) error {
-	uri := fmt.Sprintf("%s/virtual_dns/%s", api.userBaseURL("/user"), virtualDNSID)
-	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
-	if err != nil {
-		return err
-	}
-
-	response := &VirtualDNSResponse{}
-	err = json.Unmarshal(res, &response)
-	if err != nil {
-		return errors.Wrap(err, errUnmarshalError)
-	}
-
-	return nil
-}
-
-// encode encodes non-nil fields into URL encoded form.
-func (o VirtualDNSUserAnalyticsOptions) encode() string {
-	v := url.Values{}
-	if o.Since != nil {
-		v.Set("since", (*o.Since).UTC().Format(time.RFC3339))
-	}
-	if o.Until != nil {
-		v.Set("until", (*o.Until).UTC().Format(time.RFC3339))
-	}
-	if o.Metrics != nil {
-		v.Set("metrics", strings.Join(o.Metrics, ","))
-	}
-	return v.Encode()
+	return api.DeleteDNSFirewallCluster(ctx, virtualDNSID)
 }
 
 // VirtualDNSUserAnalytics retrieves analytics report for a specified dimension and time range
+//
+// Deprecated: Use DNSFirewallUserAnalytics instead.
 func (api *API) VirtualDNSUserAnalytics(ctx context.Context, virtualDNSID string, o VirtualDNSUserAnalyticsOptions) (VirtualDNSAnalytics, error) {
-	uri := fmt.Sprintf("%s/virtual_dns/%s/dns_analytics/report?%s", api.userBaseURL("/user"), virtualDNSID, o.encode())
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return VirtualDNSAnalytics{}, err
+	res, err := api.DNSFirewallUserAnalytics(ctx, virtualDNSID, DNSFirewallUserAnalyticsOptions(o))
+	return res.vdnsDowngrade(), err
+}
+
+// --- Compatibility helper functions ---
+
+func (v VirtualDNS) vdnsUpgrade() DNSFirewallCluster {
+	return DNSFirewallCluster{
+		ID:                   v.ID,
+		Name:                 v.Name,
+		OriginIPs:            v.OriginIPs,
+		DNSFirewallIPs:       v.VirtualDNSIPs,
+		MinimumCacheTTL:      v.MinimumCacheTTL,
+		MaximumCacheTTL:      v.MaximumCacheTTL,
+		DeprecateAnyRequests: v.DeprecateAnyRequests,
+		ModifiedOn:           v.ModifiedOn,
+	}
+}
+
+func (v *DNSFirewallCluster) vdnsDowngrade() *VirtualDNS {
+	if v == nil {
+		return nil
 	}
 
-	response := VirtualDNSAnalyticsResponse{}
-	err = json.Unmarshal(res, &response)
-	if err != nil {
-		return VirtualDNSAnalytics{}, errors.Wrap(err, errUnmarshalError)
+	return &VirtualDNS{
+		ID:                   v.ID,
+		Name:                 v.Name,
+		OriginIPs:            v.OriginIPs,
+		VirtualDNSIPs:        v.DNSFirewallIPs,
+		MinimumCacheTTL:      v.MinimumCacheTTL,
+		MaximumCacheTTL:      v.MaximumCacheTTL,
+		DeprecateAnyRequests: v.DeprecateAnyRequests,
+		ModifiedOn:           v.ModifiedOn,
 	}
+}
 
-	return response.Result, nil
+func (v DNSFirewallAnalytics) vdnsDowngrade() VirtualDNSAnalytics {
+	return VirtualDNSAnalytics{
+		Totals: VirtualDNSAnalyticsMetrics(v.Totals),
+		Min:    VirtualDNSAnalyticsMetrics(v.Min),
+		Max:    VirtualDNSAnalyticsMetrics(v.Max),
+	}
 }


### PR DESCRIPTION
## Description

This adds new types and functions for the DNS Firewall and DNS Firewall Analytics API to `dns_firewall.go`, deprecating `virtual_dns.go`

For compatibility, the functions in `virtual_dns.go` are now wrappers around the functions in `dns_firewall.go`. This means that we now always use the new routes, even when one of the deprecated functions is called.

In addition to replacing "Virtual DNS" with "DNS Firewall", a few minor changes were also made to names and function signatures.

Finally, the new DNS Firewall equivalents of the following functions are no longer exported:

- VirtualDNSResponse
- VirtualDNSListResponse
- VirtualDNSAnalyticsResponse

## Context

DNS Firewall was previously known as Virtual DNS. The virtual_dns routes were recently deprecated in favor of (similar) dns_firewall routes.

## Has your change been tested?

Yes, tests were copied from virtualdns.go with only minor changes.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/