### PR TITLE
Fixing type for dns_server field

### DIFF
--- a/fallback_domain.go
+++ b/fallback_domain.go
@@ -18,9 +18,9 @@ type FallbackDomainResponse struct {
 
 // FallbackDomain represents the individual domain struct.
 type FallbackDomain struct {
-	Suffix       string `json:"suffix,omitempty"`
-	Description  string `json:"description,omitempty"`
-	DNSServer    string `json:"dns_server,omitempty"`
+	Suffix       string   `json:"suffix,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	DNSServer    []string `json:"dns_server,omitempty"`
 }
 
 // ListFallbackDomains returns all fallback domains within an account.

--- a/fallback_domain_test.go
+++ b/fallback_domain_test.go
@@ -61,7 +61,7 @@ func TestFallbackDomainDNSServer(t *testing.T) {
         {
           "suffix": "example.com",
           "description": "Domain bypass for local development",
-					"dns_server": "['192.168.0.1', '10.1.1.1']"
+					"dns_server": ["192.168.0.1", "10.1.1.1"]
        }
       ]
     }
@@ -71,7 +71,7 @@ func TestFallbackDomainDNSServer(t *testing.T) {
 	want := []FallbackDomain{{
 		Suffix:        "example.com",
 		Description:   "Domain bypass for local development",
-		DNSServer:     "['192.168.0.1', '10.1.1.1']",
+		DNSServer:     []string{"192.168.0.1", "10.1.1.1"},
 	}}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/devices/policy/fallback_domains", handler)
@@ -99,7 +99,7 @@ func TestUpdateFallbackDomain(t *testing.T) {
         {
           "suffix": "example_one.com",
           "description": "example one",
-					"dns_server": "['192.168.0.1', '10.1.1.1']"
+					"dns_server": ["192.168.0.1", "10.1.1.1"]
        },
        {
           "suffix": "example_two.com",
@@ -118,7 +118,7 @@ func TestUpdateFallbackDomain(t *testing.T) {
 		{
 			Suffix:      "example_one.com",
 			Description: "example one",
-			DNSServer:   "['192.168.0.1', '10.1.1.1']",
+			DNSServer:   []string{"192.168.0.1", "10.1.1.1"},
 		},
 		{
 			Suffix:      "example_two.com",


### PR DESCRIPTION
Fixing the type for the dns_server field in fallback domains. It accepts a list of strings, and not just a string. 

## Has your change been tested?

Fixed unit tests. 

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
