### PR TITLE
README.md: add NewWithAPIToken usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ func main() {
 	// Construct a new API object with API KEY
 	api, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_API_EMAIL"))
 	// alternatively, you can use a scoped API token
-	// 
 	// api, err := cloudflare.NewWithAPIToken(os.Getenv("CLOUDFLARE_API_TOKEN"))
 	if err != nil {
 		log.Fatal(err)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ import (
 )
 
 func main() {
-	// Construct a new API object with API KEY
+	// Construct a new API object using a global API key
 	api, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_API_EMAIL"))
 	// alternatively, you can use a scoped API token
 	// api, err := cloudflare.NewWithAPIToken(os.Getenv("CLOUDFLARE_API_TOKEN"))

--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ import (
 )
 
 func main() {
-	// Construct a new API object
+	// Construct a new API object with API KEY
 	api, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_API_EMAIL"))
+	// alternatively, you can use an API TOKEN
+	//api, err := cloudflare.NewWithAPIToken(os.Getenv("CLOUDFLARE_API_TOKEN"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ import (
 func main() {
 	// Construct a new API object with API KEY
 	api, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_API_EMAIL"))
-	// alternatively, you can use an API TOKEN
-	//api, err := cloudflare.NewWithAPIToken(os.Getenv("CLOUDFLARE_API_TOKEN"))
+	// alternatively, you can use a scoped API token
+	// 
+	// api, err := cloudflare.NewWithAPIToken(os.Getenv("CLOUDFLARE_API_TOKEN"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
There are two ways to create an API client:
- `cloudflare.New(apiKey, apiEmail)` 
- `cloudflare.NewWithAPIToken(apiToken)`

Using one mistakenly as the other fails without a helpful log:
```
ListZonesContext command failed: HTTP status 400: Invalid request headers (6003)
``` 

## Description

All I did was add `NewWithAPIToken` to README.md to add visibility. Would've saved me some time, and is probably useful for others encountering this first time as well.
