### PR TITLE
Propagate Context in Workers KV methods

### DIFF
--- a/workers_kv.go
+++ b/workers_kv.go
@@ -171,8 +171,8 @@ func (api *API) UpdateWorkersKVNamespace(ctx context.Context, namespaceID string
 func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, value []byte) (Response, error) {
 	key = url.PathEscape(key)
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/values/%s", api.AccountID, namespaceID, key)
-	res, err := api.makeRequestWithHeaders(
-		http.MethodPut, uri, value, http.Header{"Content-Type": []string{"application/octet-stream"}},
+	res, err := api.makeRequestContextWithHeaders(
+		ctx, http.MethodPut, uri, value, http.Header{"Content-Type": []string{"application/octet-stream"}},
 	)
 	if err != nil {
 		return Response{}, err
@@ -191,8 +191,8 @@ func (api *API) WriteWorkersKV(ctx context.Context, namespaceID, key string, val
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-write-multiple-key-value-pairs
 func (api *API) WriteWorkersKVBulk(ctx context.Context, namespaceID string, kvs WorkersKVBulkWriteRequest) (Response, error) {
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk", api.AccountID, namespaceID)
-	res, err := api.makeRequestWithHeaders(
-		http.MethodPut, uri, kvs, http.Header{"Content-Type": []string{"application/json"}},
+	res, err := api.makeRequestContextWithHeaders(
+		ctx, http.MethodPut, uri, kvs, http.Header{"Content-Type": []string{"application/json"}},
 	)
 	if err != nil {
 		return Response{}, err
@@ -242,8 +242,8 @@ func (api API) DeleteWorkersKV(ctx context.Context, namespaceID, key string) (Re
 // API reference: https://api.cloudflare.com/#workers-kv-namespace-delete-multiple-key-value-pairs
 func (api *API) DeleteWorkersKVBulk(ctx context.Context, namespaceID string, keys []string) (Response, error) {
 	uri := fmt.Sprintf("/accounts/%s/storage/kv/namespaces/%s/bulk", api.AccountID, namespaceID)
-	res, err := api.makeRequestWithHeaders(
-		http.MethodDelete, uri, keys, http.Header{"Content-Type": []string{"application/json"}},
+	res, err := api.makeRequestContextWithHeaders(
+		ctx, http.MethodDelete, uri, keys, http.Header{"Content-Type": []string{"application/json"}},
 	)
 	if err != nil {
 		return Response{}, err


### PR DESCRIPTION
Update the `WriteWorkersKV`, `WriteWorkersKVBulk`, and `DeleteWorkersKVBulk` methods to pass the provided Context to the helper method that makes the HTTP request. Before this change, the Context provided as an argument to these methods was ignored, and a new, empty context was created and used for the HTTP request.

## Description

Replace calls to `makeRequestWithHeaders` with calls to `makeRequestContextWithHeaders` and include the provided Context. Before this change, `makeRequestWithHeaders` would create a new, empty context that would be used for the HTTP request. This is unexpected because all other methods for Workers KV use the provided Context for the HTTP request (by common convention), and in these three cases the caller is unable to control the HTTP request using the provided Context.

## Has your change been tested?

Yes, I wrote some unit tests to verify the changes, but did not include them in the PR since this behavior is not tested in other methods that use Context. In these tests, I created a Cloudflare API client that used an HTTP client that used a transport implementation that recorded the Context of the outbound request, and checked that a customized Context provided to these methods made it through to the actual HTTP request.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
