### PR TITLE
Replace hard coded per_page parameter on DNS API with default

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -94,8 +94,7 @@ func (api *API) CreateDNSRecord(ctx context.Context, zoneID string, rr DNSRecord
 func (api *API) DNSRecords(ctx context.Context, zoneID string, rr DNSRecord) ([]DNSRecord, error) {
 	// Construct a query string
 	v := url.Values{}
-	// Request as many records as possible per page - API max is 100
-	v.Set("per_page", "100")
+	// Using default per_page value as specified by the API
 	if rr.Name != "" {
 		v.Set("name", toUTS46ASCII(rr.Name))
 	}

--- a/dns_test.go
+++ b/dns_test.go
@@ -169,7 +169,6 @@ func TestDNSRecords(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		assert.Equal(t, "100", r.URL.Query().Get("per_page"))
 		assert.Equal(t, asciiInput.Name, r.URL.Query().Get("name"))
 		assert.Equal(t, asciiInput.Type, r.URL.Query().Get("type"))
 		assert.Equal(t, asciiInput.Content, r.URL.Query().Get("content"))


### PR DESCRIPTION
## Description
The API has increased its limit to 5000 therefore its easier for both client
and server to grab as many records as possible per query. This may change in the future
and therefore we should just use default.

https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records

## Has your change been tested?

Yes, we queried the API with this variable removed and verified that it indeed used the default value.
