### PR TITLE
GATE-2293 added teams udp config

### DIFF
--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -95,6 +95,16 @@ type TeamsLoggingSettings struct {
 	RedactPii                 bool                                               `json:"redact_pii,omitempty"`
 }
 
+type TeamsDeviceSettings struct {
+	GatewayProxyEnabled    bool `json:"gateway_proxy_enabled"`
+	GatewayProxyUDPEnabled bool `json:"gateway_udp_proxy_enabled"`
+}
+
+type TeamsDeviceSettingsResponse struct {
+	Response
+	Result TeamsDeviceSettings `json:"result"`
+}
+
 type TeamsLoggingSettingsResponse struct {
 	Response
 	Result TeamsLoggingSettings `json:"result"`
@@ -138,6 +148,26 @@ func (api *API) TeamsAccountConfiguration(ctx context.Context, accountID string)
 	}
 
 	return teamsConfigResponse.Result, nil
+}
+
+// TeamsAccountDeviceConfiguration returns teams account device configuration with udp status.
+//
+// API reference: TBA.
+func (api *API) TeamsAccountDeviceConfiguration(ctx context.Context, accountID string) (TeamsDeviceSettings, error) {
+	uri := fmt.Sprintf("/accounts/%s/devices/settings", accountID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return TeamsDeviceSettings{}, err
+	}
+
+	var teamsDeviceResponse TeamsDeviceSettingsResponse
+	err = json.Unmarshal(res, &teamsDeviceResponse)
+	if err != nil {
+		return TeamsDeviceSettings{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return teamsDeviceResponse.Result, nil
 }
 
 // TeamsAccountLoggingConfiguration returns teams account logging configuration.
@@ -198,4 +228,24 @@ func (api *API) TeamsAccountUpdateLoggingConfiguration(ctx context.Context, acco
 	}
 
 	return teamsConfigResponse.Result, nil
+}
+
+// TeamsAccountDeviceUpdateConfiguration updates teams account device configuration including udp filtering status.
+//
+// API reference: TBA.
+func (api *API) TeamsAccountDeviceUpdateConfiguration(ctx context.Context, accountID string, settings TeamsDeviceSettings) (TeamsDeviceSettings, error) {
+	uri := fmt.Sprintf("/accounts/%s/devices/settings", accountID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, settings)
+	if err != nil {
+		return TeamsDeviceSettings{}, err
+	}
+
+	var teamsDeviceResponse TeamsDeviceSettingsResponse
+	err = json.Unmarshal(res, &teamsDeviceResponse)
+	if err != nil {
+		return TeamsDeviceSettings{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return teamsDeviceResponse.Result, nil
 }

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -204,3 +204,60 @@ func TestTeamsAccountUpdateLoggingConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestTeamsAccountGetDeviceConfiguration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {"gateway_proxy_enabled": true,"gateway_udp_proxy_enabled":false}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/devices/settings", handler)
+
+	actual, err := client.TeamsAccountDeviceConfiguration(context.Background(), testAccountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, actual, TeamsDeviceSettings{
+			GatewayProxyEnabled:    true,
+			GatewayProxyUDPEnabled: false,
+		})
+	}
+}
+
+func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {"gateway_proxy_enabled": true,"gateway_udp_proxy_enabled":true}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/devices/settings", handler)
+
+	actual, err := client.TeamsAccountDeviceUpdateConfiguration(context.Background(), testAccountID, TeamsDeviceSettings{
+		GatewayProxyUDPEnabled: true,
+		GatewayProxyEnabled:    true,
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, actual, TeamsDeviceSettings{
+			GatewayProxyEnabled:    true,
+			GatewayProxyUDPEnabled: true,
+		})
+	}
+}


### PR DESCRIPTION
Missed an additional set of config to make UDP filtering configurable. Added here in the PR and shouldn't break any existing changes.

I will add this to the Cloudflare public API documentation with the rest and update the URL here shortly