### PR TITLE
re-order structs for memory allocation savings

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -26,27 +26,27 @@ const (
 
 // AccessApplication represents an Access application.
 type AccessApplication struct {
-	ID                      string                         `json:"id,omitempty"`
-	CreatedAt               *time.Time                     `json:"created_at,omitempty"`
-	UpdatedAt               *time.Time                     `json:"updated_at,omitempty"`
+	GatewayRules            []AccessApplicationGatewayRule `json:"gateway_rules,omitempty"`
+	AllowedIdps             []string                       `json:"allowed_idps,omitempty"`
+	CustomDenyMessage       string                         `json:"custom_deny_message,omitempty"`
+	LogoURL                 string                         `json:"logo_url,omitempty"`
 	AUD                     string                         `json:"aud,omitempty"`
-	Name                    string                         `json:"name"`
 	Domain                  string                         `json:"domain"`
 	Type                    AccessApplicationType          `json:"type,omitempty"`
 	SessionDuration         string                         `json:"session_duration,omitempty"`
-	AutoRedirectToIdentity  bool                           `json:"auto_redirect_to_identity,omitempty"`
-	EnableBindingCookie     bool                           `json:"enable_binding_cookie,omitempty"`
-	AllowedIdps             []string                       `json:"allowed_idps,omitempty"`
-	CorsHeaders             *AccessApplicationCorsHeaders  `json:"cors_headers,omitempty"`
-	CustomDenyMessage       string                         `json:"custom_deny_message,omitempty"`
-	CustomDenyURL           string                         `json:"custom_deny_url,omitempty"`
-	HttpOnlyCookieAttribute bool                           `json:"http_only_cookie_attribute,omitempty"`
 	SameSiteCookieAttribute string                         `json:"same_site_cookie_attribute,omitempty"`
-	LogoURL                 string                         `json:"logo_url,omitempty"`
+	CustomDenyURL           string                         `json:"custom_deny_url,omitempty"`
+	Name                    string                         `json:"name"`
+	ID                      string                         `json:"id,omitempty"`
+	PrivateAddress          string                         `json:"private_address"`
+	CorsHeaders             *AccessApplicationCorsHeaders  `json:"cors_headers,omitempty"`
+	CreatedAt               *time.Time                     `json:"created_at,omitempty"`
+	UpdatedAt               *time.Time                     `json:"updated_at,omitempty"`
+	AutoRedirectToIdentity  bool                           `json:"auto_redirect_to_identity,omitempty"`
 	SkipInterstitial        bool                           `json:"skip_interstitial,omitempty"`
 	AppLauncherVisible      bool                           `json:"app_launcher_visible,omitempty"`
-	GatewayRules            []AccessApplicationGatewayRule `json:"gateway_rules,omitempty"`
-	PrivateAddress          string                         `json:"private_address"`
+	EnableBindingCookie     bool                           `json:"enable_binding_cookie,omitempty"`
+	HttpOnlyCookieAttribute bool                           `json:"http_only_cookie_attribute,omitempty"`
 }
 
 type AccessApplicationGatewayRule struct {

--- a/dns.go
+++ b/dns.go
@@ -15,21 +15,21 @@ import (
 
 // DNSRecord represents a DNS record in a zone.
 type DNSRecord struct {
-	ID         string      `json:"id,omitempty"`
+	CreatedOn  time.Time   `json:"created_on,omitempty"`
+	ModifiedOn time.Time   `json:"modified_on,omitempty"`
 	Type       string      `json:"type,omitempty"`
 	Name       string      `json:"name,omitempty"`
 	Content    string      `json:"content,omitempty"`
-	Proxiable  bool        `json:"proxiable,omitempty"`
-	Proxied    *bool       `json:"proxied,omitempty"`
-	TTL        int         `json:"ttl,omitempty"`
-	Locked     bool        `json:"locked,omitempty"`
+	Meta       interface{} `json:"meta,omitempty"`
+	Data       interface{} `json:"data,omitempty"` // data returned by: SRV, LOC
+	ID         string      `json:"id,omitempty"`
 	ZoneID     string      `json:"zone_id,omitempty"`
 	ZoneName   string      `json:"zone_name,omitempty"`
-	CreatedOn  time.Time   `json:"created_on,omitempty"`
-	ModifiedOn time.Time   `json:"modified_on,omitempty"`
-	Data       interface{} `json:"data,omitempty"` // data returned by: SRV, LOC
-	Meta       interface{} `json:"meta,omitempty"`
 	Priority   *uint16     `json:"priority,omitempty"`
+	TTL        int         `json:"ttl,omitempty"`
+	Proxied    *bool       `json:"proxied,omitempty"`
+	Proxiable  bool        `json:"proxiable,omitempty"`
+	Locked     bool        `json:"locked,omitempty"`
 }
 
 // DNSRecordResponse represents the response from the DNS endpoint.

--- a/spectrum.go
+++ b/spectrum.go
@@ -105,21 +105,21 @@ func (p *SpectrumApplicationOriginPort) MarshalJSON() ([]byte, error) {
 
 // SpectrumApplication defines a single Spectrum Application.
 type SpectrumApplication struct {
-	ID               string                         `json:"id,omitempty"`
-	Protocol         string                         `json:"protocol,omitempty"`
-	IPv4             bool                           `json:"ipv4,omitempty"`
 	DNS              SpectrumApplicationDNS         `json:"dns,omitempty"`
 	OriginDirect     []string                       `json:"origin_direct,omitempty"`
-	OriginPort       *SpectrumApplicationOriginPort `json:"origin_port,omitempty"`
-	OriginDNS        *SpectrumApplicationOriginDNS  `json:"origin_dns,omitempty"`
-	IPFirewall       bool                           `json:"ip_firewall,omitempty"`
-	ProxyProtocol    ProxyProtocol                  `json:"proxy_protocol,omitempty"`
-	TLS              string                         `json:"tls,omitempty"`
+	ID               string                         `json:"id,omitempty"`
+	Protocol         string                         `json:"protocol,omitempty"`
 	TrafficType      string                         `json:"traffic_type,omitempty"`
+	TLS              string                         `json:"tls,omitempty"`
+	ProxyProtocol    ProxyProtocol                  `json:"proxy_protocol,omitempty"`
+	ModifiedOn       *time.Time                     `json:"modified_on,omitempty"`
+	OriginDNS        *SpectrumApplicationOriginDNS  `json:"origin_dns,omitempty"`
+	OriginPort       *SpectrumApplicationOriginPort `json:"origin_port,omitempty"`
+	CreatedOn        *time.Time                     `json:"created_on,omitempty"`
 	EdgeIPs          *SpectrumApplicationEdgeIPs    `json:"edge_ips,omitempty"`
 	ArgoSmartRouting bool                           `json:"argo_smart_routing,omitempty"`
-	CreatedOn        *time.Time                     `json:"created_on,omitempty"`
-	ModifiedOn       *time.Time                     `json:"modified_on,omitempty"`
+	IPv4             bool                           `json:"ipv4,omitempty"`
+	IPFirewall       bool                           `json:"ip_firewall,omitempty"`
 }
 
 // UnmarshalJSON handles setting the `ProxyProtocol` field based on the value of the deprecated `spp` field.

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -12,20 +12,20 @@ import (
 
 // WaitingRoom describes a WaitingRoom object.
 type WaitingRoom struct {
-	ID                    string    `json:"id,omitempty"`
 	CreatedOn             time.Time `json:"created_on,omitempty"`
 	ModifiedOn            time.Time `json:"modified_on,omitempty"`
+	Path                  string    `json:"path"`
 	Name                  string    `json:"name"`
 	Description           string    `json:"description,omitempty"`
-	Suspended             bool      `json:"suspended"`
+	CustomPageHTML        string    `json:"custom_page_html,omitempty"`
 	Host                  string    `json:"host"`
-	Path                  string    `json:"path"`
-	QueueAll              bool      `json:"queue_all"`
+	ID                    string    `json:"id,omitempty"`
 	NewUsersPerMinute     int       `json:"new_users_per_minute"`
 	TotalActiveUsers      int       `json:"total_active_users"`
 	SessionDuration       int       `json:"session_duration"`
+	QueueAll              bool      `json:"queue_all"`
 	DisableSessionRenewal bool      `json:"disable_session_renewal"`
-	CustomPageHTML        string    `json:"custom_page_html,omitempty"`
+	Suspended             bool      `json:"suspended"`
 	JsonResponseEnabled   bool      `json:"json_response_enabled"`
 }
 

--- a/zone.go
+++ b/zone.go
@@ -66,9 +66,9 @@ type ZoneMeta struct {
 // ZonePlan contains the plan information for a zone.
 type ZonePlan struct {
 	ZonePlanCommon
+	LegacyID          string `json:"legacy_id"`
 	IsSubscribed      bool   `json:"is_subscribed"`
 	CanSubscribe      bool   `json:"can_subscribe"`
-	LegacyID          string `json:"legacy_id"`
 	LegacyDiscount    bool   `json:"legacy_discount"`
 	ExternallyManaged bool   `json:"externally_managed"`
 }


### PR DESCRIPTION
updates some structs to be re-ordered and make more efficient use of
memory allocation with less waste.

| file                  | savings |
|-----------------------|---------|
| access_application.go | 11.11%  |
| dns.go                | 7.14%   |
| spectrum.go           | 7.69%   |
| waiting_room.go       | 15.38%  |
| zone.go               | 14.29%  |