### PR TITLE
Add additional struct to Custom hostname

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -79,7 +79,7 @@ type CustomHostnameSSL struct {
 	ValidationErrors     []CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
 	HTTPUrl              string                              `json:"http_url,omitempty"`
 	HTTPBody             string                              `json:"http_body,omitempty"`
-	Certificates	     []CustomHostnameSSLCertificates	 `json:"certificates,omitempty"`
+	Certificates         []CustomHostnameSSLCertificates     `json:"certificates,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -47,6 +47,7 @@ type CustomHostnameOwnershipVerification struct {
 type CustomHostnameSSLValidationErrors struct {
 	Message string `json:"message,omitempty"`
 }
+
 // CustomHostnameSSLCertificates represent certificate properties like issuer, expires date and etc.
 type CustomHostnameSSLCertificates struct {
 	Issuer            string     `json:"issuer"`
@@ -57,6 +58,7 @@ type CustomHostnameSSLCertificates struct {
 	FingerprintSha256 string     `json:"fingerprint_sha256"`
 	ID                string     `json:"id"`
 }
+
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
 type CustomHostnameSSL struct {
 	ID                   string                              `json:"id,omitempty"`

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -47,7 +47,16 @@ type CustomHostnameOwnershipVerification struct {
 type CustomHostnameSSLValidationErrors struct {
 	Message string `json:"message,omitempty"`
 }
-
+// CustomHostnameSSLCertificates represent certificate properties like issuer, expires date and etc.
+type CustomHostnameSSLCertificates struct {
+	Issuer            string     `json:"issuer"`
+	SerialNumber      string     `json:"serial_number"`
+	Signature         string     `json:"signature"`
+	ExpiresOn         *time.Time `json:"expires_on"`
+	IssuedOn          *time.Time `json:"issued_on"`
+	FingerprintSha256 string     `json:"fingerprint_sha256"`
+	ID                string     `json:"id"`
+}
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
 type CustomHostnameSSL struct {
 	ID                   string                              `json:"id,omitempty"`
@@ -68,6 +77,7 @@ type CustomHostnameSSL struct {
 	ValidationErrors     []CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
 	HTTPUrl              string                              `json:"http_url,omitempty"`
 	HTTPBody             string                              `json:"http_body,omitempty"`
+	Certificates	     []CustomHostnameSSLCertificates	 `json:"certificates,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.


### PR DESCRIPTION
Add additional struct to Custom hostname

## Description

This change allow to get from api information about SSL certificate for custom hostname. Information like
Issuer, SerialNumber, Signature, ExpiresOn, IssuedOn, Fingerprint.

It's very useful in case when you need to monitoring certificate expiration date or certificate fingerprint for security reason and etc.


## Has your change been tested?

Yes, I've test expiration days left for my certificate.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
