### PR TITLE
GATE-2386: Adds support for missing team rules settings

### DIFF
--- a/teams_rules.go
+++ b/teams_rules.go
@@ -49,6 +49,7 @@ type TeamsBISOAdminControlSettings struct {
 	DisableUpload    bool `json:"du"`
 	DisableKeyboard  bool `json:"dk"`
 }
+
 type TeamsCheckSessionSettings struct {
 	Enforce  bool     `json:"enforce"`
 	Duration Duration `json:"duration"`

--- a/teams_rules.go
+++ b/teams_rules.go
@@ -26,8 +26,14 @@ type TeamsRuleSettings struct {
 	// settings for l4(network) level overrides
 	L4Override *TeamsL4OverrideSettings `json:"l4override"`
 
+	// settings for adding headers to http requests
+	AddHeaders http.Header `json:"add_headers"`
+
 	// settings for browser isolation actions
 	BISOAdminControls *TeamsBISOAdminControlSettings `json:"biso_admin_controls"`
+
+	// settings for session check in allow action
+	CheckSession *TeamsCheckSessionSettings `json:"check_session"`
 }
 
 // TeamsL4OverrideSettings used in l4 filter type rule with action set to override.
@@ -39,6 +45,13 @@ type TeamsL4OverrideSettings struct {
 type TeamsBISOAdminControlSettings struct {
 	DisablePrinting  bool `json:"dp"`
 	DisableCopyPaste bool `json:"dcp"`
+	DisableDownload  bool `json:"dd"`
+	DisableUpload    bool `json:"du"`
+	DisableKeyboard  bool `json:"dk"`
+}
+type TeamsCheckSessionSettings struct {
+	Enforce  bool     `json:"enforce"`
+	Duration Duration `json:"duration"`
 }
 
 type TeamsFilterType string

--- a/teams_rules_test.go
+++ b/teams_rules_test.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -246,23 +245,6 @@ func TestTeamsCreateRule(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
-		type PartialTeamsCheckSessionSettings struct {
-			Enforce  bool   `json:"enforce"`
-			Duration string `json:"duration"`
-		}
-		type PartialTeamsRuleSettings struct {
-			AddHeaders   http.Header                       `json:"add_headers,omitempty"`
-			CheckSession *PartialTeamsCheckSessionSettings `json:"check_session,omitempty"`
-		}
-		type PartialTeamsRule struct {
-			RuleSettings PartialTeamsRuleSettings `json:"rule_settings,omitempty"`
-		}
-		var req PartialTeamsRule
-		err := json.NewDecoder(r.Body).Decode(&req)
-		assert.NoError(t, err)
-		assert.Equal(t, req.RuleSettings.CheckSession.Duration, "5m0s")
-		assert.Equal(t, req.RuleSettings.AddHeaders[http.CanonicalHeaderKey("X-Test")], []string{"abcd"})
-
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
 			"success": true,

--- a/teams_rules_test.go
+++ b/teams_rules_test.go
@@ -2,6 +2,7 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -45,7 +46,11 @@ func TestTeamsRules(t *testing.T) {
 					"override_host": "",
 					"l4override": null,
 					"biso_admin_controls": null,
-					"add_headers": null
+					"add_headers": null,
+					"check_session": {
+						"enforce": true,
+						"duration": "15m0s"
+					}
 				  }
 				},
 				{
@@ -71,7 +76,8 @@ func TestTeamsRules(t *testing.T) {
 					"override_host": "",
 					"l4override": null,
 					"biso_admin_controls": null,
-					"add_headers": null
+					"add_headers": null,
+					"check_session": null
 				  }
 				}
 			]
@@ -100,7 +106,12 @@ func TestTeamsRules(t *testing.T) {
 			OverrideIPs:       nil,
 			OverrideHost:      "",
 			L4Override:        nil,
+			AddHeaders:        nil,
 			BISOAdminControls: nil,
+			CheckSession: &TeamsCheckSessionSettings{
+				Enforce:  true,
+				Duration: Duration{900 * time.Second},
+			},
 		},
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -124,7 +135,9 @@ func TestTeamsRules(t *testing.T) {
 				OverrideIPs:       nil,
 				OverrideHost:      "",
 				L4Override:        nil,
+				AddHeaders:        nil,
 				BISOAdminControls: nil,
+				CheckSession:      nil,
 			},
 			CreatedAt: &createdAt,
 			UpdatedAt: &updatedAt,
@@ -174,7 +187,11 @@ func TestTeamsRule(t *testing.T) {
 					"override_host": "",
 					"l4override": null,
 					"biso_admin_controls": null,
-					"add_headers": null
+					"add_headers": null,
+					"check_session": {
+						"enforce": true,
+						"duration": "15m0s"
+					}
 				}
 			}
 		}
@@ -202,7 +219,12 @@ func TestTeamsRule(t *testing.T) {
 			OverrideIPs:       nil,
 			OverrideHost:      "",
 			L4Override:        nil,
+			AddHeaders:        nil,
 			BISOAdminControls: nil,
+			CheckSession: &TeamsCheckSessionSettings{
+				Enforce:  true,
+				Duration: Duration{900 * time.Second},
+			},
 		},
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -224,6 +246,23 @@ func TestTeamsCreateRule(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		type PartialTeamsCheckSessionSettings struct {
+			Enforce  bool   `json:"enforce"`
+			Duration string `json:"duration"`
+		}
+		type PartialTeamsRuleSettings struct {
+			AddHeaders   http.Header                       `json:"add_headers,omitempty"`
+			CheckSession *PartialTeamsCheckSessionSettings `json:"check_session,omitempty"`
+		}
+		type PartialTeamsRule struct {
+			RuleSettings PartialTeamsRuleSettings `json:"rule_settings,omitempty"`
+		}
+		var req PartialTeamsRule
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+		assert.Equal(t, req.RuleSettings.CheckSession.Duration, "5m0s")
+		assert.Equal(t, req.RuleSettings.AddHeaders[http.CanonicalHeaderKey("X-Test")], []string{"abcd"})
+
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
 			"success": true,
@@ -247,7 +286,13 @@ func TestTeamsCreateRule(t *testing.T) {
 					"override_host": "",
 					"l4override": null,
 					"biso_admin_controls": null,
-					"add_headers": null
+					"add_headers": {
+						"X-Test": ["abcd"]
+					},
+					"check_session": {
+						"enforce": true,
+						"duration": "5m0s"
+					}
 				}
 			}
 		}
@@ -270,7 +315,12 @@ func TestTeamsCreateRule(t *testing.T) {
 			OverrideIPs:       nil,
 			OverrideHost:      "",
 			L4Override:        nil,
+			AddHeaders:        http.Header{"X-Test": []string{"abcd"}},
 			BISOAdminControls: nil,
+			CheckSession: &TeamsCheckSessionSettings{
+				Enforce:  true,
+				Duration: Duration{300 * time.Second},
+			},
 		},
 		DeletedAt: nil,
 	}
@@ -316,7 +366,8 @@ func TestTeamsUpdateRule(t *testing.T) {
 					"override_host": "",
 					"l4override": null,
 					"biso_admin_controls": null,
-					"add_headers": null
+					"add_headers": null,
+					"check_session": null
 				}
 			}
 		}
@@ -343,7 +394,9 @@ func TestTeamsUpdateRule(t *testing.T) {
 			OverrideIPs:       nil,
 			OverrideHost:      "",
 			L4Override:        nil,
+			AddHeaders:        nil,
 			BISOAdminControls: nil,
+			CheckSession:      nil,
 		},
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -383,7 +436,8 @@ func TestTeamsPatchRule(t *testing.T) {
 					"override_host": "",
 					"l4override": null,
 					"biso_admin_controls": null,
-					"add_headers": null
+					"add_headers": null,
+					"check_session": null
 				}
 			}
 		}
@@ -402,7 +456,9 @@ func TestTeamsPatchRule(t *testing.T) {
 			OverrideIPs:       nil,
 			OverrideHost:      "",
 			L4Override:        nil,
+			AddHeaders:        nil,
 			BISOAdminControls: nil,
+			CheckSession:      nil,
 		},
 	}
 


### PR DESCRIPTION
## Description

This PR adds support for creating rules with session management
settings (check_session), adding HTTP headers (add_headers), and other
missing browser isolation options.

## Has your change been tested?

Automated tests + manual tests against a live account.

## Types of changes

What sort of change does your code introduce/modify?

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
