### PR TITLE
Add `Certificates` field to the `CustomHostnameSSL` type

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -48,6 +48,17 @@ type CustomHostnameSSLValidationErrors struct {
 	Message string `json:"message,omitempty"`
 }
 
+// CustomHostnameSSLCertificate represents an SSL certificate that's part of a Certificate Pack.
+type CustomHostnameSSLCertificate struct {
+	ID                string     `json:"id,omitempty"`
+	Issuer            string     `json:"issuer,omitempty"`
+	SerialNumber      string     `json:"serial_number,omitempty"`
+	Signature         string     `json:"signature,omitempty"`
+	ExpiresOn         *time.Time `json:"expires_on,omitempty"`
+	IssuedOn          *time.Time `json:"issued_on,omitempty"`
+	FingerprintSHA256 string     `json:"fingerprint_sha256,omitempty"`
+}
+
 // CustomHostnameSSL represents the SSL section in a given custom hostname.
 type CustomHostnameSSL struct {
 	ID                   string                              `json:"id,omitempty"`
@@ -68,6 +79,7 @@ type CustomHostnameSSL struct {
 	ValidationErrors     []CustomHostnameSSLValidationErrors `json:"validation_errors,omitempty"`
 	HTTPUrl              string                              `json:"http_url,omitempty"`
 	HTTPBody             string                              `json:"http_body,omitempty"`
+	Certificates         []CustomHostnameSSLCertificate      `json:"certificates,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.


### PR DESCRIPTION
This PR adds `Certificates` field to the `CustomHostnameSSL` struct.

## Description

The added field is present in the response of [List Custom Hostnames](https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames) endpoint, probably because it is a wildcard certificate (`CustomHostnameSSL.Wildcard` is `true`). We use the `Certificates` field to monitor expiration of certificates from the [Certificate Pack](https://developers.cloudflare.com/ssl/edge-certificates/custom-certificates#certificate-packs). We can't use any other field to do this. This is what the response looks like:
<details>
<summary>Example JSON response</summary>
<pre>
{
  "result": [
    {
      "id": "&lt;REDACTED&gt;",
      "hostname": "api.example.com",
      "ssl": {
        "id": "&lt;REDACTED&gt;",
        "type": "dv",
        "method": "txt",
        "status": "active",
        "hosts": [
          "api.example.com",
          ".api.example.com"
        ],
        "bundle_method": "ubiquitous",
        "certificates": [
          {
            "issuer": "CloudflareInc",
            "serial_number": "&lt;REDACTED&gt;",
            "signature": "ECDSAWithSHA256",
            "expires_on": "2022-10-21T23:59:59Z",
            "issued_on": "2021-10-22T00:00:00Z",
            "fingerprint_sha256": "&lt;REDACTED&gt;",
            "id": "&lt;REDACTED&gt;"
          },
          {
            "issuer": "CloudflareInc",
            "serial_number": "&lt;REDACTED&gt;",
            "signature": "SHA256WithRSA",
            "expires_on": "2022-10-21T23:59:59Z",
            "issued_on": "2021-10-22T00:00:00Z",
            "fingerprint_sha256": "&lt;REDACTED&gt;",
            "id": "&lt;REDACTED&gt;"
          }
        ],
        "wildcard": true,
        "certificate_authority": "digicert"
      },
      "status": "active",
      "created_at": "2021-10-21T10:03:04.726596Z"
    },
    {
      "id": "&lt;REDACTED&gt;",
      "hostname": "api.example2.com",
      "ssl": {
        "id": "&lt;REDACTED&gt;",
        "type": "dv",
        "method": "txt",
        "status": "active",
        "hosts": [
          ".api.example2.com",
          "api.example2.com"
        ],
        "settings": {
          "min_tls_version": "1.2"
        },
        "bundle_method": "ubiquitous",
        "certificates": [
          {
            "issuer": "CloudflareInc",
            "serial_number": "&lt;REDACTED&gt;",
            "signature": "ECDSAWithSHA256",
            "expires_on": "2023-01-15T23:59:59Z",
            "issued_on": "2022-01-16T00:00:00Z",
            "fingerprint_sha256": "&lt;REDACTED&gt;",
            "id": "&lt;REDACTED&gt;"
          },
          {
            "issuer": "CloudflareInc",
            "serial_number": "&lt;REDACTED&gt;",
            "signature": "SHA256WithRSA",
            "expires_on": "2023-01-15T23:59:59Z",
            "issued_on": "2022-01-16T00:00:00Z",
            "fingerprint_sha256": "&lt;REDACTED&gt;",
            "id": "&lt;REDACTED&gt;"
          }
        ],
        "wildcard": true,
        "certificate_authority": "digicert"
      },
      "status": "active",
      "created_at": "2022-01-15T16:02:39.062845Z"
    },
],
  "result_info": {
    "page": 1,
    "per_page": 500,
    "count": 20,
    "total_count": 20,
    "total_pages": 1
  },
  "success": true,
  "errors": [],
  "messages": []
}
</pre>
</details>

## Has your change been tested?

I will add tests when the changes are approved.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
