### PR TITLE
Add RevokeAccessUserTokens and RevokeZoneLevelAccessUserTokens

### DIFF
--- a/access_user_tokens.go
+++ b/access_user_tokens.go
@@ -1,0 +1,38 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+type AccessUserEmail struct {
+	Email string `json:"email"`
+}
+
+// RevokeAccessUserTokens revokes any outstanding tokens issued for a specific user
+// Access User.
+//
+// API reference: https://api.cloudflare.com/#access-organizations-revoke-all-access-tokens-for-a-user
+func (api *API) RevokeAccessUserTokens(ctx context.Context, accountID string, accessUserEmail AccessUserEmail) error {
+	return api.revokeUserTokens(ctx, accountID, accessUserEmail, AccountRouteRoot)
+}
+
+// RevokeZoneLevelAccessUserTokens revokes any outstanding tokens issued for a specific user
+// Access User.
+//
+// API reference: https://api.cloudflare.com/#zone-level-access-organizations-revoke-all-access-tokens-for-a-user
+func (api *API) RevokeZoneLevelAccessUserTokens(ctx context.Context, zoneID string, accessUserEmail AccessUserEmail) error {
+	return api.revokeUserTokens(ctx, zoneID, accessUserEmail, ZoneRouteRoot)
+}
+
+func (api *API) revokeUserTokens(ctx context.Context, id string, accessUserEmail AccessUserEmail, routeRoot RouteRoot) error {
+	uri := fmt.Sprintf("/%s/%s/access/organizations/revoke_user", routeRoot, id)
+
+	_, err := api.makeRequestContext(ctx, http.MethodPost, uri, accessUserEmail)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/access_user_tokens_test.go
+++ b/access_user_tokens_test.go
@@ -1,0 +1,55 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestRevokeUserTokens(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"result": true
+		}
+		`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/organizations/revoke_user", handler)
+
+	AccessUserEmail := AccessUserEmail{Email: "test@example.com"}
+
+	err := client.RevokeAccessUserTokens(context.Background(), testAccountID, AccessUserEmail)
+
+	assert.NoError(t, err)
+}
+
+func TestZoneLevelRevokeUserTokens(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"result": true
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/organizations/revoke_user", handler)
+
+	AccessUserEmail := AccessUserEmail{Email: "test@example.com"}
+
+	err := client.RevokeZoneLevelAccessUserTokens(context.Background(), testZoneID, AccessUserEmail)
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Description

Add RevokeAccessUserTokens and RevokeZoneLevelAccessUserTokens to invoke
https://api.cloudflare.com/#access-groups-create-access-group
https://api.cloudflare.com/#zone-level-access-groups-create-access-group

## Has your change been tested?

Automated tests.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
