### PR TITLE
adds support for worker scripts using module syntax

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -29,6 +29,10 @@ type WorkerScriptParams struct {
 	// Bindings should be a map where the keys are the binding name, and the
 	// values are the binding content
 	Bindings map[string]WorkerBinding
+
+	// Module changes the Content-Type header to specify the script is an
+	// ES Module syntax script.
+	Module bool
 }
 
 // WorkerRoute is used to map traffic matching a URL pattern to a workers
@@ -492,11 +496,16 @@ func (api *API) ListWorkerScripts(ctx context.Context) (WorkerListResponse, erro
 // UploadWorker push raw script content for your worker.
 //
 // API reference: https://api.cloudflare.com/#worker-script-upload-worker
-func (api *API) UploadWorker(ctx context.Context, requestParams *WorkerRequestParams, data string) (WorkerScriptResponse, error) {
-	if requestParams.ScriptName != "" {
-		return api.uploadWorkerWithName(ctx, requestParams.ScriptName, "application/javascript", []byte(data))
+func (api *API) UploadWorker(ctx context.Context, requestParams *WorkerRequestParams, params *WorkerScriptParams) (WorkerScriptResponse, error) {
+	contentType := "application/javascript"
+	if params.Module {
+		contentType = "application/javascript+module"
 	}
-	return api.uploadWorkerForZone(ctx, requestParams.ZoneID, "application/javascript", []byte(data))
+
+	if requestParams.ScriptName != "" {
+		return api.uploadWorkerWithName(ctx, requestParams.ScriptName, contentType, []byte(params.Script))
+	}
+	return api.uploadWorkerForZone(ctx, requestParams.ZoneID, contentType, []byte(params.Script))
 }
 
 // UploadWorkerWithBindings push raw script content and bindings for your worker
@@ -594,7 +603,13 @@ func formatMultipartBody(params *WorkerScriptParams) (string, []byte, error) {
 	// Write script part
 	hdr = textproto.MIMEHeader{}
 	hdr.Set("content-disposition", fmt.Sprintf(`form-data; name="%s"`, scriptPartName))
-	hdr.Set("content-type", "application/javascript")
+
+	contentType := "application/javascript"
+	if params.Module {
+		contentType = "application/javascript+module"
+	}
+	hdr.Set("content-type", contentType)
+
 	pw, err = mpw.CreatePart(hdr)
 	if err != nil {
 		return "", nil, err

--- a/workers_example_test.go
+++ b/workers_example_test.go
@@ -23,7 +23,7 @@ func ExampleAPI_UploadWorker() {
 		log.Fatal(err)
 	}
 
-	res, err := api.UploadWorker(context.Background(), &cloudflare.WorkerRequestParams{ZoneID: zoneID}, workerScript)
+	res, err := api.UploadWorker(context.Background(), &cloudflare.WorkerRequestParams{ZoneID: zoneID}, &cloudflare.WorkerScriptParams{Script: workerScript})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func UploadWorkerWithName() {
 		log.Fatal(err)
 	}
 
-	res, err := api.UploadWorker(context.Background(), &cloudflare.WorkerRequestParams{ScriptName: "baz"}, workerScript)
+	res, err := api.UploadWorker(context.Background(), &cloudflare.WorkerRequestParams{ScriptName: "baz"}, &cloudflare.WorkerScriptParams{Script: workerScript})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Adds a `Module` field to WorkerScriptParams that changes the Content-Type of the resulting request to `application/javascript+module`. This isn't documented, but it is exactly what the Workers editor in the dashboard seems to do.

The only breaking change is on UploadWorker, which I believe we could avoid by omitting that entire change, or adding an UploadWorkerWithParams abstraction. I'm happy to hear either.

Closes #794 

## Has your change been tested?

Unit tests were added to cover at least one case for with and without bindings, I don't believe it's necessary to duplicate every UploadWorker test, as a single one can test the code flows correctly.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
