### PR TITLE
Add support for country level steering to Load Balancing

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -80,6 +80,7 @@ type LoadBalancer struct {
 	DefaultPools              []string                   `json:"default_pools"`
 	RegionPools               map[string][]string        `json:"region_pools"`
 	PopPools                  map[string][]string        `json:"pop_pools"`
+	CountryPools              map[string][]string        `json:"country_pools"`
 	Proxied                   bool                       `json:"proxied"`
 	Enabled                   *bool                      `json:"enabled,omitempty"`
 	Persistence               string                     `json:"session_affinity,omitempty"`
@@ -89,11 +90,11 @@ type LoadBalancer struct {
 
 	// SteeringPolicy controls pool selection logic.
 	// "off" select pools in DefaultPools order
-	// "geo" select pools based on RegionPools/PopPools
+	// "geo" select pools based on RegionPools/PopPools/CountryPools
 	// "dynamic_latency" select pools based on RTT (requires health checks)
 	// "random" selects pools in a random order
 	// "proximity" select pools based on 'distance' from request
-	// "" maps to "geo" if RegionPools or PopPools have entries otherwise "off"
+	// "" maps to "geo" if RegionPools or PopPools or CountryPools have entries otherwise "off"
 	SteeringPolicy string `json:"steering_policy,omitempty"`
 }
 
@@ -156,6 +157,7 @@ type LoadBalancerRuleOverrides struct {
 	DefaultPools []string            `json:"default_pools,omitempty"`
 	PoPPools     map[string][]string `json:"pop_pools,omitempty"`
 	RegionPools  map[string][]string `json:"region_pools,omitempty"`
+	CountryPools map[string][]string `json:"country_pools,omitempty"`
 }
 
 // LoadBalancerRuleOverridesSessionAffinityAttrs mimics SessionAffinityAttributes without the

--- a/load_balancing.go
+++ b/load_balancing.go
@@ -109,23 +109,26 @@ type LoadBalancerLoadShedding struct {
 // LoadBalancerRule represents a single rule entry for a Load Balancer. Each rules
 // is run one after the other in priority order. Disabled rules are skipped.
 type LoadBalancerRule struct {
-	// Name is required but is only used for human readability
-	Name string `json:"name"`
-	// Priority controls the order of rule execution the lowest value will be invoked first
-	Priority int  `json:"priority"`
-	Disabled bool `json:"disabled"`
-
-	Condition string                    `json:"condition"`
 	Overrides LoadBalancerRuleOverrides `json:"overrides"`
 
-	// Terminates flag this rule as 'terminating'. No further rules will
-	// be executed after this one.
-	Terminates bool `json:"terminates,omitempty"`
+	// Name is required but is only used for human readability
+	Name string `json:"name"`
+
+	Condition string `json:"condition"`
+
+	// Priority controls the order of rule execution the lowest value will be invoked first
+	Priority int `json:"priority"`
 
 	// FixedResponse if set and the condition is true we will not run
 	// routing logic but rather directly respond with the provided fields.
 	// FixedResponse implies terminates.
 	FixedResponse *LoadBalancerFixedResponseData `json:"fixed_response,omitempty"`
+
+	Disabled bool `json:"disabled"`
+
+	// Terminates flag this rule as 'terminating'. No further rules will
+	// be executed after this one.
+	Terminates bool `json:"terminates,omitempty"`
 }
 
 // LoadBalancerFixedResponseData contains all the data needed to generate

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -909,7 +909,15 @@ func TestCreateLoadBalancer(t *testing.T) {
                 "ENAM": [
                   "00920f38ce07c2e2f4df50b1f61d4194"
                 ]
-			  },
+              },
+              "country_pools": {
+                "US": [
+                  "de90f38ced07c2e2f4df50b1f61d4194"
+                ],
+                "GB": [
+                  "abd90f38ced07c2e2f4df50b1f61d4194"
+                ]
+              },
               "pop_pools": {
                 "LAX": [
                   "de90f38ced07c2e2f4df50b1f61d4194",
@@ -970,6 +978,14 @@ func TestCreateLoadBalancer(t *testing.T) {
                   ],
                   "ENAM": [
                     "00920f38ce07c2e2f4df50b1f61d4194"
+                  ]
+                },
+                "country_pools": {
+                  "US": [
+                    "de90f38ced07c2e2f4df50b1f61d4194"
+                  ],
+                  "GB": [
+                    "abd90f38ced07c2e2f4df50b1f61d4194"
                   ]
                 },
                 "pop_pools": {
@@ -1033,6 +1049,14 @@ func TestCreateLoadBalancer(t *testing.T) {
 				"00920f38ce07c2e2f4df50b1f61d4194",
 			},
 		},
+		CountryPools: map[string][]string{
+			"US": {
+				"de90f38ced07c2e2f4df50b1f61d4194",
+			},
+			"GB": {
+				"abd90f38ced07c2e2f4df50b1f61d4194",
+			},
+		},
 		PopPools: map[string][]string{
 			"LAX": {
 				"de90f38ced07c2e2f4df50b1f61d4194",
@@ -1083,6 +1107,14 @@ func TestCreateLoadBalancer(t *testing.T) {
 			},
 			"ENAM": {
 				"00920f38ce07c2e2f4df50b1f61d4194",
+			},
+		},
+		CountryPools: map[string][]string{
+			"US": {
+				"de90f38ced07c2e2f4df50b1f61d4194",
+			},
+			"GB": {
+				"abd90f38ced07c2e2f4df50b1f61d4194",
 			},
 		},
 		PopPools: map[string][]string{
@@ -1159,6 +1191,14 @@ func TestListLoadBalancers(t *testing.T) {
                         "00920f38ce07c2e2f4df50b1f61d4194"
                       ]
                     },
+                    "country_pools": {
+                      "US": [
+                        "de90f38ced07c2e2f4df50b1f61d4194"
+                      ],
+                      "GB": [
+                        "abd90f38ced07c2e2f4df50b1f61d4194"
+                      ]
+                    },
                     "pop_pools": {
                       "LAX": [
                         "de90f38ced07c2e2f4df50b1f61d4194",
@@ -1208,6 +1248,14 @@ func TestListLoadBalancers(t *testing.T) {
 				},
 				"ENAM": {
 					"00920f38ce07c2e2f4df50b1f61d4194",
+				},
+			},
+			CountryPools: map[string][]string{
+				"US": {
+					"de90f38ced07c2e2f4df50b1f61d4194",
+				},
+				"GB": {
+					"abd90f38ced07c2e2f4df50b1f61d4194",
 				},
 			},
 			PopPools: map[string][]string{
@@ -1266,6 +1314,14 @@ func TestLoadBalancerDetails(t *testing.T) {
                     "00920f38ce07c2e2f4df50b1f61d4194"
                   ]
                 },
+                "country_pools": {
+                  "US": [
+                    "de90f38ced07c2e2f4df50b1f61d4194"
+                  ],
+                  "GB": [
+                    "abd90f38ced07c2e2f4df50b1f61d4194"
+                  ]
+                },
                 "pop_pools": {
                   "LAX": [
                     "de90f38ced07c2e2f4df50b1f61d4194",
@@ -1307,6 +1363,14 @@ func TestLoadBalancerDetails(t *testing.T) {
 			},
 			"ENAM": {
 				"00920f38ce07c2e2f4df50b1f61d4194",
+			},
+		},
+		CountryPools: map[string][]string{
+			"US": {
+				"de90f38ced07c2e2f4df50b1f61d4194",
+			},
+			"GB": {
+				"abd90f38ced07c2e2f4df50b1f61d4194",
 			},
 		},
 		PopPools: map[string][]string{
@@ -1383,6 +1447,14 @@ func TestModifyLoadBalancer(t *testing.T) {
                     "00920f38ce07c2e2f4df50b1f61d4194"
                   ]
                 },
+                "country_pools": {
+                  "US": [
+                    "de90f38ced07c2e2f4df50b1f61d4194"
+                  ],
+                  "GB": [
+                    "f9138c5d07c2e2f4df57b1f61d4196"
+                  ]
+                },
                 "pop_pools": {
                   "LAX": [
                     "9290f38c5d07c2e2f4df57b1f61d4196"
@@ -1423,6 +1495,14 @@ func TestModifyLoadBalancer(t *testing.T) {
                   ],
                   "ENAM": [
                     "00920f38ce07c2e2f4df50b1f61d4194"
+                  ]
+                },
+                "country_pools": {
+                  "US": [
+                    "de90f38ced07c2e2f4df50b1f61d4194"
+                  ],
+                  "GB": [
+                    "f9138c5d07c2e2f4df57b1f61d4196"
                   ]
                 },
                 "pop_pools": {
@@ -1468,6 +1548,14 @@ func TestModifyLoadBalancer(t *testing.T) {
 				"00920f38ce07c2e2f4df50b1f61d4194",
 			},
 		},
+		CountryPools: map[string][]string{
+			"US": {
+				"de90f38ced07c2e2f4df50b1f61d4194",
+			},
+			"GB": {
+				"f9138c5d07c2e2f4df57b1f61d4196",
+			},
+		},
 		PopPools: map[string][]string{
 			"LAX": {
 				"9290f38c5d07c2e2f4df57b1f61d4196",
@@ -1501,6 +1589,14 @@ func TestModifyLoadBalancer(t *testing.T) {
 			},
 			"ENAM": {
 				"00920f38ce07c2e2f4df50b1f61d4194",
+			},
+		},
+		CountryPools: map[string][]string{
+			"US": {
+				"de90f38ced07c2e2f4df50b1f61d4194",
+			},
+			"GB": {
+				"f9138c5d07c2e2f4df57b1f61d4196",
 			},
 		},
 		PopPools: map[string][]string{


### PR DESCRIPTION
## Description

 `country_pools` field is a mapping of country codes to a list of pool IDs (ordered by their failover priority) for the given country. Any country mapping not explicitly defined will fall back to using the corresponding `region_pools` mapping if it exists else to `default_pools`.

## Has your change been tested?

Added new fields to load balancing tests which verifies the input struct matches the returning JSON/struct.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
