### PR TITLE
Change ratelimit `mitigation_expression` to `counting_expression`

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -251,14 +251,11 @@ type RulesetRule struct {
 
 // RulesetRuleRateLimit contains the structure of a HTTP rate limit Ruleset Rule.
 type RulesetRuleRateLimit struct {
-	Characteristics   []string `json:"characteristics,omitempty"`
-	RequestsPerPeriod int      `json:"requests_per_period,omitempty"`
-	Period            int      `json:"period,omitempty"`
-	MitigationTimeout int      `json:"mitigation_timeout,omitempty"`
-
-	// Should always be sent as "" will trigger the service to use the Ruleset
-	// expression instead.
-	MitigationExpression string `json:"mitigation_expression"`
+	Characteristics    []string `json:"characteristics,omitempty"`
+	RequestsPerPeriod  int      `json:"requests_per_period,omitempty"`
+	Period             int      `json:"period,omitempty"`
+	MitigationTimeout  int      `json:"mitigation_timeout,omitempty"`
+	CountingExpression string   `json:"counting_expression,omitempty"`
 }
 
 // RulesetRuleExposedCredentialCheck contains the structure of an exposed


### PR DESCRIPTION
## Description

This reflects a change in the public API, summarised in the following
table:

|        | counting expression             | mitigation expression             |
|--------|---------------------------------|-----------------------------------|
| before | `expression`                    | `ratelimit.mitigation_expression` |
| after  | `ratelimit.counting_expression` | `expression`                      |

In both cases, setting `ratelimit.counting_expression` or
`ratelimit.mitigation_expression` to the empty string (or not setting it
at all) signifies that it should take the same value as `expression`.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.