### PR TITLE
Teams rule setting disable dnssec validation option

### DIFF
--- a/teams_rules.go
+++ b/teams_rules.go
@@ -34,6 +34,9 @@ type TeamsRuleSettings struct {
 
 	// settings for session check in allow action
 	CheckSession *TeamsCheckSessionSettings `json:"check_session"`
+
+	// whether to disable dnssec validation for allow action
+	InsecureDisableDNSSECValidation bool `json:"insecure_disable_dnssec_validation"`
 }
 
 // TeamsL4OverrideSettings used in l4 filter type rule with action set to override.

--- a/teams_rules_test.go
+++ b/teams_rules_test.go
@@ -49,7 +49,8 @@ func TestTeamsRules(t *testing.T) {
 					"check_session": {
 						"enforce": true,
 						"duration": "15m0s"
-					}
+					},
+                    "insecure_disable_dnssec_validation": false
 				  }
 				},
 				{
@@ -76,7 +77,8 @@ func TestTeamsRules(t *testing.T) {
 					"l4override": null,
 					"biso_admin_controls": null,
 					"add_headers": null,
-					"check_session": null
+					"check_session": null,
+                    "insecure_disable_dnssec_validation": true
 				  }
 				}
 			]
@@ -111,6 +113,7 @@ func TestTeamsRules(t *testing.T) {
 				Enforce:  true,
 				Duration: Duration{900 * time.Second},
 			},
+			InsecureDisableDNSSECValidation: false,
 		},
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -137,6 +140,8 @@ func TestTeamsRules(t *testing.T) {
 				AddHeaders:        nil,
 				BISOAdminControls: nil,
 				CheckSession:      nil,
+				// setting is invalid for block rules, just testing serialization here
+				InsecureDisableDNSSECValidation: true,
 			},
 			CreatedAt: &createdAt,
 			UpdatedAt: &updatedAt,
@@ -190,7 +195,8 @@ func TestTeamsRule(t *testing.T) {
 					"check_session": {
 						"enforce": true,
 						"duration": "15m0s"
-					}
+					},
+                    "insecure_disable_dnssec_validation": false
 				}
 			}
 		}
@@ -224,6 +230,7 @@ func TestTeamsRule(t *testing.T) {
 				Enforce:  true,
 				Duration: Duration{900 * time.Second},
 			},
+			InsecureDisableDNSSECValidation: false,
 		},
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -274,7 +281,8 @@ func TestTeamsCreateRule(t *testing.T) {
 					"check_session": {
 						"enforce": true,
 						"duration": "5m0s"
-					}
+					},
+                    "insecure_disable_dnssec_validation": false
 				}
 			}
 		}
@@ -303,6 +311,7 @@ func TestTeamsCreateRule(t *testing.T) {
 				Enforce:  true,
 				Duration: Duration{300 * time.Second},
 			},
+			InsecureDisableDNSSECValidation: false,
 		},
 		DeletedAt: nil,
 	}
@@ -349,7 +358,8 @@ func TestTeamsUpdateRule(t *testing.T) {
 					"l4override": null,
 					"biso_admin_controls": null,
 					"add_headers": null,
-					"check_session": null
+					"check_session": null,
+                    "insecure_disable_dnssec_validation": false
 				}
 			}
 		}
@@ -371,14 +381,15 @@ func TestTeamsUpdateRule(t *testing.T) {
 		Identity:      "",
 		DevicePosture: "",
 		RuleSettings: TeamsRuleSettings{
-			BlockPageEnabled:  false,
-			BlockReason:       "",
-			OverrideIPs:       nil,
-			OverrideHost:      "",
-			L4Override:        nil,
-			AddHeaders:        nil,
-			BISOAdminControls: nil,
-			CheckSession:      nil,
+			BlockPageEnabled:                false,
+			BlockReason:                     "",
+			OverrideIPs:                     nil,
+			OverrideHost:                    "",
+			L4Override:                      nil,
+			AddHeaders:                      nil,
+			BISOAdminControls:               nil,
+			CheckSession:                    nil,
+			InsecureDisableDNSSECValidation: false,
 		},
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
@@ -419,7 +430,8 @@ func TestTeamsPatchRule(t *testing.T) {
 					"l4override": null,
 					"biso_admin_controls": null,
 					"add_headers": null,
-					"check_session": null
+					"check_session": null,
+                    "insecure_disable_dnssec_validation": false
 				}
 			}
 		}
@@ -433,14 +445,15 @@ func TestTeamsPatchRule(t *testing.T) {
 		Enabled:     true,
 		Action:      Block,
 		RuleSettings: TeamsRuleSettings{
-			BlockPageEnabled:  false,
-			BlockReason:       "",
-			OverrideIPs:       nil,
-			OverrideHost:      "",
-			L4Override:        nil,
-			AddHeaders:        nil,
-			BISOAdminControls: nil,
-			CheckSession:      nil,
+			BlockPageEnabled:                false,
+			BlockReason:                     "",
+			OverrideIPs:                     nil,
+			OverrideHost:                    "",
+			L4Override:                      nil,
+			AddHeaders:                      nil,
+			BISOAdminControls:               nil,
+			CheckSession:                    nil,
+			InsecureDisableDNSSECValidation: false,
 		},
 	}
 


### PR DESCRIPTION
## Description

Add new teams rule setting option: "insecure_disable_dnssec_validation".

## Has your change been tested?

I updated the serialization tests, nothing else to test here.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
