### PR TITLE
Add Waiting Room status method

### DIFF
--- a/waiting_room.go
+++ b/waiting_room.go
@@ -29,6 +29,15 @@ type WaitingRoom struct {
 	JsonResponseEnabled   bool      `json:"json_response_enabled"`
 }
 
+// WaitingRoomStatus describes the status of a waiting room.
+type WaitingRoomStatus struct {
+	Status                    string `json:"status"`
+	EventID                   string `json:"event_id"`
+	EstimatedQueuedUsers      int    `json:"estimated_queued_users"`
+	EstimatedTotalActiveUsers int    `json:"estimated_total_active_users"`
+	MaxEstimatedTimeMinutes   int    `json:"max_estimated_time_minutes"`
+}
+
 // WaitingRoomDetailResponse is the API response, containing a single WaitingRoom.
 type WaitingRoomDetailResponse struct {
 	Response
@@ -39,6 +48,12 @@ type WaitingRoomDetailResponse struct {
 type WaitingRoomsResponse struct {
 	Response
 	Result []WaitingRoom `json:"result"`
+}
+
+// WaitingRoomStatusResponse is the API response, containing the status of a waiting room.
+type WaitingRoomStatusResponse struct {
+	Response
+	Result WaitingRoomStatus `json:"result"`
 }
 
 // CreateWaitingRoom creates a new Waiting Room for a zone.
@@ -143,4 +158,21 @@ func (api *API) DeleteWaitingRoom(ctx context.Context, zoneID, waitingRoomID str
 		return errors.Wrap(err, errUnmarshalError)
 	}
 	return nil
+}
+
+// WaitingRoomStatus returns the status of one Waiting Room for a zone.
+//
+// API reference: https://api.cloudflare.com/#waiting-room-get-waiting-room-status
+func (api *API) WaitingRoomStatus(ctx context.Context, zoneID, waitingRoomID string) (WaitingRoomStatus, error) {
+	uri := fmt.Sprintf("/zones/%s/waiting_rooms/%s/status", zoneID, waitingRoomID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return WaitingRoomStatus{}, err
+	}
+	var r WaitingRoomStatusResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return WaitingRoomStatus{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
 }

--- a/waiting_room_test.go
+++ b/waiting_room_test.go
@@ -32,7 +32,7 @@ var waitingRoomJSON = fmt.Sprintf(`
     }
    `, testTimestampWaitingRoom.Format(time.RFC3339Nano), testTimestampWaitingRoom.Format(time.RFC3339Nano))
 
-var waitingRoomStatusJSON = fmt.Sprintf(`
+var waitingRoomStatusJSON = `
     {
       "status": "queueing",
       "event_id": "25756b2dfe6e378a06b033b670413757",
@@ -40,7 +40,7 @@ var waitingRoomStatusJSON = fmt.Sprintf(`
       "estimated_total_active_users": 9,
       "max_estimated_time_minutes": 5
     }
-   `)
+   `
 
 var waitingRoom = WaitingRoom{
 	ID:                    "699d98642c564d2e855e9661899b7252",


### PR DESCRIPTION
## Description
I added the method `WaitingRoomStatus` (maybe GetWaitingRoomStatus?) to get the current status of a Waiting Room.

I left the `status` property as a string in the Go struct. This could be updated to an explicit status type if necessary.

## Has your change been tested?
I have added a `TestWaitingRoomStatus` test in `waiting_room_test.go`.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.