### PR TITLE
fix waiting room event JSON marshalling

### DIFF
--- a/waiting_room.go
+++ b/waiting_room.go
@@ -53,7 +53,7 @@ type WaitingRoomEvent struct {
 	NewUsersPerMinute     int       `json:"new_users_per_minute,omitempty"`
 	TotalActiveUsers      int       `json:"total_active_users,omitempty"`
 	SessionDuration       int       `json:"session_duration,omitempty"`
-	DisableSessionRenewal bool      `json:"disable_session_renewal,omitempty"`
+	DisableSessionRenewal *bool     `json:"disable_session_renewal,omitempty"`
 	Suspended             bool      `json:"suspended"`
 	ShuffleAtEventStart   bool      `json:"shuffle_at_event_start"`
 }

--- a/waiting_room_test.go
+++ b/waiting_room_test.go
@@ -105,7 +105,7 @@ var waitingRoomEvent = WaitingRoomEvent{
 	NewUsersPerMinute:     2000,
 	TotalActiveUsers:      2500,
 	SessionDuration:       0,
-	DisableSessionRenewal: false,
+	DisableSessionRenewal: nil,
 	QueueingMethod:        "random",
 	CustomPageHTML:        "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Event is prequeueing / Queue all enabled {{/waitTimeKnown}}",
 }


### PR DESCRIPTION
## Description
The value `disable_session_renewal` should be omitted when `nil` as the falsey value has meaning in this context.
The current code would never allow the event to override the waiting room with a `false` value as it would be omitted from json marshalling.

## Has your change been tested?
Yes, the tests have been modified in `waiting_room_test.go`
I changed the struct `waitingRoomEvent` to use `nil` instead of `false` and the json generates as `null`

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
(the previous changes that introduce the bug haven't been released yet)
## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

