### PR TITLE
add waiting room event preview

### DIFF
--- a/waiting_room.go
+++ b/waiting_room.go
@@ -260,6 +260,24 @@ func (api *API) WaitingRoomEvent(ctx context.Context, zoneID string, waitingRoom
 	return r.Result, nil
 }
 
+// WaitingRoomEventPreview returns an event's configuration as if it was active.
+// Inherited fields from the waiting room will be displayed with their current values.
+//
+// API reference: https://api.cloudflare.com/#waiting-room-preview-active-event-details
+func (api *API) WaitingRoomEventPreview(ctx context.Context, zoneID string, waitingRoomID string, eventID string) (WaitingRoomEvent, error) {
+	uri := fmt.Sprintf("/zones/%s/waiting_rooms/%s/events/%s/details", zoneID, waitingRoomID, eventID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return WaitingRoomEvent{}, err
+	}
+	var r WaitingRoomEventDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return WaitingRoomEvent{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
 // ChangeWaitingRoomEvent lets you change individual settings for a Waiting Room Event. This is
 // in contrast to UpdateWaitingRoomEvent which replaces the entire Waiting Room Event.
 //

--- a/waiting_room_test.go
+++ b/waiting_room_test.go
@@ -475,6 +475,31 @@ func TestWaitingRoomEvent(t *testing.T) {
 	}
 }
 
+func TestWaitingRoomEventPreview(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			  "success": true,
+			  "errors": [],
+			  "messages": [],
+			  "result": %s
+			}
+		`, waitingRoomEventJSON)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/waiting_rooms/699d98642c564d2e855e9661899b7252/events/25756b2dfe6e378a06b033b670413757/details", handler)
+	want := waitingRoomEvent
+
+	actual, err := client.WaitingRoomEventPreview(context.Background(), testZoneID, "699d98642c564d2e855e9661899b7252", "25756b2dfe6e378a06b033b670413757")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
 func TestUpdateWaitingRoomEvent(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description
Add method to preview a Waiting Room Event as if it was active.
This is almost identical to getting a single Event. Just `/preview` added on to the path.
https://api.cloudflare.com/#waiting-room-preview-active-event-details

## Has your change been tested?

Yes, a test has been added to `waiting_room_test.go`.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.