### PR TITLE
Update links to Origin CA Root certificates

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -22,8 +22,8 @@ import (
 const apiURL = "https://api.cloudflare.com/client/v4"
 
 const (
-	originCARootCertEccURL = "https://developers.cloudflare.com/ssl/0d2cd0f374da0fb6dbf53128b60bbbf7/origin_ca_ecc_root.pem"
-	originCARootCertRsaURL = "https://developers.cloudflare.com/ssl/e2b9968022bf23b071d95229b5678452/origin_ca_rsa_root.pem"
+	originCARootCertEccURL = "https://developers.cloudflare.com/ssl/static/origin_ca_ecc_root.pem"
+	originCARootCertRsaURL = "https://developers.cloudflare.com/ssl/static/origin_ca_rsa_root.pem"
 )
 
 const (

--- a/origin_ca.go
+++ b/origin_ca.go
@@ -221,6 +221,11 @@ func OriginCARootCertificate(algorithm string) ([]byte, error) {
 		return nil, errors.Wrap(err, "HTTP request failed")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "Response body could not be read")


### PR DESCRIPTION
## Description

This PR updates the links used to obtain the Cloudflare Origin CA root certificates as per the (new) links obtained from https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/ as the current links now result in a `404` (and associated HTML). Hopefully, these new links are now `static` as indicated in the URl itself :crossed_fingers:.

Note:  An update to https://github.com/cloudflare/terraform-provider-cloudflare will be required on the back of this change as the 
`cloudflare_origin_ca_root_certificate` data resource is currently returning HTML in the `cert_pem` output.

## Has your change been tested?

Tests already exist and should pass with updated URLs.

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
