### PR TITLE
fix: make Enabled within RulesetRuleActionParametersCategories optional for DDoS L7 phase

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -216,7 +216,7 @@ type RulesetRuleActionParametersOverrides struct {
 type RulesetRuleActionParametersCategories struct {
 	Category string `json:"category"`
 	Action   string `json:"action,omitempty"`
-	Enabled  bool   `json:"enabled"`
+	Enabled  *bool  `json:"enabled,omitempty"`
 }
 
 type RulesetRuleActionParametersRules struct {


### PR DESCRIPTION
## Description

As per the API response while configuring ruleset category override in ddos_l7, the Enabled field cannot be used:
    DDoS L7 overrides cannot use the enabled field, DDoS L7 overrides cannot use the enabled field

Therefore, this commit makes the field optional.

```
    "overrides": {
     "categories": [
      {
       // INVALID
       "category": "unusual-requests",
       "action": "challenge",
       "enabled": false
      },
      {
       // VALID
       "category": "botnets",
       "action": "challenge",
      }
     ],
```

## Has your change been tested?

The change was tested within `cloudflare/terraform-provider-cloudflare` via a nacceptance test as well as by running the provider itself within Terraform.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- Unclear to me at this time where a documentation change might be required.
- Have not identified any relevant test associated with this structure after doing a quick code search.
