### PR TITLE
add simple debug for HTTP requests

### DIFF
--- a/options.go
+++ b/options.go
@@ -92,6 +92,13 @@ func BaseURL(baseURL string) Option {
 	}
 }
 
+func Debug(debug bool) Option {
+	return func(api *API) error {
+		api.Debug = debug
+		return nil
+	}
+}
+
 // parseOptions parses the supplied options functions and returns a configured
 // *API instance.
 func (api *API) parseOptions(opts ...Option) error {

--- a/zones.go
+++ b/zones.go
@@ -14,6 +14,13 @@ type ZoneIdentifier string
 
 type ZonesService service
 
+type ZoneCreateParams struct {
+	Name      string   `json:"name"`
+	JumpStart bool     `json:"jump_start"`
+	Type      string   `json:"type"`
+	Account   *Account `json:"organization,omitempty"`
+}
+
 type ZoneParams struct {
 	Match       string `url:"match,omitempty"`
 	Name        string `url:"name,omitempty"`
@@ -41,6 +48,24 @@ func (z ZoneIdentifier) Validate() error {
 		return fmt.Errorf(errInvalidZoneIdentifer, z)
 	}
 	return nil
+}
+
+// New creates a new zone.
+//
+// API reference: https://api.cloudflare.com/#zone-zone-details
+func (s *ZonesService) New(ctx context.Context, zone *ZoneCreateParams) (Zone, error) {
+	res, err := s.client.Call(ctx, http.MethodPost, "/zones", zone)
+	if err != nil {
+		return Zone{}, err
+	}
+
+	var r ZoneResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return Zone{}, fmt.Errorf("failed to unmarshal zone JSON data: %w", err)
+	}
+
+	return r.Result, nil
 }
 
 // Get fetches a single zone.


### PR DESCRIPTION
sometimes, people just want to see the HTTP interactions without a MITM tool.
this enables that by configuring `Debug` to a boolean on the client.

old client

```go
api, err := cloudflare.New("xxx", "xxx@example.com", cloudflare.Debug(true))
if err != nil {
  log.Fatal(err)
}
```

experimental

```go
cParams := &cloudflare.ClientParams{
	Key:   "xxx",
	Email: "xxx@example.com",
	Debug: true,
}
c, _ := cloudflare.NewExperimental(cParams)
```

note: this is different to BYO logger.