### PR TITLE
Add listing of tunnel routes without optional parameters.

### DIFF
--- a/tunnel_routes.go
+++ b/tunnel_routes.go
@@ -1,0 +1,43 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type TunnelRoute struct {
+	Network    string    `json:"network"`
+	TunnelId   string    `json:"tunnel_id"`
+	TunnelName string    `json:"tunnel_name"`
+	Comment    string    `json:"comment"`
+	CreatedAt  time.Time `json:"created_at"`
+	DeletedAt  time.Time `json:"deleted_at"`
+}
+
+// TunnelRouteListResponse is the API response for listing tunnel routes.
+type TunnelRouteListResponse struct {
+	Response
+	Result []TunnelRoute `json:"result"`
+}
+
+func (api *API) TunnelRoutes(ctx context.Context) ([]TunnelRoute, error) {
+	uri := fmt.Sprintf("/%s/%s/teamnet/routes", AccountRouteRoot, api.AccountID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+
+	if err != nil {
+		return []TunnelRoute{}, err
+	}
+
+	var resp TunnelRouteListResponse
+	err = json.Unmarshal(res, &resp)
+	if err != nil {
+		return []TunnelRoute{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return resp.Result, nil
+}

--- a/tunnel_routes_test.go
+++ b/tunnel_routes_test.go
@@ -1,0 +1,62 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//List Tunnel Routes (GET accounts/:account_identifier/teamnet/routes)
+func TestAPI_ListTunnelRoutes(t *testing.T) {
+	setup(UsingAccount(testAccountID))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+			  {
+			    "network": "ff01::/32",
+				"tunnel_id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+				"tunnel_name": "blog",
+				"comment": "Example comment for this route",
+				"created_at": "2021-01-25T18:22:34.317854Z",
+				"deleted_at": "2021-01-25T18:22:34.317854Z"
+              }
+            ]
+          }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/teamnet/routes", handler)
+
+	ts, _ := time.Parse(time.RFC3339Nano, "2021-01-25T18:22:34.317854Z")
+	want := []TunnelRoute{
+		{
+			"ff01::/32",
+			"f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+			"blog",
+			"Example comment for this route",
+			ts,
+			ts,
+		},
+	}
+
+	got, err := client.TunnelRoutes(context.Background())
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}
+
+//Get Tunnel Route by IP (GET accounts/:account_identifier/teamnet/routes/ip/:ip)
+//Create Route (POST accounts/:account_identifier/teamnet/routes/network/:ip_network)
+//Update Route (PATCH accounts/:account_identifier/teamnet/routes/network/:ip_network)
+//Delete Route (DELETE accounts/:account_identifier/teamnet/routes/network/:ip_network)


### PR DESCRIPTION
I'm opening this to add the tunnel routes API endpoints closing #748 in service of ultimately addressing the same resources in the terraform provider (https://github.com/cloudflare/terraform-provider-cloudflare/issues/1086)

## Has your change been tested?

It hasn't... yet.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
