### PR TITLE
Rename tunnel route get methods to conform to convention

### DIFF
--- a/tunnel_routes.go
+++ b/tunnel_routes.go
@@ -67,10 +67,10 @@ type tunnelRouteResponse struct {
 	Result TunnelRoute `json:"result"`
 }
 
-// TunnelRoutes lists all defined routes for tunnels in the account.
+// ListTunnelRoutes lists all defined routes for tunnels in the account.
 //
 // See: https://api.cloudflare.com/#tunnel-route-list-tunnel-routes
-func (api *API) TunnelRoutes(ctx context.Context, params TunnelRoutesListParams) ([]TunnelRoute, error) {
+func (api *API) ListTunnelRoutes(ctx context.Context, params TunnelRoutesListParams) ([]TunnelRoute, error) {
 	if params.AccountID == "" {
 		return []TunnelRoute{}, ErrMissingAccountID
 	}
@@ -91,10 +91,10 @@ func (api *API) TunnelRoutes(ctx context.Context, params TunnelRoutesListParams)
 	return resp.Result, nil
 }
 
-// TunnelRouteForIP finds the Tunnel Route that encompasses the given IP.
+// GetTunnelRouteForIP finds the Tunnel Route that encompasses the given IP.
 //
 // See: https://api.cloudflare.com/#tunnel-route-get-tunnel-route-by-ip
-func (api *API) TunnelRouteForIP(ctx context.Context, params TunnelRoutesForIPParams) (TunnelRoute, error) {
+func (api *API) GetTunnelRouteForIP(ctx context.Context, params TunnelRoutesForIPParams) (TunnelRoute, error) {
 	uri := fmt.Sprintf("/%s/%s/teamnet/routes/ip/%s", AccountRouteRoot, params.AccountID, params.Network)
 
 	responseBody, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)

--- a/tunnel_routes_test.go
+++ b/tunnel_routes_test.go
@@ -50,7 +50,7 @@ func TestListTunnelRoutes(t *testing.T) {
 	}
 
 	params := TunnelRoutesListParams{AccountID: testAccountID}
-	got, err := client.TunnelRoutes(context.Background(), params)
+	got, err := client.ListTunnelRoutes(context.Background(), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, got)
@@ -91,7 +91,7 @@ func TestTunnelRouteForIP(t *testing.T) {
 		DeletedAt:  &ts,
 	}
 
-	got, err := client.TunnelRouteForIP(context.Background(), TunnelRoutesForIPParams{AccountID: testAccountID, Network: "10.1.0.137"})
+	got, err := client.GetTunnelRouteForIP(context.Background(), TunnelRoutesForIPParams{AccountID: testAccountID, Network: "10.1.0.137"})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, got)


### PR DESCRIPTION
After #844 was merged @tjstansell raised that these methods were probably misnamed so I'm correcting it now.
