### PR TITLE
Add Worker bindings support for Services and Durable Objects

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -93,14 +93,14 @@ const (
 	WorkerInheritBindingType WorkerBindingType = "inherit"
 	// WorkerKvNamespaceBindingType is the type for KV Namespace bindings.
 	WorkerKvNamespaceBindingType WorkerBindingType = "kv_namespace"
-	// WorkerWebAssemblyBindingType is the type for Web Assembly module bindings.
-	WorkerWebAssemblyBindingType WorkerBindingType = "wasm_module"
-	// WorkerSecretTextBindingType is the type for secret text bindings.
-	WorkerSecretTextBindingType WorkerBindingType = "secret_text"
 	// WorkerPlainTextBindingType is the type for plain text bindings.
 	WorkerPlainTextBindingType WorkerBindingType = "plain_text"
+	// WorkerSecretTextBindingType is the type for secret text bindings.
+	WorkerSecretTextBindingType WorkerBindingType = "secret_text"
 	// WorkerServiceBindingType is the type for service bindings.
 	WorkerServiceBindingType WorkerBindingType = "service"
+	// WorkerWebAssemblyBindingType is the type for Web Assembly module bindings.
+	WorkerWebAssemblyBindingType WorkerBindingType = "wasm_module"
 )
 
 // WorkerBindingListItem a struct representing an individual binding in a list of bindings.
@@ -428,6 +428,13 @@ func (api *API) ListWorkerBindings(ctx context.Context, requestParams *WorkerReq
 			bindingListItem.Binding = WorkerKvNamespaceBinding{
 				NamespaceID: namespaceID,
 			}
+		case WorkerPlainTextBindingType:
+			text := jsonBinding["text"].(string)
+			bindingListItem.Binding = WorkerPlainTextBinding{
+				Text: text,
+			}
+		case WorkerSecretTextBindingType:
+			bindingListItem.Binding = WorkerSecretTextBinding{}
 		case WorkerServiceBindingType:
 			service := jsonBinding["service"].(string)
 			environment := jsonBinding["environment"].(string)
@@ -443,13 +450,6 @@ func (api *API) ListWorkerBindings(ctx context.Context, requestParams *WorkerReq
 					bindingName:   name,
 				},
 			}
-		case WorkerPlainTextBindingType:
-			text := jsonBinding["text"].(string)
-			bindingListItem.Binding = WorkerPlainTextBinding{
-				Text: text,
-			}
-		case WorkerSecretTextBindingType:
-			bindingListItem.Binding = WorkerSecretTextBinding{}
 		default:
 			bindingListItem.Binding = WorkerInheritBinding{}
 		}

--- a/workers.go
+++ b/workers.go
@@ -89,6 +89,8 @@ func (b WorkerBindingType) String() string {
 }
 
 const (
+	// WorkerDurableObjectBindingType is the type for Durable Object bindings.
+	WorkerDurableObjectBindingType WorkerBindingType = "durable_object_namespace"
 	// WorkerInheritBindingType is the type for inherited bindings.
 	WorkerInheritBindingType WorkerBindingType = "inherit"
 	// WorkerKvNamespaceBindingType is the type for KV Namespace bindings.
@@ -185,6 +187,30 @@ func (b WorkerKvNamespaceBinding) serialize(bindingName string) (workerBindingMe
 		"name":         bindingName,
 		"type":         b.Type(),
 		"namespace_id": b.NamespaceID,
+	}, nil, nil
+}
+
+// WorkerDurableObjectBinding is a binding to a Workers DurableObject
+type WorkerDurableObjectBinding struct {
+	ClassName string
+	ScriptName string
+}
+
+// Type returns the type of the binding.
+func (b WorkerDurableObjectBinding) Type() WorkerBindingType {
+	return WorkerDurableObjectBindingType
+}
+
+func (b WorkerDurableObjectBinding) serialize(bindingName string) (workerBindingMeta, workerBindingBodyWriter, error) {
+	if b.ClassName== "" {
+		return nil, nil, errors.Errorf(`ClassName for binding "%s" cannot be empty`, bindingName)
+	}
+
+	return workerBindingMeta{
+		"name":         bindingName,
+		"type":         b.Type(),
+		"class_name":	b.ClassName,
+		"script_name":	b.ScriptName,
 	}, nil, nil
 }
 
@@ -423,6 +449,13 @@ func (api *API) ListWorkerBindings(ctx context.Context, requestParams *WorkerReq
 		}
 
 		switch WorkerBindingType(bType) {
+		case WorkerDurableObjectBindingType:
+			class_name := jsonBinding["class_name"].(string)
+			script_name := jsonBinding["script_name"].(string)
+			bindingListItem.Binding = WorkerDurableObjectBinding{
+				ClassName: class_name,
+				ScriptName: script_name,
+			}
 		case WorkerKvNamespaceBindingType:
 			namespaceID := jsonBinding["namespace_id"].(string)
 			bindingListItem.Binding = WorkerKvNamespaceBinding{


### PR DESCRIPTION
# Description

I manage some of my workers script using the cloudflare-terraform provider. The new binding types need to be supported in cloudflare-go first and can then be added there.

## Has your change been tested?

Not tested yet, I wrote this cold.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
