### PR TITLE
s/api.AccountID/accountID

### DIFF
--- a/ip_address_management.go
+++ b/ip_address_management.go
@@ -62,8 +62,8 @@ type AdvertisementStatusUpdateRequest struct {
 // ListPrefixes lists all IP prefixes for a given account
 //
 // API reference: https://api.cloudflare.com/#ip-address-management-prefixes-list-prefixes
-func (api *API) ListPrefixes(ctx context.Context) ([]IPPrefix, error) {
-	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes", api.AccountID)
+func (api *API) ListPrefixes(ctx context.Context, accountID string) ([]IPPrefix, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes", accountID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []IPPrefix{}, err
@@ -80,8 +80,8 @@ func (api *API) ListPrefixes(ctx context.Context) ([]IPPrefix, error) {
 // GetPrefix returns a specific IP prefix
 //
 // API reference: https://api.cloudflare.com/#ip-address-management-prefixes-prefix-details
-func (api *API) GetPrefix(ctx context.Context, id string) (IPPrefix, error) {
-	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s", api.AccountID, id)
+func (api *API) GetPrefix(ctx context.Context, accountID, ID string) (IPPrefix, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return IPPrefix{}, err
@@ -98,8 +98,8 @@ func (api *API) GetPrefix(ctx context.Context, id string) (IPPrefix, error) {
 // UpdatePrefixDescription edits the description of the IP prefix
 //
 // API reference: https://api.cloudflare.com/#ip-address-management-prefixes-update-prefix-description
-func (api *API) UpdatePrefixDescription(ctx context.Context, id string, description string) (IPPrefix, error) {
-	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s", api.AccountID, id)
+func (api *API) UpdatePrefixDescription(ctx context.Context, accountID, ID string, description string) (IPPrefix, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, IPPrefixUpdateRequest{Description: description})
 	if err != nil {
 		return IPPrefix{}, err
@@ -116,8 +116,8 @@ func (api *API) UpdatePrefixDescription(ctx context.Context, id string, descript
 // GetAdvertisementStatus returns the BGP status of the IP prefix
 //
 // API reference: https://api.cloudflare.com/#ip-address-management-prefixes-update-prefix-description
-func (api *API) GetAdvertisementStatus(ctx context.Context, id string) (AdvertisementStatus, error) {
-	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s/bgp/status", api.AccountID, id)
+func (api *API) GetAdvertisementStatus(ctx context.Context, accountID, ID string) (AdvertisementStatus, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s/bgp/status", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return AdvertisementStatus{}, err
@@ -134,8 +134,8 @@ func (api *API) GetAdvertisementStatus(ctx context.Context, id string) (Advertis
 // UpdateAdvertisementStatus changes the BGP status of an IP prefix
 //
 // API reference: https://api.cloudflare.com/#ip-address-management-prefixes-update-prefix-description
-func (api *API) UpdateAdvertisementStatus(ctx context.Context, id string, advertised bool) (AdvertisementStatus, error) {
-	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s/bgp/status", api.AccountID, id)
+func (api *API) UpdateAdvertisementStatus(ctx context.Context, accountID, ID string, advertised bool) (AdvertisementStatus, error) {
+	uri := fmt.Sprintf("/accounts/%s/addressing/prefixes/%s/bgp/status", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, AdvertisementStatusUpdateRequest{Advertised: advertised})
 	if err != nil {
 		return AdvertisementStatus{}, err

--- a/ip_address_management_test.go
+++ b/ip_address_management_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestListIPPrefix(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -39,7 +39,7 @@ func TestListIPPrefix(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/addressing/prefixes", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/addressing/prefixes", handler)
 
 	createdAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
 	modifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
@@ -60,14 +60,14 @@ func TestListIPPrefix(t *testing.T) {
 		},
 	}
 
-	actual, err := client.ListPrefixes(context.Background())
+	actual, err := client.ListPrefixes(context.Background(), testAccountID)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestGetIPPrefix(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func TestGetIPPrefix(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c", handler)
 
 	createdAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
 	modifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
@@ -112,14 +112,14 @@ func TestGetIPPrefix(t *testing.T) {
 		AdvertisedModifiedAt: &advertisedModifiedAt,
 	}
 
-	actual, err := client.GetPrefix(context.Background(), "f68579455bd947efb65ffa1bcf33b52c")
+	actual, err := client.GetPrefix(context.Background(), testAccountID, "f68579455bd947efb65ffa1bcf33b52c")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestUpdatePrefixDescription(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -145,7 +145,7 @@ func TestUpdatePrefixDescription(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c", handler)
 
 	createdAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
 	modifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
@@ -164,14 +164,14 @@ func TestUpdatePrefixDescription(t *testing.T) {
 		AdvertisedModifiedAt: &advertisedModifiedAt,
 	}
 
-	actual, err := client.UpdatePrefixDescription(context.Background(), "f68579455bd947efb65ffa1bcf33b52c", "My IP Prefix")
+	actual, err := client.UpdatePrefixDescription(context.Background(), testAccountID, "f68579455bd947efb65ffa1bcf33b52c", "My IP Prefix")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestGetAdvertisementStatus(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -188,7 +188,7 @@ func TestGetAdvertisementStatus(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c/bgp/status", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c/bgp/status", handler)
 
 	advertisedModifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
 
@@ -197,14 +197,14 @@ func TestGetAdvertisementStatus(t *testing.T) {
 		AdvertisedModifiedAt: &advertisedModifiedAt,
 	}
 
-	actual, err := client.GetAdvertisementStatus(context.Background(), "f68579455bd947efb65ffa1bcf33b52c")
+	actual, err := client.GetAdvertisementStatus(context.Background(), testAccountID, "f68579455bd947efb65ffa1bcf33b52c")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestUpdateAdvertisementStatus(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -221,7 +221,7 @@ func TestUpdateAdvertisementStatus(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c/bgp/status", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/addressing/prefixes/f68579455bd947efb65ffa1bcf33b52c/bgp/status", handler)
 
 	advertisedModifiedAt, _ := time.Parse(time.RFC3339, "2020-04-24T21:25:55.643771Z")
 
@@ -230,7 +230,7 @@ func TestUpdateAdvertisementStatus(t *testing.T) {
 		AdvertisedModifiedAt: &advertisedModifiedAt,
 	}
 
-	actual, err := client.UpdateAdvertisementStatus(context.Background(), "f68579455bd947efb65ffa1bcf33b52c", false)
+	actual, err := client.UpdateAdvertisementStatus(context.Background(), testAccountID, "f68579455bd947efb65ffa1bcf33b52c", false)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}

--- a/ip_list_test.go
+++ b/ip_list_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestListIPLists(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +36,7 @@ func TestListIPLists(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2020-01-10T14:00:00Z")
@@ -54,14 +54,14 @@ func TestListIPLists(t *testing.T) {
 		},
 	}
 
-	actual, err := client.ListIPLists(context.Background())
+	actual, err := client.ListIPLists(context.Background(), testAccountID)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestCreateIPList(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -84,7 +84,7 @@ func TestCreateIPList(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2020-01-10T14:00:00Z")
@@ -100,14 +100,14 @@ func TestCreateIPList(t *testing.T) {
 		ModifiedOn:            &modifiedOn,
 	}
 
-	actual, err := client.CreateIPList(context.Background(), "list1", "This is a note.", "ip")
+	actual, err := client.CreateIPList(context.Background(), testAccountID, "list1", "This is a note.", "ip")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestGetIPList(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +130,7 @@ func TestGetIPList(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2020-01-10T14:00:00Z")
@@ -146,14 +146,14 @@ func TestGetIPList(t *testing.T) {
 		ModifiedOn:            &modifiedOn,
 	}
 
-	actual, err := client.GetIPList(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e")
+	actual, err := client.GetIPList(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestUpdateIPList(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -176,7 +176,7 @@ func TestUpdateIPList(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2020-01-10T14:00:00Z")
@@ -192,7 +192,7 @@ func TestUpdateIPList(t *testing.T) {
 		ModifiedOn:            &modifiedOn,
 	}
 
-	actual, err := client.UpdateIPList(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e",
+	actual, err := client.UpdateIPList(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e",
 		"This note was updated.")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -200,7 +200,7 @@ func TestUpdateIPList(t *testing.T) {
 }
 
 func TestDeleteIPList(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -216,7 +216,7 @@ func TestDeleteIPList(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
 
 	want := IPListDeleteResponse{}
 	want.Success = true
@@ -224,14 +224,14 @@ func TestDeleteIPList(t *testing.T) {
 	want.Messages = []ResponseInfo{}
 	want.Result.ID = "34b12448945f11eaa1b71c4d701ab86e"
 
-	actual, err := client.DeleteIPList(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e")
+	actual, err := client.DeleteIPList(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestListIPListsItems(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -282,7 +282,7 @@ func TestListIPListsItems(t *testing.T) {
 		}
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2020-01-10T14:00:00Z")
@@ -304,14 +304,14 @@ func TestListIPListsItems(t *testing.T) {
 		},
 	}
 
-	actual, err := client.ListIPListItems(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e")
+	actual, err := client.ListIPListItems(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
 }
 
 func TestCreateIPListItems(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -327,7 +327,7 @@ func TestCreateIPListItems(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
 
 	want := IPListItemCreateResponse{}
 	want.Success = true
@@ -335,7 +335,7 @@ func TestCreateIPListItems(t *testing.T) {
 	want.Messages = []ResponseInfo{}
 	want.Result.OperationID = "4da8780eeb215e6cb7f48dd981c4ea02"
 
-	actual, err := client.CreateIPListItemsAsync(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e",
+	actual, err := client.CreateIPListItemsAsync(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e",
 		[]IPListItemCreateRequest{{
 			IP:      "192.0.2.1",
 			Comment: "Private IP",
@@ -349,7 +349,7 @@ func TestCreateIPListItems(t *testing.T) {
 }
 
 func TestReplaceIPListItems(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -365,7 +365,7 @@ func TestReplaceIPListItems(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
 
 	want := IPListItemCreateResponse{}
 	want.Success = true
@@ -373,7 +373,7 @@ func TestReplaceIPListItems(t *testing.T) {
 	want.Messages = []ResponseInfo{}
 	want.Result.OperationID = "4da8780eeb215e6cb7f48dd981c4ea02"
 
-	actual, err := client.ReplaceIPListItemsAsync(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e",
+	actual, err := client.ReplaceIPListItemsAsync(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e",
 		[]IPListItemCreateRequest{{
 			IP:      "192.0.2.1",
 			Comment: "Private IP",
@@ -387,7 +387,7 @@ func TestReplaceIPListItems(t *testing.T) {
 }
 
 func TestDeleteIPListItems(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -403,7 +403,7 @@ func TestDeleteIPListItems(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items", handler)
 
 	want := IPListItemDeleteResponse{}
 	want.Success = true
@@ -411,7 +411,7 @@ func TestDeleteIPListItems(t *testing.T) {
 	want.Messages = []ResponseInfo{}
 	want.Result.OperationID = "4da8780eeb215e6cb7f48dd981c4ea02"
 
-	actual, err := client.DeleteIPListItemsAsync(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e",
+	actual, err := client.DeleteIPListItemsAsync(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e",
 		IPListItemDeleteRequest{[]IPListItemDeleteItemRequest{{
 			ID: "34b12448945f11eaa1b71c4d701ab86e",
 		}}})
@@ -421,7 +421,7 @@ func TestDeleteIPListItems(t *testing.T) {
 }
 
 func TestGetIPListItem(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -441,7 +441,7 @@ func TestGetIPListItem(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items/"+
+	mux.HandleFunc("/accounts/"+testAccountID+"/rules/lists/2c0fc9fa937b11eaa1b71c4d701ab86e/items/"+
 		"34b12448945f11eaa1b71c4d701ab86e", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2020-01-01T08:00:00Z")
@@ -455,7 +455,7 @@ func TestGetIPListItem(t *testing.T) {
 		ModifiedOn: &modifiedOn,
 	}
 
-	actual, err := client.GetIPListItem(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e",
+	actual, err := client.GetIPListItem(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e",
 		"34b12448945f11eaa1b71c4d701ab86e")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -467,7 +467,7 @@ func TestPollIPListTimeout(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := client.pollIPListBulkOperation(ctx, "list1")
+	err := client.pollIPListBulkOperation(ctx, testAccountID, "list1")
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	assert.WithinDuration(t, start, time.Now(), time.Second,
 		"pollIPListBulkOperation took too much time with an expiring context")

--- a/magic_firewall_rulesets.go
+++ b/magic_firewall_rulesets.go
@@ -99,12 +99,8 @@ type UpdateMagicFirewallRulesetResponse struct {
 // ListMagicFirewallRulesets lists all Rulesets for a given account
 //
 // API reference: https://api.cloudflare.com/#rulesets-list-rulesets
-func (api *API) ListMagicFirewallRulesets(ctx context.Context) ([]MagicFirewallRuleset, error) {
-	if err := api.checkAccountID(); err != nil {
-		return []MagicFirewallRuleset{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/rulesets", api.AccountID)
+func (api *API) ListMagicFirewallRulesets(ctx context.Context, accountID string) ([]MagicFirewallRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets", accountID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []MagicFirewallRuleset{}, err
@@ -121,12 +117,8 @@ func (api *API) ListMagicFirewallRulesets(ctx context.Context) ([]MagicFirewallR
 // GetMagicFirewallRuleset returns a specific Magic Firewall Ruleset
 //
 // API reference: https://api.cloudflare.com/#rulesets-get-a-ruleset
-func (api *API) GetMagicFirewallRuleset(ctx context.Context, id string) (MagicFirewallRuleset, error) {
-	if err := api.checkAccountID(); err != nil {
-		return MagicFirewallRuleset{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", api.AccountID, id)
+func (api *API) GetMagicFirewallRuleset(ctx context.Context, accountID, ID string) (MagicFirewallRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return MagicFirewallRuleset{}, err
@@ -143,12 +135,8 @@ func (api *API) GetMagicFirewallRuleset(ctx context.Context, id string) (MagicFi
 // CreateMagicFirewallRuleset creates a Magic Firewall ruleset
 //
 // API reference: https://api.cloudflare.com/#rulesets-list-rulesets
-func (api *API) CreateMagicFirewallRuleset(ctx context.Context, name string, description string, rules []MagicFirewallRulesetRule) (MagicFirewallRuleset, error) {
-	if err := api.checkAccountID(); err != nil {
-		return MagicFirewallRuleset{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/rulesets", api.AccountID)
+func (api *API) CreateMagicFirewallRuleset(ctx context.Context, accountID, name, description string, rules []MagicFirewallRulesetRule) (MagicFirewallRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets", accountID)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri,
 		CreateMagicFirewallRulesetRequest{
 			Name:        name,
@@ -171,12 +159,8 @@ func (api *API) CreateMagicFirewallRuleset(ctx context.Context, name string, des
 // DeleteMagicFirewallRuleset deletes a Magic Firewall ruleset
 //
 // API reference: https://api.cloudflare.com/#rulesets-delete-ruleset
-func (api *API) DeleteMagicFirewallRuleset(ctx context.Context, id string) error {
-	if err := api.checkAccountID(); err != nil {
-		return err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", api.AccountID, id)
+func (api *API) DeleteMagicFirewallRuleset(ctx context.Context, accountID, ID string) error {
+	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 
 	if err != nil {
@@ -195,12 +179,8 @@ func (api *API) DeleteMagicFirewallRuleset(ctx context.Context, id string) error
 // UpdateMagicFirewallRuleset updates a Magic Firewall ruleset
 //
 // API reference: https://api.cloudflare.com/#rulesets-update-ruleset
-func (api *API) UpdateMagicFirewallRuleset(ctx context.Context, id string, description string, rules []MagicFirewallRulesetRule) (MagicFirewallRuleset, error) {
-	if err := api.checkAccountID(); err != nil {
-		return MagicFirewallRuleset{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", api.AccountID, id)
+func (api *API) UpdateMagicFirewallRuleset(ctx context.Context, accountID, ID string, description string, rules []MagicFirewallRulesetRule) (MagicFirewallRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri,
 		UpdateMagicFirewallRulesetRequest{Description: description, Rules: rules})
 	if err != nil {
@@ -213,12 +193,4 @@ func (api *API) UpdateMagicFirewallRuleset(ctx context.Context, id string, descr
 	}
 
 	return result.Result, nil
-}
-
-func (api *API) checkAccountID() error {
-	if api.AccountID == "" {
-		return fmt.Errorf("account ID must not be empty")
-	}
-
-	return nil
 }

--- a/magic_firewall_rulesets_test.go
+++ b/magic_firewall_rulesets_test.go
@@ -35,7 +35,7 @@ func TestListMagicFirewallRulesets(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rulesets", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets", handler)
 
 	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
 
@@ -51,7 +51,7 @@ func TestListMagicFirewallRulesets(t *testing.T) {
 		},
 	}
 
-	actual, err := client.ListMagicFirewallRulesets(context.Background())
+	actual, err := client.ListMagicFirewallRulesets(context.Background(), testAccountID)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -95,7 +95,7 @@ func TestGetMagicFirewallRuleset(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
 
 	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
 	rules := []MagicFirewallRulesetRule{{
@@ -123,7 +123,7 @@ func TestGetMagicFirewallRuleset(t *testing.T) {
 		Rules:       rules,
 	}
 
-	actual, err := client.GetMagicFirewallRuleset(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e")
+	actual, err := client.GetMagicFirewallRuleset(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -167,7 +167,7 @@ func TestCreateMagicFirewallRuleset(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rulesets", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets", handler)
 
 	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
 	rules := []MagicFirewallRulesetRule{{
@@ -195,7 +195,7 @@ func TestCreateMagicFirewallRuleset(t *testing.T) {
 		Rules:       rules,
 	}
 
-	actual, err := client.CreateMagicFirewallRuleset(context.Background(), "ruleset1", "Test Firewall Ruleset", rules)
+	actual, err := client.CreateMagicFirewallRuleset(context.Background(), testAccountID, "ruleset1", "Test Firewall Ruleset", rules)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -252,7 +252,7 @@ func TestUpdateMagicFirewallRuleset(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/foo/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
 
 	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
 	rules := []MagicFirewallRulesetRule{{
@@ -292,7 +292,7 @@ func TestUpdateMagicFirewallRuleset(t *testing.T) {
 		Rules:       rules,
 	}
 
-	actual, err := client.UpdateMagicFirewallRuleset(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e", "Test Firewall Ruleset Update", rules)
+	actual, err := client.UpdateMagicFirewallRuleset(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e", "Test Firewall Ruleset Update", rules)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -311,8 +311,8 @@ func TestDeleteMagicFirewallRuleset(t *testing.T) {
 		fmt.Fprint(w, ``)
 	}
 
-	mux.HandleFunc("/accounts/foo/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
 
-	err := client.DeleteMagicFirewallRuleset(context.Background(), "2c0fc9fa937b11eaa1b71c4d701ab86e")
+	err := client.DeleteMagicFirewallRuleset(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
 	assert.NoError(t, err)
 }

--- a/magic_transit_static_routes.go
+++ b/magic_transit_static_routes.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // Magic Transit Static Routes Error messages.
@@ -76,12 +77,8 @@ type CreateMagicTransitStaticRoutesRequest struct {
 // ListMagicTransitStaticRoutes lists all static routes for a given account
 //
 // API reference: https://api.cloudflare.com/#magic-transit-static-routes-list-routes
-func (api *API) ListMagicTransitStaticRoutes(ctx context.Context) ([]MagicTransitStaticRoute, error) {
-	if err := api.checkAccountID(); err != nil {
-		return []MagicTransitStaticRoute{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/magic/routes", api.AccountID)
+func (api *API) ListMagicTransitStaticRoutes(ctx context.Context, accountID string) ([]MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes", accountID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []MagicTransitStaticRoute{}, err
@@ -98,12 +95,8 @@ func (api *API) ListMagicTransitStaticRoutes(ctx context.Context) ([]MagicTransi
 // GetMagicTransitStaticRoute returns exactly one static route
 //
 // API reference: https://api.cloudflare.com/#magic-transit-static-routes-route-details
-func (api *API) GetMagicTransitStaticRoute(ctx context.Context, id string) (MagicTransitStaticRoute, error) {
-	if err := api.checkAccountID(); err != nil {
-		return MagicTransitStaticRoute{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/magic/routes/%s", api.AccountID, id)
+func (api *API) GetMagicTransitStaticRoute(ctx context.Context, accountID, ID string) (MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return MagicTransitStaticRoute{}, err
@@ -120,12 +113,8 @@ func (api *API) GetMagicTransitStaticRoute(ctx context.Context, id string) (Magi
 // CreateMagicTransitStaticRoute creates a new static route
 //
 // API reference: https://api.cloudflare.com/#magic-transit-static-routes-create-routes
-func (api *API) CreateMagicTransitStaticRoute(ctx context.Context, route MagicTransitStaticRoute) ([]MagicTransitStaticRoute, error) {
-	if err := api.checkAccountID(); err != nil {
-		return []MagicTransitStaticRoute{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/magic/routes", api.AccountID)
+func (api *API) CreateMagicTransitStaticRoute(ctx context.Context, accountID string, route MagicTransitStaticRoute) ([]MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes", accountID)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, CreateMagicTransitStaticRoutesRequest{
 		Routes: []MagicTransitStaticRoute{
 			route,
@@ -147,12 +136,8 @@ func (api *API) CreateMagicTransitStaticRoute(ctx context.Context, route MagicTr
 // UpdateMagicTransitStaticRoute updates a static route
 //
 // API reference: https://api.cloudflare.com/#magic-transit-static-routes-update-route
-func (api *API) UpdateMagicTransitStaticRoute(ctx context.Context, id string, route MagicTransitStaticRoute) (MagicTransitStaticRoute, error) {
-	if err := api.checkAccountID(); err != nil {
-		return MagicTransitStaticRoute{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/magic/routes/%s", api.AccountID, id)
+func (api *API) UpdateMagicTransitStaticRoute(ctx context.Context, accountID, ID string, route MagicTransitStaticRoute) (MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, route)
 
 	if err != nil {
@@ -174,12 +159,8 @@ func (api *API) UpdateMagicTransitStaticRoute(ctx context.Context, id string, ro
 // DeleteMagicTransitStaticRoute deletes a static route
 //
 // API reference: https://api.cloudflare.com/#magic-transit-static-routes-delete-route
-func (api *API) DeleteMagicTransitStaticRoute(ctx context.Context, id string) (MagicTransitStaticRoute, error) {
-	if err := api.checkAccountID(); err != nil {
-		return MagicTransitStaticRoute{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/magic/routes/%s", api.AccountID, id)
+func (api *API) DeleteMagicTransitStaticRoute(ctx context.Context, accountID, ID string) (MagicTransitStaticRoute, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/routes/%s", accountID, ID)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 
 	if err != nil {

--- a/magic_transit_static_routes_test.go
+++ b/magic_transit_static_routes_test.go
@@ -46,7 +46,7 @@ func TestListMagicTransitStaticRoutes(t *testing.T) {
     }`)
 	}
 
-	mux.HandleFunc("/accounts/foo/magic/routes", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
@@ -72,7 +72,7 @@ func TestListMagicTransitStaticRoutes(t *testing.T) {
 		},
 	}
 
-	actual, err := client.ListMagicTransitStaticRoutes(context.Background())
+	actual, err := client.ListMagicTransitStaticRoutes(context.Background(), testAccountID)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -112,7 +112,7 @@ func TestGetMagicTransitStaticRoute(t *testing.T) {
     }`)
 	}
 
-	mux.HandleFunc("/accounts/foo/magic/routes/c4a7362d577a6c3019a474fd6f485821", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes/c4a7362d577a6c3019a474fd6f485821", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
@@ -136,7 +136,7 @@ func TestGetMagicTransitStaticRoute(t *testing.T) {
 		},
 	}
 
-	actual, err := client.GetMagicTransitStaticRoute(context.Background(), "c4a7362d577a6c3019a474fd6f485821")
+	actual, err := client.GetMagicTransitStaticRoute(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -178,7 +178,7 @@ func TestCreateMagicTransitStaticRoutes(t *testing.T) {
     }`)
 	}
 
-	mux.HandleFunc("/accounts/foo/magic/routes", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
@@ -202,7 +202,7 @@ func TestCreateMagicTransitStaticRoutes(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateMagicTransitStaticRoute(context.Background(), want)
+	actual, err := client.CreateMagicTransitStaticRoute(context.Background(), testAccountID, want)
 	if assert.NoError(t, err) {
 		assert.Equal(t, []MagicTransitStaticRoute{
 			want,
@@ -245,7 +245,7 @@ func TestUpdateMagicTransitStaticRoute(t *testing.T) {
     }`)
 	}
 
-	mux.HandleFunc("/accounts/foo/magic/routes/c4a7362d577a6c3019a474fd6f485821", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes/c4a7362d577a6c3019a474fd6f485821", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
@@ -269,7 +269,7 @@ func TestUpdateMagicTransitStaticRoute(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateMagicTransitStaticRoute(context.Background(), "c4a7362d577a6c3019a474fd6f485821", want)
+	actual, err := client.UpdateMagicTransitStaticRoute(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821", want)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -310,7 +310,7 @@ func TestDeleteMagicTransitStaticRoute(t *testing.T) {
     }`)
 	}
 
-	mux.HandleFunc("/accounts/foo/magic/routes/c4a7362d577a6c3019a474fd6f485821", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/routes/c4a7362d577a6c3019a474fd6f485821", handler)
 
 	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
@@ -334,7 +334,7 @@ func TestDeleteMagicTransitStaticRoute(t *testing.T) {
 		},
 	}
 
-	actual, err := client.DeleteMagicTransitStaticRoute(context.Background(), "c4a7362d577a6c3019a474fd6f485821")
+	actual, err := client.DeleteMagicTransitStaticRoute(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}

--- a/workers_cron_triggers.go
+++ b/workers_cron_triggers.go
@@ -33,12 +33,8 @@ type WorkerCronTrigger struct {
 // script.
 //
 // API reference: https://api.cloudflare.com/#worker-cron-trigger-get-cron-triggers
-func (api *API) ListWorkerCronTriggers(ctx context.Context, scriptName string) ([]WorkerCronTrigger, error) {
-	if err := api.checkAccountID(); err != nil {
-		return []WorkerCronTrigger{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", api.AccountID, scriptName)
+func (api *API) ListWorkerCronTriggers(ctx context.Context, accountID, scriptName string) ([]WorkerCronTrigger, error) {
+	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", accountID, scriptName)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return []WorkerCronTrigger{}, err
@@ -55,12 +51,8 @@ func (api *API) ListWorkerCronTriggers(ctx context.Context, scriptName string) (
 // UpdateWorkerCronTriggers updates a single schedule for a Worker cron trigger.
 //
 // API reference: https://api.cloudflare.com/#worker-cron-trigger-update-cron-triggers
-func (api *API) UpdateWorkerCronTriggers(ctx context.Context, scriptName string, crons []WorkerCronTrigger) ([]WorkerCronTrigger, error) {
-	if err := api.checkAccountID(); err != nil {
-		return []WorkerCronTrigger{}, err
-	}
-
-	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", api.AccountID, scriptName)
+func (api *API) UpdateWorkerCronTriggers(ctx context.Context, accountID, scriptName string, crons []WorkerCronTrigger) ([]WorkerCronTrigger, error) {
+	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/schedules", accountID, scriptName)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, crons)
 	if err != nil {
 		return []WorkerCronTrigger{}, err

--- a/workers_cron_triggers_test.go
+++ b/workers_cron_triggers_test.go
@@ -33,7 +33,7 @@ func TestListWorkerCronTriggers(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/9a7806061c88ada191ed06f989cc3dac/workers/scripts/example-script/schedules", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/workers/scripts/example-script/schedules", handler)
 	createdOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
 	want := []WorkerCronTrigger{{
@@ -42,7 +42,7 @@ func TestListWorkerCronTriggers(t *testing.T) {
 		CreatedOn:  &createdOn,
 	}}
 
-	actual, err := client.ListWorkerCronTriggers(context.Background(), "example-script")
+	actual, err := client.ListWorkerCronTriggers(context.Background(), testAccountID, "example-script")
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
@@ -71,7 +71,7 @@ func TestUpdateWorkerCronTriggers(t *testing.T) {
 		}`)
 	}
 
-	mux.HandleFunc("/accounts/9a7806061c88ada191ed06f989cc3dac/workers/scripts/example-script/schedules", handler)
+	mux.HandleFunc("/accounts/"+testAccountID+"/workers/scripts/example-script/schedules", handler)
 	createdOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
 	modifiedOn, _ := time.Parse(time.RFC3339, "2017-01-01T00:00:00Z")
 	want := []WorkerCronTrigger{{
@@ -80,7 +80,7 @@ func TestUpdateWorkerCronTriggers(t *testing.T) {
 		CreatedOn:  &createdOn,
 	}}
 
-	actual, err := client.UpdateWorkerCronTriggers(context.Background(), "example-script", want)
+	actual, err := client.UpdateWorkerCronTriggers(context.Background(), testAccountID, "example-script", want)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}


### PR DESCRIPTION
Updates all methods that were relying on `api.AccountID` via the client
constructor to pass in explicit account IDs for the methods instead.

Even though the Workers APIs still use `api.AccountID`, I'm leaving them
as the whole thing needs an overhaul now that the API has settled.

Closes #694