### PR TITLE
Add ZeroDowntimeFailover field to SessionAffinityAttributes

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -166,15 +166,17 @@ type LoadBalancerRuleOverrides struct {
 // LoadBalancerRuleOverridesSessionAffinityAttrs mimics SessionAffinityAttributes without the
 // DrainDuration field as that field can not be overwritten via rules.
 type LoadBalancerRuleOverridesSessionAffinityAttrs struct {
-	SameSite string `json:"samesite,omitempty"`
-	Secure   string `json:"secure,omitempty"`
+	SameSite             string `json:"samesite,omitempty"`
+	Secure               string `json:"secure,omitempty"`
+	ZeroDowntimeFailover string `json:"zero_downtime_failover,omitempty"`
 }
 
 // SessionAffinityAttributes represents the fields used to set attributes in a load balancer session affinity cookie.
 type SessionAffinityAttributes struct {
-	SameSite      string `json:"samesite,omitempty"`
-	Secure        string `json:"secure,omitempty"`
-	DrainDuration int    `json:"drain_duration,omitempty"`
+	SameSite             string `json:"samesite,omitempty"`
+	Secure               string `json:"secure,omitempty"`
+	DrainDuration        int    `json:"drain_duration,omitempty"`
+	ZeroDowntimeFailover string `json:"zero_downtime_failover,omitempty"`
 }
 
 // LoadBalancerOriginHealth represents the health of the origin.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -950,7 +950,8 @@ func TestCreateLoadBalancer(t *testing.T) {
               "session_affinity_attributes": {
                 "samesite": "Strict",
                 "secure": "Always",
-                "drain_duration": 60
+                "drain_duration": 60,
+                "zero_downtime_failover": "sticky"
               }
             }`, string(b))
 		}
@@ -1018,7 +1019,8 @@ func TestCreateLoadBalancer(t *testing.T) {
                 "session_affinity_attributes": {
                     "samesite": "Strict",
                     "secure": "Always",
-                    "drain_duration": 60
+                    "drain_duration": 60,
+	                "zero_downtime_failover": "sticky"
                 }
             }
         }`)
@@ -1085,9 +1087,10 @@ func TestCreateLoadBalancer(t *testing.T) {
 		Persistence:    "cookie",
 		PersistenceTTL: 5000,
 		SessionAffinityAttributes: &SessionAffinityAttributes{
-			SameSite:      "Strict",
-			Secure:        "Always",
-			DrainDuration: 60,
+			SameSite:             "Strict",
+			Secure:               "Always",
+			DrainDuration:        60,
+			ZeroDowntimeFailover: "sticky",
 		},
 	}
 	request := LoadBalancer{
@@ -1145,9 +1148,10 @@ func TestCreateLoadBalancer(t *testing.T) {
 		Persistence:    "cookie",
 		PersistenceTTL: 5000,
 		SessionAffinityAttributes: &SessionAffinityAttributes{
-			SameSite:      "Strict",
-			Secure:        "Always",
-			DrainDuration: 60,
+			SameSite:             "Strict",
+			Secure:               "Always",
+			DrainDuration:        60,
+			ZeroDowntimeFailover: "sticky",
 		},
 	}
 
@@ -1470,7 +1474,8 @@ func TestModifyLoadBalancer(t *testing.T) {
                 "session_affinity": "none",
                 "session_affinity_attributes": {
                   "samesite": "Strict",
-                  "secure": "Always"
+                  "secure": "Always",
+				  "zero_downtime_failover": "sticky"
                 }
 			}`, string(b))
 		}
@@ -1520,7 +1525,8 @@ func TestModifyLoadBalancer(t *testing.T) {
                 "session_affinity": "none",
                 "session_affinity_attributes": {
                   "samesite": "Strict",
-                  "secure": "Always"
+                  "secure": "Always",
+	              "zero_downtime_failover": "sticky"
                 }
             }
         }`)
@@ -1570,8 +1576,9 @@ func TestModifyLoadBalancer(t *testing.T) {
 		Proxied:     true,
 		Persistence: "none",
 		SessionAffinityAttributes: &SessionAffinityAttributes{
-			SameSite: "Strict",
-			Secure:   "Always",
+			SameSite:             "Strict",
+			Secure:               "Always",
+			ZeroDowntimeFailover: "sticky",
 		},
 	}
 	request := LoadBalancer{
@@ -1613,8 +1620,9 @@ func TestModifyLoadBalancer(t *testing.T) {
 		Proxied:     true,
 		Persistence: "none",
 		SessionAffinityAttributes: &SessionAffinityAttributes{
-			SameSite: "Strict",
-			Secure:   "Always",
+			SameSite:             "Strict",
+			Secure:               "Always",
+			ZeroDowntimeFailover: "sticky",
 		},
 	}
 


### PR DESCRIPTION
## Description

Add new API field called `ZeroDowntimeFailover` to `SessionAffinityAttributes` in `LoadBalancer`

## Has your change been tested?

Updated load balancing tests verify input field matches the returning JSON/struct.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
