### PR TITLE
work around teams list API bug that only returns 50 items by default

### DIFF
--- a/teams_list.go
+++ b/teams_list.go
@@ -107,7 +107,8 @@ func (api *API) TeamsList(ctx context.Context, accountID, listID string) (TeamsL
 //
 // API reference: https://api.cloudflare.com/#teams-lists-teams-list-items
 func (api *API) TeamsListItems(ctx context.Context, accountID, listID string) ([]TeamsListItem, ResultInfo, error) {
-	uri := fmt.Sprintf("/%s/%s/gateway/lists/%s/items", AccountRouteRoot, accountID, listID)
+	// limit parameter works around bug in the API
+	uri := fmt.Sprintf("/%s/%s/gateway/lists/%s/items?limit=10000", AccountRouteRoot, accountID, listID)
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {


### PR DESCRIPTION
This patch works around an internal API bug where the teams list API returns only 50 items.  There is an internal ticket with the gateway engineering team to fix this at the API itself, but it has been open for months with no progress.  This is a temporary workaround to [allow the terraform provider](https://github.com/cloudflare/terraform-provider-cloudflare/issues/1422) to actually manage teams lists larger than 50 items.  Given that [lists have a max size of 5000 for enterprise accounts](https://developers.cloudflare.com/cloudflare-one/policies/lists/) we just use the undocumented `limit` parameter to make sure we request the entire list.  This can get reverted once they fix the bug in the API.