### PR TITLE
Add Origin Override rulesets support

### DIFF
--- a/origin_override_rulesets.go
+++ b/origin_override_rulesets.go
@@ -1,0 +1,199 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// OriginOverrideRulesetKindRoot specifies a root Ruleset.
+	OriginOverrideRulesetKindRoot = "root"
+
+	// OriginOverrideRulesetPhaseOrigin specifies the Origin Override Ruleset phase.
+	OriginOverrideRulesetPhaseOrigin = "http_request_origin"
+
+	// OriginOverrideRulesetRuleActionRoute specifies a route action.
+	OriginOverrideRulesetRuleActionRoute OriginOverrideRulesetRuleAction = "route"
+)
+
+// OriginOverrideRulesetRuleAction specifies the action for a Origin Override rule.
+type OriginOverrideRulesetRuleAction string
+
+// OriginOverrideRuleset contains information about a Origin Override Ruleset.
+type OriginOverrideRuleset struct {
+	ID          string                      `json:"id"`
+	Name        string                      `json:"name"`
+	Description string                      `json:"description"`
+	Kind        string                      `json:"kind"`
+	Version     string                      `json:"version,omitempty"`
+	LastUpdated *time.Time                  `json:"last_updated,omitempty"`
+	Phase       string                      `json:"phase"`
+	Rules       []OriginOverrideRulesetRule `json:"rules"`
+}
+
+type OriginOverrideRulesetRuleActionOriginParameters struct {
+	Host string `json:"host"`
+	Port uint16 `json:"port"`
+}
+
+// OriginOverrideRulesetRuleActionParameters specifies the action parameters for a Origin Override rule.
+type OriginOverrideRulesetRuleActionParameters struct {
+	HostHeader string                                          `json:"host_header"`
+	Origin     OriginOverrideRulesetRuleActionOriginParameters `json:"origin"`
+}
+
+// OriginOverrideRulesetRule contains information about a single Origin Override rule.
+type OriginOverrideRulesetRule struct {
+	ID               string                                     `json:"id,omitempty"`
+	Version          string                                     `json:"version,omitempty"`
+	Action           OriginOverrideRulesetRuleAction            `json:"action"`
+	ActionParameters *OriginOverrideRulesetRuleActionParameters `json:"action_parameters,omitempty"`
+	Expression       string                                     `json:"expression"`
+	Description      string                                     `json:"description"`
+	LastUpdated      *time.Time                                 `json:"last_updated,omitempty"`
+	Ref              string                                     `json:"ref,omitempty"`
+	Enabled          bool                                       `json:"enabled"`
+}
+
+// CreateOriginOverrideRulesetRequest contains data for a new Origin Override ruleset.
+type CreateOriginOverrideRulesetRequest struct {
+	Name        string                      `json:"name"`
+	Description string                      `json:"description"`
+	Kind        string                      `json:"kind"`
+	Phase       string                      `json:"phase"`
+	Rules       []OriginOverrideRulesetRule `json:"rules"`
+}
+
+// UpdateOriginOverrideRulesetRequest contains data for a Origin Override ruleset update.
+type UpdateOriginOverrideRulesetRequest struct {
+	Description string                      `json:"description"`
+	Rules       []OriginOverrideRulesetRule `json:"rules"`
+}
+
+// ListOriginOverrideRulesetResponse contains a list of Origin Override rulesets.
+type ListOriginOverrideRulesetResponse struct {
+	Response
+	Result []OriginOverrideRuleset `json:"result"`
+}
+
+// GetOriginOverrideRulesetResponse contains a single Origin Override Ruleset.
+type GetOriginOverrideRulesetResponse struct {
+	Response
+	Result OriginOverrideRuleset `json:"result"`
+}
+
+// CreateOriginOverrideRulesetResponse contains response data when creating a new Origin Override ruleset.
+type CreateOriginOverrideRulesetResponse struct {
+	Response
+	Result OriginOverrideRuleset `json:"result"`
+}
+
+// UpdateOriginOverrideRulesetResponse contains response data when updating an existing Origin Override ruleset.
+type UpdateOriginOverrideRulesetResponse struct {
+	Response
+	Result OriginOverrideRuleset `json:"result"`
+}
+
+// ListOriginOverrideRulesets lists all Rulesets for a given account
+//
+// API reference: https://api.cloudflare.com/#rulesets-list-rulesets
+func (api *API) ListOriginOverrideRulesets(ctx context.Context, accountID string) ([]OriginOverrideRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets?phase=%s", accountID, OriginOverrideRulesetPhaseOrigin)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []OriginOverrideRuleset{}, err
+	}
+
+	result := ListOriginOverrideRulesetResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return []OriginOverrideRuleset{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+// GetOriginOverrideRuleset returns a specific Origin Override Ruleset
+//
+// API reference: https://api.cloudflare.com/#rulesets-get-a-ruleset
+func (api *API) GetOriginOverrideRuleset(ctx context.Context, accountID, ID string) (OriginOverrideRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", accountID, ID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return OriginOverrideRuleset{}, err
+	}
+
+	result := GetOriginOverrideRulesetResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return OriginOverrideRuleset{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+// CreateOriginOverrideRuleset creates a Origin Override ruleset
+//
+// API reference: https://api.cloudflare.com/#rulesets-list-rulesets
+func (api *API) CreateOriginOverrideRuleset(ctx context.Context, accountID, name, description string, rules []OriginOverrideRulesetRule) (OriginOverrideRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets", accountID)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri,
+		CreateOriginOverrideRulesetRequest{
+			Name:        name,
+			Description: description,
+			Kind:        OriginOverrideRulesetKindRoot,
+			Phase:       OriginOverrideRulesetPhaseOrigin,
+			Rules:       rules})
+	if err != nil {
+		return OriginOverrideRuleset{}, err
+	}
+
+	result := CreateOriginOverrideRulesetResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return OriginOverrideRuleset{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+// DeleteOriginOverrideRuleset deletes a Origin Override ruleset
+//
+// API reference: https://api.cloudflare.com/#rulesets-delete-ruleset
+func (api *API) DeleteOriginOverrideRuleset(ctx context.Context, accountID, ID string) error {
+	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", accountID, ID)
+	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+
+	if err != nil {
+		return err
+	}
+
+	// Firewall API is not implementing the standard response blob but returns an empty response (204) in case
+	// of a success. So we are checking for the response body size here
+	if len(res) > 0 {
+		return errors.Wrap(errors.New(string(res)), errMakeRequestError)
+	}
+
+	return nil
+}
+
+// UpdateOriginOverrideRuleset updates a Origin Override ruleset
+//
+// API reference: https://api.cloudflare.com/#rulesets-update-ruleset
+func (api *API) UpdateOriginOverrideRuleset(ctx context.Context, accountID, ID string, description string, rules []OriginOverrideRulesetRule) (OriginOverrideRuleset, error) {
+	uri := fmt.Sprintf("/accounts/%s/rulesets/%s", accountID, ID)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri,
+		UpdateOriginOverrideRulesetRequest{Description: description, Rules: rules})
+	if err != nil {
+		return OriginOverrideRuleset{}, err
+	}
+
+	result := UpdateOriginOverrideRulesetResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return OriginOverrideRuleset{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}

--- a/origin_override_rulesets_test.go
+++ b/origin_override_rulesets_test.go
@@ -1,0 +1,350 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListOriginOverrideRulesets(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": [
+				{
+					"id": "2c0fc9fa937b11eaa1b71c4d701ab86e",
+					"name": "ruleset1",
+					"description": "Test Origin Override Ruleset",
+					"kind": "root",
+					"version": "1",
+					"last_updated": "2020-12-02T20:24:07.776073Z",
+					"phase": "http_request_origin"
+				}
+			],
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets", handler)
+
+	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
+
+	want := []OriginOverrideRuleset{
+		{
+			ID:          "2c0fc9fa937b11eaa1b71c4d701ab86e",
+			Name:        "ruleset1",
+			Description: "Test Origin Override Ruleset",
+			Kind:        "root",
+			Version:     "1",
+			LastUpdated: &lastUpdated,
+			Phase:       OriginOverrideRulesetPhaseOrigin,
+		},
+	}
+
+	actual, err := client.ListOriginOverrideRulesets(context.Background(), testAccountID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetOriginOverrideRuleset(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"id": "2c0fc9fa937b11eaa1b71c4d701ab86e",
+				"name": "ruleset1",
+				"description": "Test Origin Override Ruleset",
+				"kind": "root",
+				"version": "1",
+				"last_updated": "2020-12-02T20:24:07.776073Z",
+				"phase": "http_request_origin",
+				"rules": [
+					{
+						"id": "62449e2e0de149619edb35e59c10d801",
+						"version": "1",
+						"action": "route",
+						"action_parameters":{
+							"host_header": "my_host",
+							"origin": {
+								"host": "test.host.com",
+								"port": 80,
+							}
+						},
+						"expression": "http.host eq \"fake.net\"",
+						"description": "Change origin destination and header",
+						"last_updated": "2020-12-02T20:24:07.776073Z",
+						"ref": "72449e2e0de149619edb35e59c10d801",
+						"enabled": true
+					}
+				]
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+
+	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
+	rules := []OriginOverrideRulesetRule{{
+		ID:      "62449e2e0de149619edb35e59c10d801",
+		Version: "1",
+		Action:  OriginOverrideRulesetRuleActionRoute,
+		ActionParameters: &OriginOverrideRulesetRuleActionParameters{
+			HostHeader: "test.host.com",
+			Origin: OriginOverrideRulesetRuleActionOriginParameters{
+				Host: "test.host.com",
+				Port: 80,
+			},
+		},
+		Expression:  "http.host eq \"fake.net\"",
+		Description: "Change origin destination and header",
+		LastUpdated: &lastUpdated,
+		Ref:         "72449e2e0de149619edb35e59c10d801",
+		Enabled:     true,
+	}}
+
+	want := OriginOverrideRuleset{
+		ID:          "2c0fc9fa937b11eaa1b71c4d701ab86e",
+		Name:        "ruleset1",
+		Description: "Test Origin Override Ruleset",
+		Kind:        "root",
+		Version:     "1",
+		LastUpdated: &lastUpdated,
+		Phase:       OriginOverrideRulesetPhaseOrigin,
+		Rules:       rules,
+	}
+
+	actual, err := client.GetOriginOverrideRuleset(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateOriginOverrideRuleset(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"id": "2c0fc9fa937b11eaa1b71c4d701ab86e",
+				"name": "ruleset1",
+				"description": "Test Origin Override Ruleset",
+				"kind": "root",
+				"version": "1",
+				"last_updated": "2020-12-02T20:24:07.776073Z",
+				"phase": "http_request_origin",
+				"rules": [
+					{
+						"id": "62449e2e0de149619edb35e59c10d801",
+						"version": "1",
+						"action": "route",
+						"action_parameters":{
+							"host_header": "my_host",
+							"origin": {
+								"host": "test.host.com",
+								"port": 80,
+							}
+						},
+						"expression": "http.host eq \"fake.net\"",
+						"description": "Change origin destination and header",
+						"last_updated": "2020-12-02T20:24:07.776073Z",
+						"ref": "72449e2e0de149619edb35e59c10d801",
+						"enabled": true
+					}
+				]
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets", handler)
+
+	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
+	rules := []OriginOverrideRulesetRule{{
+		ID:      "62449e2e0de149619edb35e59c10d801",
+		Version: "1",
+		Action:  OriginOverrideRulesetRuleActionRoute,
+		ActionParameters: &OriginOverrideRulesetRuleActionParameters{
+			HostHeader: "my_host",
+			Origin: OriginOverrideRulesetRuleActionOriginParameters{
+				Host: "test.host.com",
+				Port: 80,
+			},
+		},
+		Expression:  "http.host eq \"fake.net\"",
+		Description: "Change origin destination and header",
+		LastUpdated: &lastUpdated,
+		Ref:         "72449e2e0de149619edb35e59c10d801",
+		Enabled:     true,
+	}}
+
+	want := OriginOverrideRuleset{
+		ID:          "2c0fc9fa937b11eaa1b71c4d701ab86e",
+		Name:        "ruleset1",
+		Description: "Test Origin Override Ruleset",
+		Kind:        "root",
+		Version:     "1",
+		LastUpdated: &lastUpdated,
+		Phase:       OriginOverrideRulesetPhaseOrigin,
+		Rules:       rules,
+	}
+
+	actual, err := client.CreateOriginOverrideRuleset(context.Background(), testAccountID, "ruleset1", "Test Origin Override Ruleset", rules)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateOriginOverrideRuleset(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"result": {
+				"id": "2c0fc9fa937b11eaa1b71c4d701ab86e",
+				"name": "ruleset1",
+				"description": "Origin Override Ruleset Update",
+				"kind": "root",
+				"version": "1",
+				"last_updated": "2020-12-02T20:24:07.776073Z",
+				"phase": "http_request_origin",
+				"rules": [
+					{
+						"id": "62449e2e0de149619edb35e59c10d801",
+						"version": "1",
+						"action": "route",
+						"action_parameters":{
+							"host_header": "my_host",
+							"origin": {
+								"host": "test.host.com",
+								"port": 80,
+							}
+						},
+						"expression": "http.host eq \"fake.net\"",
+						"description": "Change origin destination and header",
+						"last_updated": "2020-12-02T20:24:07.776073Z",
+						"ref": "72449e2e0de149619edb35e59c10d801",
+						"enabled": true
+					},
+					{
+						"id": "62449e2e0de149619edb35e59c10d802",
+						"version": "1",
+						"action": "route",
+						"action_parameters":{
+							"host_header": "my_host2",
+							"origin": {
+								"host": "test2.host.com",
+								"port": 80,
+							}
+						},
+						"expression": "http.host eq \"fake2.net\"",
+						"description": "Change origin destination and header",
+						"last_updated": "2020-12-02T20:24:07.776073Z",
+						"ref": "72449e2e0de149619edb35e59c10d801",
+						"enabled": true
+					}
+				]
+			},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+
+	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-02T20:24:07.776073Z")
+	rules := []OriginOverrideRulesetRule{{
+		ID:      "62449e2e0de149619edb35e59c10d801",
+		Version: "1",
+		Action:  OriginOverrideRulesetRuleActionRoute,
+		ActionParameters: &OriginOverrideRulesetRuleActionParameters{
+			HostHeader: "my_host",
+			Origin: OriginOverrideRulesetRuleActionOriginParameters{
+				Host: "test.host.com",
+				Port: 80,
+			},
+		},
+		Expression:  "http.host eq \"fake.net\"",
+		Description: "Change origin destination and header",
+		LastUpdated: &lastUpdated,
+		Ref:         "72449e2e0de149619edb35e59c10d801",
+		Enabled:     true,
+	}, {
+		ID:      "62449e2e0de149619edb35e59c10d802",
+		Version: "1",
+		Action:  OriginOverrideRulesetRuleActionRoute,
+		ActionParameters: &OriginOverrideRulesetRuleActionParameters{
+			HostHeader: "my_host2",
+			Origin: OriginOverrideRulesetRuleActionOriginParameters{
+				Host: "test2.host.com",
+				Port: 80,
+			},
+		},
+		Expression:  "http.host eq \"fake2.net\"",
+		Description: "Change origin destination and header",
+		LastUpdated: &lastUpdated,
+		Ref:         "72449e2e0de149619edb35e59c10d801",
+		Enabled:     true,
+	}}
+
+	want := OriginOverrideRuleset{
+		ID:          "2c0fc9fa937b11eaa1b71c4d701ab86e",
+		Name:        "ruleset1",
+		Description: "Test Origin Override Ruleset Update",
+		Kind:        "root",
+		Version:     "1",
+		LastUpdated: &lastUpdated,
+		Phase:       OriginOverrideRulesetPhaseOrigin,
+		Rules:       rules,
+	}
+
+	actual, err := client.UpdateOriginOverrideRuleset(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e", "Test Origin Override Ruleset Update", rules)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+// Firewall API is not implementing the standard response blob but returns an empty response (204) in case
+// of a success. So we are checking for the response body size here
+// TODO, This is going to be changed by MFW-63.
+func TestDeleteOriginOverrideRuleset(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, ``)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets/2c0fc9fa937b11eaa1b71c4d701ab86e", handler)
+
+	err := client.DeleteOriginOverrideRuleset(context.Background(), testAccountID, "2c0fc9fa937b11eaa1b71c4d701ab86e")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Adding support for the new phase with rulesets to Override Origin and HostHeader of the request

## Description

Added new structures and calls specifically for Origin Override rulesets and Route Action

## Has your change been tested?

Added test