### PR TITLE
healthchecks: add Notification.Trigger to HealthcheckNotification struct

### DIFF
--- a/healthchecks.go
+++ b/healthchecks.go
@@ -56,6 +56,7 @@ type HealthcheckTCPConfig struct {
 type HealthcheckNotification struct {
 	Suspended      bool     `json:"suspended,omitempty"`
 	EmailAddresses []string `json:"email_addresses,omitempty"`
+	Trigger        string   `json:"trigger,omitempty"`
 }
 
 // HealthcheckListResponse is the API response, containing an array of healthchecks.

--- a/healthchecks_test.go
+++ b/healthchecks_test.go
@@ -47,7 +47,8 @@ const (
 		"tcp_config": null,
 		"notification": {
 			"suspended": false,
-			"email_addresses": ["alerts@example.com"]
+			"email_addresses": ["alerts@example.com"],
+			"trigger": "ALL"
 		},
 		"created_on": "2019-01-13T12:20:00.12345Z",
 		"modified_on": "2019-01-13T12:20:00.12345Z",
@@ -90,6 +91,7 @@ var (
 		Notification: HealthcheckNotification{
 			Suspended:      false,
 			EmailAddresses: []string{"alerts@example.com"},
+			Trigger:        "ALL",
 		},
 		Status:        "unknown",
 		FailureReason: "",


### PR DESCRIPTION
Even though this is deprecated, keep the struct inline with the public documentation.