### PR TITLE
Add `frequency` field to logpush job

### DIFF
--- a/logpush.go
+++ b/logpush.go
@@ -22,6 +22,7 @@ type LogpushJob struct {
 	LastComplete       *time.Time `json:"last_complete,omitempty"`
 	LastError          *time.Time `json:"last_error,omitempty"`
 	ErrorMessage       string     `json:"error_message,omitempty"`
+	Frequency          string     `json:"frequency,omitempty"`
 }
 
 // LogpushJobsResponse is the API response, containing an array of Logpush Jobs.

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -23,7 +23,8 @@ const (
 	"destination_conf": "s3://mybucket/logs?region=us-west-2",
 	"last_complete": "%[2]s",
 	"last_error": "%[2]s",
-	"error_message": "test"
+	"error_message": "test",
+	"frequency": "high"
   }
 `
 	serverLogpushGetOwnershipChallengeDescription = `{
@@ -52,6 +53,7 @@ var (
 		LastComplete:    &testLogpushTimestamp,
 		LastError:       &testLogpushTimestamp,
 		ErrorMessage:    "test",
+		Frequency:       "high",
 	}
 	expectedLogpushGetOwnershipChallengeStruct = LogpushGetOwnershipChallenge{
 		Filename: "logs/challenge-filename.txt",


### PR DESCRIPTION
## Description

Adds the field `frequency` to `LogpushJob` struct.

```
The frequency at which Cloudflare sends batches of logs to your destination.
Setting frequency to high sends your logs in larger quantities of smaller files.
Setting frequency to low sends logs in smaller quantities of larger files.
```

https://api.cloudflare.com/#logpush-jobs-create-logpush-job

## Has your change been tested?

Updated the existing test to include the new field with the default value of `high`. This has been part of the Logpush API for a while, just adding it here as well.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
