### PR TITLE
add next_event_prequeue_start_time and next_event_start_time 

### DIFF
--- a/waiting_room.go
+++ b/waiting_room.go
@@ -12,21 +12,23 @@ import (
 
 // WaitingRoom describes a WaitingRoom object.
 type WaitingRoom struct {
-	CreatedOn             time.Time `json:"created_on,omitempty"`
-	ModifiedOn            time.Time `json:"modified_on,omitempty"`
-	Path                  string    `json:"path"`
-	Name                  string    `json:"name"`
-	Description           string    `json:"description,omitempty"`
-	CustomPageHTML        string    `json:"custom_page_html,omitempty"`
-	Host                  string    `json:"host"`
-	ID                    string    `json:"id,omitempty"`
-	NewUsersPerMinute     int       `json:"new_users_per_minute"`
-	TotalActiveUsers      int       `json:"total_active_users"`
-	SessionDuration       int       `json:"session_duration"`
-	QueueAll              bool      `json:"queue_all"`
-	DisableSessionRenewal bool      `json:"disable_session_renewal"`
-	Suspended             bool      `json:"suspended"`
-	JsonResponseEnabled   bool      `json:"json_response_enabled"`
+	CreatedOn                  time.Time  `json:"created_on,omitempty"`
+	ModifiedOn                 time.Time  `json:"modified_on,omitempty"`
+	Path                       string     `json:"path"`
+	Name                       string     `json:"name"`
+	Description                string     `json:"description,omitempty"`
+	CustomPageHTML             string     `json:"custom_page_html,omitempty"`
+	Host                       string     `json:"host"`
+	ID                         string     `json:"id,omitempty"`
+	NewUsersPerMinute          int        `json:"new_users_per_minute"`
+	TotalActiveUsers           int        `json:"total_active_users"`
+	SessionDuration            int        `json:"session_duration"`
+	QueueAll                   bool       `json:"queue_all"`
+	DisableSessionRenewal      bool       `json:"disable_session_renewal"`
+	Suspended                  bool       `json:"suspended"`
+	JsonResponseEnabled        bool       `json:"json_response_enabled"`
+	NextEventPrequeueStartTime *time.Time `json:"next_event_prequeue_start_time,omitempty"`
+	NextEventStartTime         *time.Time `json:"next_event_start_time,omitempty"`
 }
 
 // WaitingRoomStatus describes the status of a waiting room.
@@ -40,22 +42,22 @@ type WaitingRoomStatus struct {
 
 // WaitingRoomEvent describes a WaitingRoomEvent object.
 type WaitingRoomEvent struct {
-	EventEndTime          time.Time `json:"event_end_time"`
-	CreatedOn             time.Time `json:"created_on,omitempty"`
-	ModifiedOn            time.Time `json:"modified_on,omitempty"`
-	PrequeueStartTime     time.Time `json:"prequeue_start_time,omitempty"`
-	EventStartTime        time.Time `json:"event_start_time"`
-	Name                  string    `json:"name"`
-	Description           string    `json:"description,omitempty"`
-	QueueingMethod        string    `json:"queueing_method,omitempty"`
-	ID                    string    `json:"id,omitempty"`
-	CustomPageHTML        string    `json:"custom_page_html,omitempty"`
-	NewUsersPerMinute     int       `json:"new_users_per_minute,omitempty"`
-	TotalActiveUsers      int       `json:"total_active_users,omitempty"`
-	SessionDuration       int       `json:"session_duration,omitempty"`
-	DisableSessionRenewal *bool     `json:"disable_session_renewal,omitempty"`
-	Suspended             bool      `json:"suspended"`
-	ShuffleAtEventStart   bool      `json:"shuffle_at_event_start"`
+	EventEndTime          time.Time  `json:"event_end_time"`
+	CreatedOn             time.Time  `json:"created_on,omitempty"`
+	ModifiedOn            time.Time  `json:"modified_on,omitempty"`
+	PrequeueStartTime     *time.Time `json:"prequeue_start_time,omitempty"`
+	EventStartTime        time.Time  `json:"event_start_time"`
+	Name                  string     `json:"name"`
+	Description           string     `json:"description,omitempty"`
+	QueueingMethod        string     `json:"queueing_method,omitempty"`
+	ID                    string     `json:"id,omitempty"`
+	CustomPageHTML        string     `json:"custom_page_html,omitempty"`
+	NewUsersPerMinute     int        `json:"new_users_per_minute,omitempty"`
+	TotalActiveUsers      int        `json:"total_active_users,omitempty"`
+	SessionDuration       int        `json:"session_duration,omitempty"`
+	DisableSessionRenewal *bool      `json:"disable_session_renewal,omitempty"`
+	Suspended             bool       `json:"suspended"`
+	ShuffleAtEventStart   bool       `json:"shuffle_at_event_start"`
 }
 
 // WaitingRoomPagePreviewURL describes a WaitingRoomPagePreviewURL object.

--- a/waiting_room_test.go
+++ b/waiting_room_test.go
@@ -34,9 +34,12 @@ var waitingRoomJSON = fmt.Sprintf(`
       "session_duration": 10,
       "disable_session_renewal": false,
       "json_response_enabled": true,
-      "custom_page_html": "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}"
+      "custom_page_html": "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}",
+      "next_event_prequeue_start_time": null,
+      "next_event_start_time": "%s"
     }
-   `, waitingRoomID, testTimestampWaitingRoom.Format(time.RFC3339Nano), testTimestampWaitingRoom.Format(time.RFC3339Nano))
+   `, waitingRoomID, testTimestampWaitingRoom.Format(time.RFC3339Nano), testTimestampWaitingRoom.Format(time.RFC3339Nano),
+	testTimestampWaitingRoomEventStart.Format(time.RFC3339Nano))
 
 var waitingRoomEventJSON = fmt.Sprintf(`
     {
@@ -80,21 +83,23 @@ var waitingRoomPagePreviewJSON = `
     `
 
 var waitingRoom = WaitingRoom{
-	ID:                    waitingRoomID,
-	CreatedOn:             testTimestampWaitingRoom,
-	ModifiedOn:            testTimestampWaitingRoom,
-	Name:                  "production_webinar",
-	Description:           "Production - DO NOT MODIFY",
-	Suspended:             false,
-	Host:                  "shop.example.com",
-	Path:                  "/shop/checkout",
-	QueueAll:              true,
-	NewUsersPerMinute:     600,
-	TotalActiveUsers:      1000,
-	SessionDuration:       10,
-	DisableSessionRenewal: false,
-	JsonResponseEnabled:   true,
-	CustomPageHTML:        "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}",
+	ID:                         waitingRoomID,
+	CreatedOn:                  testTimestampWaitingRoom,
+	ModifiedOn:                 testTimestampWaitingRoom,
+	Name:                       "production_webinar",
+	Description:                "Production - DO NOT MODIFY",
+	Suspended:                  false,
+	Host:                       "shop.example.com",
+	Path:                       "/shop/checkout",
+	QueueAll:                   true,
+	NewUsersPerMinute:          600,
+	TotalActiveUsers:           1000,
+	SessionDuration:            10,
+	DisableSessionRenewal:      false,
+	JsonResponseEnabled:        true,
+	CustomPageHTML:             "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}",
+	NextEventStartTime:         &testTimestampWaitingRoomEventStart,
+	NextEventPrequeueStartTime: nil,
 }
 
 var waitingRoomEvent = WaitingRoomEvent{
@@ -104,7 +109,7 @@ var waitingRoomEvent = WaitingRoomEvent{
 	Name:                  "production_webinar_event",
 	Description:           "Production event - DO NOT MODIFY",
 	Suspended:             false,
-	PrequeueStartTime:     testTimestampWaitingRoomEventPrequeue,
+	PrequeueStartTime:     &testTimestampWaitingRoomEventPrequeue,
 	EventStartTime:        testTimestampWaitingRoomEventStart,
 	EventEndTime:          testTimestampWaitingRoomEventEnd,
 	ShuffleAtEventStart:   false,


### PR DESCRIPTION
- Add `next_event_prequeue_start_time` and `next_event_start_time` to Waiting Room.

- Use time.Time pointer for nullable Waiting Room Event `prequeue_start_time` property.

## Description
The waiting room schema now exposes the prequeue start time and start time of the next event or the event that is currently in progress.
This is not documented in the official API yet.

The `prequeue_start_time` property on `WaitingRoomEvent`  should be a pointer. It is optional and if not specified should serialize to `null`.
I think switching to a pointer might be a breaking change, especially for the Terraform provider. 

## Has your change been tested?

Updated unit tests and pass.
Tested with real resources using the API.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) 

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
