### PR TITLE
tunnel: return tunnel token, fix uri

### DIFF
--- a/tunnel.go
+++ b/tunnel.go
@@ -48,6 +48,12 @@ type TunnelDetailResponse struct {
 	Response
 }
 
+// TunnelTokenResponse is  the API response for a tunnel token.
+type TunnelTokenResponse struct {
+	Result string `json:"result"`
+	Response
+}
+
 type TunnelParams struct {
 	AccountID string
 	ID        string
@@ -263,27 +269,27 @@ func (api *API) CleanupTunnelConnections(ctx context.Context, params TunnelClean
 // TunnelToken that allows to run a tunnel.
 //
 // API reference: https://api.cloudflare.com/#cloudflare-tunnel-get-cloudflare-tunnel-token
-func (api *API) TunnelToken(ctx context.Context, params TunnelTokenParams) error {
+func (api *API) TunnelToken(ctx context.Context, params TunnelTokenParams) (string, error) {
 	if params.AccountID == "" {
-		return ErrMissingAccountID
+		return "", ErrMissingAccountID
 	}
 
 	if params.ID == "" {
-		return errors.New("missing tunnel ID")
+		return "", errors.New("missing tunnel ID")
 	}
 
-	uri := fmt.Sprintf("accounts/%s/cfd_tunnel/%s/token", params.AccountID, params.ID)
+	uri := fmt.Sprintf("/accounts/%s/cfd_tunnel/%s/token", params.AccountID, params.ID)
 
 	res, err := api.makeRequestContextWithHeaders(ctx, http.MethodGet, uri, nil, nil)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	var argoDetailsResponse TunnelDetailResponse
-	err = json.Unmarshal(res, &argoDetailsResponse)
+	var tunnelTokenResponse TunnelTokenResponse
+	err = json.Unmarshal(res, &tunnelTokenResponse)
 	if err != nil {
-		return errors.Wrap(err, errUnmarshalError)
+		return "", errors.Wrap(err, errUnmarshalError)
 	}
 
-	return nil
+	return tunnelTokenResponse.Result, nil
 }

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -247,3 +247,26 @@ func TestCleanupTunnelConnections(t *testing.T) {
 	err := client.CleanupTunnelConnections(context.Background(), TunnelCleanupParams{AccountID: testAccountID, ID: "f174e90a-fafe-4643-bbbc-4a0ed4fc8415"})
 	assert.NoError(t, err)
 }
+
+func TestTunnelToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": "ZHNraGdhc2RraGFza2hqZGFza2poZGFza2poYXNrZGpoYWtzamRoa2FzZGpoa2FzamRoa2Rhc2po\na2FzamRoa2FqCg=="
+		  }
+		`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/cfd_tunnel/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/token", handler)
+
+	token, err := client.TunnelToken(context.Background(), TunnelTokenParams{AccountID: testAccountID, ID: "f174e90a-fafe-4643-bbbc-4a0ed4fc8415"})
+	assert.NoError(t, err)
+	assert.Equal(t, "ZHNraGdhc2RraGFza2hqZGFza2poZGFza2poYXNrZGpoYWtzamRoa2FzZGpoa2FzamRoa2Rhc2po\na2FzamRoa2FqCg==", token)
+}


### PR DESCRIPTION
## Description

Update TunnelToken to return the result as a string. Also fixes the uri to start with `/`

Downstream PR here: https://github.com/cloudflare/terraform-provider-cloudflare/pull/1590 (to be updated)

## Has your change been tested?

Tested locally with changes to the terraform provider (see above PR) to verify token result was retrievable and properly set in state.

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.