### PR TITLE
deprecate `UsingAccount`

### DIFF
--- a/images_test.go
+++ b/images_test.go
@@ -39,7 +39,7 @@ var expectedImageStruct = Image{
 }
 
 func TestUploadImage(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -80,7 +80,7 @@ func TestUploadImage(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1", handler)
 	want := expectedImageStruct
 
-	actual, err := client.UploadImage(context.Background(), client.AccountID, ImageUploadRequest{
+	actual, err := client.UploadImage(context.Background(), testAccountID, ImageUploadRequest{
 		File: fakeFile{
 			Buffer: bytes.NewBufferString("this is definitely an image"),
 		},
@@ -97,7 +97,7 @@ func TestUploadImage(t *testing.T) {
 }
 
 func TestUpdateImage(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	input := ImageUpdateRequest{
@@ -141,7 +141,7 @@ func TestUpdateImage(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1/ZxR0pLaXRldlBtaFhhO2FiZGVnaA", handler)
 	want := expectedImageStruct
 
-	actual, err := client.UpdateImage(context.Background(), client.AccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA", input)
+	actual, err := client.UpdateImage(context.Background(), testAccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA", input)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -149,7 +149,7 @@ func TestUpdateImage(t *testing.T) {
 }
 
 func TestCreateImageDirectUploadURL(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	input := ImageDirectUploadURLRequest{
@@ -183,7 +183,7 @@ func TestCreateImageDirectUploadURL(t *testing.T) {
 		UploadURL: "https://upload.imagedelivery.net/fgr33htrthytjtyereifjewoi338272s7w1383",
 	}
 
-	actual, err := client.CreateImageDirectUploadURL(context.Background(), client.AccountID, input)
+	actual, err := client.CreateImageDirectUploadURL(context.Background(), testAccountID, input)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -191,7 +191,7 @@ func TestCreateImageDirectUploadURL(t *testing.T) {
 }
 
 func TestListImages(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -226,7 +226,7 @@ func TestListImages(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1", handler)
 	want := []Image{expectedImageStruct}
 
-	actual, err := client.ListImages(context.Background(), client.AccountID, PaginationOptions{})
+	actual, err := client.ListImages(context.Background(), testAccountID, PaginationOptions{})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -234,7 +234,7 @@ func TestListImages(t *testing.T) {
 }
 
 func TestImageDetails(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -265,7 +265,7 @@ func TestImageDetails(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1/ZxR0pLaXRldlBtaFhhO2FiZGVnaA", handler)
 	want := expectedImageStruct
 
-	actual, err := client.ImageDetails(context.Background(), client.AccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA")
+	actual, err := client.ImageDetails(context.Background(), testAccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -273,7 +273,7 @@ func TestImageDetails(t *testing.T) {
 }
 
 func TestBaseImage(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -285,7 +285,7 @@ func TestBaseImage(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1/ZxR0pLaXRldlBtaFhhO2FiZGVnaA/blob", handler)
 	want := []byte{}
 
-	actual, err := client.BaseImage(context.Background(), client.AccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA")
+	actual, err := client.BaseImage(context.Background(), testAccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -293,7 +293,7 @@ func TestBaseImage(t *testing.T) {
 }
 
 func TestDeleteImage(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -310,7 +310,7 @@ func TestDeleteImage(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1/ZxR0pLaXRldlBtaFhhO2FiZGVnaA", handler)
 
-	err := client.DeleteImage(context.Background(), client.AccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA")
+	err := client.DeleteImage(context.Background(), testAccountID, "ZxR0pLaXRldlBtaFhhO2FiZGVnaA")
 	require.NoError(t, err)
 }
 

--- a/magic_firewall_rulesets_test.go
+++ b/magic_firewall_rulesets_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestListMagicFirewallRulesets(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -58,7 +58,7 @@ func TestListMagicFirewallRulesets(t *testing.T) {
 }
 
 func TestGetMagicFirewallRuleset(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +130,7 @@ func TestGetMagicFirewallRuleset(t *testing.T) {
 }
 
 func TestCreateMagicFirewallRuleset(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -202,7 +202,7 @@ func TestCreateMagicFirewallRuleset(t *testing.T) {
 }
 
 func TestUpdateMagicFirewallRuleset(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -302,7 +302,7 @@ func TestUpdateMagicFirewallRuleset(t *testing.T) {
 // of a success. So we are checking for the response body size here
 // TODO, This is going to be changed by MFW-63.
 func TestDeleteMagicFirewallRuleset(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/magic_transit_static_routes_test.go
+++ b/magic_transit_static_routes_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestListMagicTransitStaticRoutes(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -79,7 +79,7 @@ func TestListMagicTransitStaticRoutes(t *testing.T) {
 }
 
 func TestGetMagicTransitStaticRoute(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -143,7 +143,7 @@ func TestGetMagicTransitStaticRoute(t *testing.T) {
 }
 
 func TestCreateMagicTransitStaticRoutes(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -211,7 +211,7 @@ func TestCreateMagicTransitStaticRoutes(t *testing.T) {
 }
 
 func TestUpdateMagicTransitStaticRoute(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -276,7 +276,7 @@ func TestUpdateMagicTransitStaticRoute(t *testing.T) {
 }
 
 func TestDeleteMagicTransitStaticRoute(t *testing.T) {
-	setup(UsingAccount("foo"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/options.go
+++ b/options.go
@@ -30,6 +30,8 @@ func Headers(headers http.Header) Option {
 
 // UsingAccount allows you to apply account-level changes (Load Balancing,
 // Railguns) to an account instead.
+//
+// Deprecated: Resources should define the `AccountID` parameter explicitly.
 func UsingAccount(accountID string) Option {
 	return func(api *API) error {
 		api.AccountID = accountID

--- a/pages_project_test.go
+++ b/pages_project_test.go
@@ -331,7 +331,7 @@ var (
 )
 
 func TestListPagesProjects(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -373,7 +373,7 @@ func TestListPagesProjects(t *testing.T) {
 }
 
 func TestPagesProject(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -397,7 +397,7 @@ func TestPagesProject(t *testing.T) {
 }
 
 func TestCreatePagesProject(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -421,7 +421,7 @@ func TestCreatePagesProject(t *testing.T) {
 }
 
 func TestUpdatePagesProject(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	updateAttributes := &PagesProject{
@@ -450,7 +450,7 @@ func TestUpdatePagesProject(t *testing.T) {
 }
 
 func TestDeletePagesProject(t *testing.T) {
-	setup(UsingAccount(testAccountID))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Only workers relies on this now so we can deprecate it in favour of
explicit account identifiers.

Cleans up tests that never actually needed this.

Follows on from #850