### PR TITLE
AS-8430: Update history API to accept timestamp query params

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -456,8 +456,8 @@ func (api *API) Raw(method, endpoint string, data interface{}) (json.RawMessage,
 // PaginationOptions can be passed to a list request to configure paging
 // These values will be defaulted if omitted, and PerPage has min/max limits set by resource.
 type PaginationOptions struct {
-	Page    int `json:"page,omitempty"`
-	PerPage int `json:"per_page,omitempty"`
+	Page    int `json:"page,omitempty" url:"page,omitempty"`
+	PerPage int `json:"per_page,omitempty" url:"per_page,omitempty"`
 }
 
 // RetryPolicy specifies number of retries and min/max retry delays

--- a/notifications.go
+++ b/notifications.go
@@ -405,19 +405,37 @@ func (api *API) GetAvailableNotificationTypes(ctx context.Context, accountID str
 	return r, nil
 }
 
+// TimeRange is an object for filtering the alert history based on timestamp.
+type TimeRange struct {
+	Since  string `json:"since,omitempty"`
+	Before string `json:"before,omitempty"`
+}
+
+// AlertHistoryFilter is an object for filtering the alert history response from the api.
+type AlertHistoryFilter struct {
+	TimeRange  TimeRange
+	Pagination PaginationOptions
+}
+
 // ListNotificationHistory will return the history of alerts sent for
 // a given account. The time period varies based on zone plan.
 // Free, Biz, Pro = 30 days
 // Ent = 90 days
 //
 // API Reference: https://api.cloudflare.com/#notification-history-list-history
-func (api *API) ListNotificationHistory(ctx context.Context, accountID string, pageOpts PaginationOptions) ([]NotificationHistory, ResultInfo, error) {
+func (api *API) ListNotificationHistory(ctx context.Context, accountID string, alertHistoryFilter AlertHistoryFilter) ([]NotificationHistory, ResultInfo, error) {
 	v := url.Values{}
-	if pageOpts.PerPage > 0 {
-		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
+	if alertHistoryFilter.Pagination.PerPage > 0 {
+		v.Set("per_page", strconv.Itoa(alertHistoryFilter.Pagination.PerPage))
 	}
-	if pageOpts.Page > 0 {
-		v.Set("page", strconv.Itoa(pageOpts.Page))
+	if alertHistoryFilter.Pagination.Page > 0 {
+		v.Set("page", strconv.Itoa(alertHistoryFilter.Pagination.Page))
+	}
+	if alertHistoryFilter.TimeRange.Since != "" {
+		v.Set("since", alertHistoryFilter.TimeRange.Since)
+	}
+	if alertHistoryFilter.TimeRange.Before != "" {
+		v.Set("before", alertHistoryFilter.TimeRange.Before)
 	}
 
 	baseURL := fmt.Sprintf("/accounts/%s/alerting/v3/history", accountID)

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -536,7 +536,7 @@ func TestListNotificationHistory(t *testing.T) {
 		Before: time.Now().Format(time.RFC3339),
 	}
 
-	historyFilters := AlertHistoryFilter{TimeRange: timeRange, Pagination: pageOptions}
+	historyFilters := AlertHistoryFilter{TimeRange: timeRange, PaginationOptions: pageOptions}
 
 	alertHistory, err := json.Marshal(expected)
 	require.NoError(t, err)

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -531,6 +531,13 @@ func TestListNotificationHistory(t *testing.T) {
 		Page:    1,
 	}
 
+	timeRange := TimeRange{
+		Since:  time.Now().Add(-15 * time.Minute).Format(time.RFC3339),
+		Before: time.Now().Format(time.RFC3339),
+	}
+
+	historyFilters := AlertHistoryFilter{TimeRange: timeRange, Pagination: pageOptions}
+
 	alertHistory, err := json.Marshal(expected)
 	require.NoError(t, err)
 	require.NotNil(t, alertHistory)
@@ -558,7 +565,7 @@ func TestListNotificationHistory(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/alerting/v3/history", handler)
 
-	actualResult, actualResultInfo, err := client.ListNotificationHistory(context.Background(), testAccountID, pageOptions)
+	actualResult, actualResultInfo, err := client.ListNotificationHistory(context.Background(), testAccountID, historyFilters)
 	require.Nil(t, err)
 	require.NotNil(t, actualResult)
 	require.Equal(t, expected, actualResult)


### PR DESCRIPTION
Alert history API now have the ability to query by timestamp filter. This PR is to add that functionality to cloudflare-go integration as well.