### PR TITLE
support empty custom metadata

### DIFF
--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -92,7 +92,7 @@ type CustomHostname struct {
 	CustomOriginServer        string                                  `json:"custom_origin_server,omitempty"`
 	CustomOriginSNI           string                                  `json:"custom_origin_sni,omitempty"`
 	SSL                       *CustomHostnameSSL                      `json:"ssl,omitempty"`
-	CustomMetadata            CustomMetadata                          `json:"custom_metadata,omitempty"`
+	CustomMetadata            *CustomMetadata                         `json:"custom_metadata,omitempty"`
 	Status                    CustomHostnameStatus                    `json:"status,omitempty"`
 	VerificationErrors        []string                                `json:"verification_errors,omitempty"`
 	OwnershipVerification     CustomHostnameOwnershipVerification     `json:"ownership_verification,omitempty"`


### PR DESCRIPTION
## Description

When updating custom metadata, the omitempty prevents go from marshalling an empty map as needed by PATCH semantics for updates (eg. to delete the metadata).

Using a pointer for the map (as is done for the SSL member, and has started being adopted elsewhere in this pkg) resolves this.

## Has your change been tested?

Additional tests have been added (and the existing tests cover the normal cases).

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is sort of a breaking change - any applications using the CustomMetadata field will need to pass an address instead, but since Go is typed they should be aware of the change.

Also, since IIRC this is an enterprise feature, and only after requesting it be activated, I suspect the number of users impacted is minimal. (totally a guess on my part)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
