### PR TITLE
Updating API usage of IPsec tunnels

### DIFF
--- a/magic_transit_ipsec_tunnel.go
+++ b/magic_transit_ipsec_tunnel.go
@@ -16,16 +16,31 @@ const (
 	errMagicTransitIPsecTunnelNotDeleted  = "When trying to delete IPsec tunnel, API returned deleted: false"
 )
 
+type RemoteIdentities struct {
+	HexID  string `json:"hex_id"`
+	FQDNID string `json:"fqdn_id"`
+	UserID string `json:"user_id"`
+}
+
+// MagicTransitIPsecTunnelPskMetadata contains metadata associated with PSK.
+type MagicTransitIPsecTunnelPskMetadata struct {
+	LastGeneratedOn *time.Time `json:"last_generated_on,omitempty"`
+}
+
 // MagicTransitIPsecTunnel contains information about an IPsec tunnel.
 type MagicTransitIPsecTunnel struct {
-	ID                 string     `json:"id,omitempty"`
-	CreatedOn          *time.Time `json:"created_on,omitempty"`
-	ModifiedOn         *time.Time `json:"modified_on,omitempty"`
-	Name               string     `json:"name"`
-	CustomerEndpoint   string     `json:"customer_endpoint"`
-	CloudflareEndpoint string     `json:"cloudflare_endpoint"`
-	InterfaceAddress   string     `json:"interface_address"`
-	Description        string     `json:"description,omitempty"`
+	ID                 string                              `json:"id,omitempty"`
+	CreatedOn          *time.Time                          `json:"created_on,omitempty"`
+	ModifiedOn         *time.Time                          `json:"modified_on,omitempty"`
+	Name               string                              `json:"name"`
+	CustomerEndpoint   string                              `json:"customer_endpoint"`
+	CloudflareEndpoint string                              `json:"cloudflare_endpoint"`
+	InterfaceAddress   string                              `json:"interface_address"`
+	Description        string                              `json:"description,omitempty"`
+	HealthCheck        *MagicTransitTunnelHealthcheck      `json:"health_check,omitempty"`
+	Psk                string                              `json:"psk,omitempty"`
+	PskMetadata        *MagicTransitIPsecTunnelPskMetadata `json:"psk_metadata,omitempty"`
+	RemoteIdentities   *RemoteIdentities                   `json:"remote_identities,omitempty"`
 }
 
 // ListMagicTransitIPsecTunnelsResponse contains a response including IPsec tunnels.
@@ -64,6 +79,15 @@ type DeleteMagicTransitIPsecTunnelResponse struct {
 	Result struct {
 		Deleted            bool                    `json:"deleted"`
 		DeletedIPsecTunnel MagicTransitIPsecTunnel `json:"deleted_ipsec_tunnel"`
+	} `json:"result"`
+}
+
+// GenerateMagicTransitIPsecTunnelPSKResponse contains a response after generating IPsec Tunnel.
+type GenerateMagicTransitIPsecTunnelPSKResponse struct {
+	Response
+	Result struct {
+		Psk         string                              `json:"psk"`
+		PskMetadata *MagicTransitIPsecTunnelPskMetadata `json:"psk_metadata"`
 	} `json:"result"`
 }
 
@@ -168,4 +192,23 @@ func (api *API) DeleteMagicTransitIPsecTunnel(ctx context.Context, accountID str
 	}
 
 	return result.Result.DeletedIPsecTunnel, nil
+}
+
+// GenerateMagicTransitIPsecTunnelPSK generates a pre shared key (psk) for an IPsec tunnel
+//
+// API reference: https://api.cloudflare.com/#magic-ipsec-tunnels-generate-pre-shared-key-psk-for-ipsec-tunnels
+func (api *API) GenerateMagicTransitIPsecTunnelPSK(ctx context.Context, accountID string, id string) (string, *MagicTransitIPsecTunnelPskMetadata, error) {
+	uri := fmt.Sprintf("/accounts/%s/magic/ipsec_tunnels/%s/psk_generate", accountID, id)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, nil)
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	result := GenerateMagicTransitIPsecTunnelPSKResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return "", nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result.Psk, result.Result.PskMetadata, nil
 }

--- a/magic_transit_tunnel_healthcheck.go
+++ b/magic_transit_tunnel_healthcheck.go
@@ -1,0 +1,8 @@
+package cloudflare
+
+// MagicTransitTunnelHealthcheck contains information about a tunnel health check.
+type MagicTransitTunnelHealthcheck struct {
+	Enabled bool   `json:"enabled"`
+	Target  string `json:"target,omitempty"`
+	Type    string `json:"type,omitempty"`
+}


### PR DESCRIPTION
Signed-off-by: Amos Paul <amos@cloudflare.com>

## Description

Cloudflare-go is used by Terraform resource provider for Cloudflare. Updating API calls to Magic Transit IPsec Tunnels to support Terraform.

## Has your change been tested?

The changes are mostly w.r.t parsing response objects from API calls to cloudflare. This has been tested using unit tests.



## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
