### PR TITLE
Add support for tunnel virtual networks

### DIFF
--- a/tunnel_virtual_networks.go
+++ b/tunnel_virtual_networks.go
@@ -1,0 +1,157 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// TunnelVirtualNetwork is segregation of Tunnel IP Routes via Virtualized Networks to handle overlapping private IPs in your origins.
+type TunnelVirtualNetwork struct {
+	ID               string     `json:"id"`
+	Name             string     `json:"name"`
+	IsDefaultNetwork bool       `json:"is_default_network"`
+	Comment          string     `json:"comment"`
+	CreatedAt        *time.Time `json:"created_at"`
+	DeletedAt        *time.Time `json:"deleted_at"`
+}
+
+type TunnelVirtualNetworksListParams struct {
+	AccountID string
+	ID        string `url:"id,omitempty"`
+	Name      string `url:"name,omitempty"`
+	IsDefault *bool  `url:"is_default,omitempty"`
+	IsDeleted *bool  `url:"is_deleted,omitempty"`
+	PaginationOptions
+}
+
+type TunnelVirtualNetworkCreateParams struct {
+	AccountID string `json:"-"`
+	VnetName  string `json:"vnet_name"`
+	Comment   string `json:"comment,omitempty"`
+	IsDefault *bool  `json:"is_default,omitempty"`
+}
+
+type TunnelVirtualNetworkUpdateParams struct {
+	AccountID        string `json:"-"`
+	VnetID           string `json:"-"`
+	VnetName         string `json:"vnet_name,omitempty"`
+	Comment          string `json:"comment,omitempty"`
+	IsDefaultNetwork *bool  `json:"is_default_network,omitempty"`
+}
+
+type TunnelVirtualNetworkDeleteParams struct {
+	AccountID string `json:"-"`
+	VnetID    string `json:"-"`
+}
+
+// tunnelRouteListResponse is the API response for listing tunnel virtual networks.
+type tunnelVirtualNetworkListResponse struct {
+	Response
+	Result []TunnelVirtualNetwork `json:"result"`
+}
+
+type tunnelVirtualNetworkResponse struct {
+	Response
+	Result TunnelVirtualNetwork `json:"result"`
+}
+
+// ListTunnelVirtualNetworks lists all defined virtual networks for tunnels in the account.
+//
+// See: https://api.cloudflare.com/#tunnel-virtual-network-list-virtual-networks
+func (api *API) ListTunnelVirtualNetworks(ctx context.Context, params TunnelVirtualNetworksListParams) ([]TunnelVirtualNetwork, error) {
+	if params.AccountID == "" {
+		return []TunnelVirtualNetwork{}, ErrMissingAccountID
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/teamnet/virtual_networks", AccountRouteRoot, params.AccountID), params)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, params)
+	if err != nil {
+		return []TunnelVirtualNetwork{}, err
+	}
+
+	var resp tunnelVirtualNetworkListResponse
+	err = json.Unmarshal(res, &resp)
+	if err != nil {
+		return []TunnelVirtualNetwork{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return resp.Result, nil
+}
+
+// CreateTunnelVirtualNetwork adds a new virtual network to the account
+//
+// See: https://api.cloudflare.com/#tunnel-virtual-network-create-virtual-network
+func (api *API) CreateTunnelVirtualNetwork(ctx context.Context, params TunnelVirtualNetworkCreateParams) (TunnelVirtualNetwork, error) {
+	if params.AccountID == "" {
+		return TunnelVirtualNetwork{}, ErrMissingAccountID
+	}
+
+	uri := fmt.Sprintf("/%s/%s/teamnet/virtual_networks", AccountRouteRoot, params.AccountID)
+
+	responseBody, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
+	if err != nil {
+		return TunnelVirtualNetwork{}, err
+	}
+
+	var resp tunnelVirtualNetworkResponse
+	err = json.Unmarshal(responseBody, &resp)
+	if err != nil {
+		return TunnelVirtualNetwork{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return resp.Result, nil
+}
+
+// DeleteTunnelVirtualNetwork deletes an existing virtual network from the account.
+//
+// See: https://api.cloudflare.com/#tunnel-virtual-network-delete-virtual-network
+func (api *API) DeleteTunnelVirtualNetwork(ctx context.Context, params TunnelVirtualNetworkDeleteParams) error {
+	if params.AccountID == "" {
+		return ErrMissingAccountID
+	}
+
+	uri := fmt.Sprintf("/%s/%s/teamnet/virtual_networks/%s", AccountRouteRoot, params.AccountID, url.PathEscape(params.VnetID))
+
+	responseBody, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+
+	var resp tunnelVirtualNetworkResponse
+	err = json.Unmarshal(responseBody, &resp)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}
+
+// UpdateTunnelRoute updates an existing virtual network in the account.
+//
+// See: https://api.cloudflare.com/#tunnel-virtual-network-update-virtual-network
+func (api *API) UpdateTunnelVirtualNetwork(ctx context.Context, params TunnelVirtualNetworkUpdateParams) (TunnelVirtualNetwork, error) {
+	if params.AccountID == "" {
+		return TunnelVirtualNetwork{}, ErrMissingAccountID
+	}
+
+	uri := fmt.Sprintf("/%s/%s/teamnet/virtual_networks/%s", AccountRouteRoot, params.AccountID, url.PathEscape(params.VnetID))
+
+	responseBody, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return TunnelVirtualNetwork{}, err
+	}
+
+	var resp tunnelVirtualNetworkResponse
+	err = json.Unmarshal(responseBody, &resp)
+	if err != nil {
+		return TunnelVirtualNetwork{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return resp.Result, nil
+}

--- a/tunnel_virtual_networks_test.go
+++ b/tunnel_virtual_networks_test.go
@@ -1,0 +1,191 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTunnelVirtualNetworks(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+			  {
+			    "id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+				"name": "us-east-1-vpc",
+				"is_default_network": true,
+				"comment": "Staging VPC for data science",
+				"created_at": "2021-01-25T18:22:34.317854Z",
+				"deleted_at": "2021-01-25T18:22:34.317854Z"
+              }
+            ]
+          }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/teamnet/virtual_networks", handler)
+
+	ts, _ := time.Parse(time.RFC3339Nano, "2021-01-25T18:22:34.317854Z")
+
+	want := []TunnelVirtualNetwork{
+		{
+			ID:               "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+			Name:             "us-east-1-vpc",
+			IsDefaultNetwork: true,
+			Comment:          "Staging VPC for data science",
+			CreatedAt:        &ts,
+			DeletedAt:        &ts,
+		},
+	}
+
+	params := TunnelVirtualNetworksListParams{AccountID: testAccountID}
+	got, err := client.ListTunnelVirtualNetworks(context.Background(), params)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestCreateTunnelVirtualNetwork(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+				"name": "us-east-1-vpc",
+				"is_default_network": true,
+				"comment": "Staging VPC for data science",
+				"created_at": "2021-01-25T18:22:34.317854Z",
+				"deleted_at": "2021-01-25T18:22:34.317854Z"
+            }
+          }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/teamnet/virtual_networks", handler)
+
+	ts, _ := time.Parse(time.RFC3339Nano, "2021-01-25T18:22:34.317854Z")
+	want := TunnelVirtualNetwork{
+		ID:               "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+		Name:             "us-east-1-vpc",
+		IsDefaultNetwork: true,
+		Comment:          "Staging VPC for data science",
+		CreatedAt:        &ts,
+		DeletedAt:        &ts,
+	}
+
+	tunnel, err := client.CreateTunnelVirtualNetwork(context.Background(), TunnelVirtualNetworkCreateParams{
+		AccountID: testAccountID,
+		VnetName:  "us-east-1-vpc",
+		IsDefault: BoolPtr(true),
+		Comment:   "Staging VPC for data science",
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, tunnel)
+	}
+}
+
+func TestUpdateTunnelVirtualNetwork(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method, "Expected method 'PATCH', got %s", r.Method)
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		defer r.Body.Close()
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+				"name": "us-east-1-vpc",
+				"is_default_network": true,
+				"comment": "Staging VPC for data science",
+				"created_at": "2021-01-25T18:22:34.317854Z",
+				"deleted_at": "2021-01-25T18:22:34.317854Z"
+            }
+          }`)
+	}
+
+	ts, _ := time.Parse(time.RFC3339Nano, "2021-01-25T18:22:34.317854Z")
+	want := TunnelVirtualNetwork{
+		ID:               "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+		Name:             "us-east-1-vpc",
+		IsDefaultNetwork: true,
+		Comment:          "Staging VPC for data science",
+		CreatedAt:        &ts,
+		DeletedAt:        &ts,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/teamnet/virtual_networks/f70ff985-a4ef-4643-bbbc-4a0ed4fc8415", handler)
+
+	tunnel, err := client.UpdateTunnelVirtualNetwork(context.Background(), TunnelVirtualNetworkUpdateParams{
+		AccountID:        testAccountID,
+		VnetID:           "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+		VnetName:         "us-east-1-vpc",
+		IsDefaultNetwork: BoolPtr(true),
+		Comment:          "Staging VPC for data science",
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, tunnel)
+	}
+}
+
+func TestDeleteTunnelVirtualNetwork(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+				"name": "us-east-1-vpc",
+				"is_default_network": true,
+				"comment": "Staging VPC for data science",
+				"created_at": "2021-01-25T18:22:34.317854Z",
+				"deleted_at": "2021-01-25T18:22:34.317854Z"
+            }
+          }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/teamnet/virtual_networks/f70ff985-a4ef-4643-bbbc-4a0ed4fc8415", handler)
+
+	err := client.DeleteTunnelVirtualNetwork(context.Background(), TunnelVirtualNetworkDeleteParams{
+		AccountID: testAccountID,
+		VnetID:    "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+	})
+
+	assert.NoError(t, err)
+}

--- a/tunnel_virtual_networks_test.go
+++ b/tunnel_virtual_networks_test.go
@@ -70,12 +70,12 @@ func TestCreateTunnelVirtualNetwork(t *testing.T) {
 			"errors": [],
 			"messages": [],
 			"result": {
-				"id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
-				"name": "us-east-1-vpc",
-				"is_default_network": true,
-				"comment": "Staging VPC for data science",
-				"created_at": "2021-01-25T18:22:34.317854Z",
-				"deleted_at": "2021-01-25T18:22:34.317854Z"
+			  "id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+			  "name": "us-east-1-vpc",
+			  "is_default_network": true,
+			  "comment": "Staging VPC for data science",
+			  "created_at": "2021-01-25T18:22:34.317854Z",
+			  "deleted_at": "2021-01-25T18:22:34.317854Z"
             }
           }`)
 	}
@@ -122,12 +122,12 @@ func TestUpdateTunnelVirtualNetwork(t *testing.T) {
 			"errors": [],
 			"messages": [],
 			"result": {
-				"id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
-				"name": "us-east-1-vpc",
-				"is_default_network": true,
-				"comment": "Staging VPC for data science",
-				"created_at": "2021-01-25T18:22:34.317854Z",
-				"deleted_at": "2021-01-25T18:22:34.317854Z"
+			  "id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+			  "name": "us-east-1-vpc",
+			  "is_default_network": true,
+			  "comment": "Staging VPC for data science",
+			  "created_at": "2021-01-25T18:22:34.317854Z",
+			  "deleted_at": "2021-01-25T18:22:34.317854Z"
             }
           }`)
 	}
@@ -170,12 +170,12 @@ func TestDeleteTunnelVirtualNetwork(t *testing.T) {
 			"errors": [],
 			"messages": [],
 			"result": {
-				"id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
-				"name": "us-east-1-vpc",
-				"is_default_network": true,
-				"comment": "Staging VPC for data science",
-				"created_at": "2021-01-25T18:22:34.317854Z",
-				"deleted_at": "2021-01-25T18:22:34.317854Z"
+			  "id": "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
+			  "name": "us-east-1-vpc",
+			  "is_default_network": true,
+			  "comment": "Staging VPC for data science",
+			  "created_at": "2021-01-25T18:22:34.317854Z",
+			  "deleted_at": "2021-01-25T18:22:34.317854Z"
             }
           }`)
 	}


### PR DESCRIPTION
Add support for tunnel virtual networks

## Description

Cloudflare docs [already contain](https://api.cloudflare.com/#tunnel-virtual-network-properties) Vnets support. Just need to implement it here 

## Has your change been tested?

Covered with unit tests. Will start using them immediately after the merge.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation. **Docs already exist**
- [ ] I have updated the documentation accordingly. **Docs already exist**
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

Resolves cloudflare/cloudflare-go#913
Unblocks cloudflare/terraform-provider-cloudflare#1602

