### PR TITLE
Fix Tunnel Virtual Network params:

### DIFF
--- a/tunnel_virtual_networks.go
+++ b/tunnel_virtual_networks.go
@@ -35,15 +35,15 @@ type TunnelVirtualNetworksListParams struct {
 
 type TunnelVirtualNetworkCreateParams struct {
 	AccountID string `json:"-"`
-	VnetName  string `json:"vnet_name"`
+	Name      string `json:"name"`
 	Comment   string `json:"comment,omitempty"`
-	IsDefault *bool  `json:"is_default,omitempty"`
+	IsDefault bool   `json:"is_default"`
 }
 
 type TunnelVirtualNetworkUpdateParams struct {
 	AccountID        string `json:"-"`
 	VnetID           string `json:"-"`
-	VnetName         string `json:"vnet_name,omitempty"`
+	Name             string `json:"name,omitempty"`
 	Comment          string `json:"comment,omitempty"`
 	IsDefaultNetwork *bool  `json:"is_default_network,omitempty"`
 }
@@ -97,7 +97,7 @@ func (api *API) CreateTunnelVirtualNetwork(ctx context.Context, params TunnelVir
 		return TunnelVirtualNetwork{}, ErrMissingAccountID
 	}
 
-	if params.VnetName == "" {
+	if params.Name == "" {
 		return TunnelVirtualNetwork{}, ErrMissingVnetName
 	}
 

--- a/tunnel_virtual_networks_test.go
+++ b/tunnel_virtual_networks_test.go
@@ -94,8 +94,8 @@ func TestCreateTunnelVirtualNetwork(t *testing.T) {
 
 	tunnel, err := client.CreateTunnelVirtualNetwork(context.Background(), TunnelVirtualNetworkCreateParams{
 		AccountID: testAccountID,
-		VnetName:  "us-east-1-vpc",
-		IsDefault: BoolPtr(true),
+		Name:      "us-east-1-vpc",
+		IsDefault: true,
 		Comment:   "Staging VPC for data science",
 	})
 
@@ -147,7 +147,7 @@ func TestUpdateTunnelVirtualNetwork(t *testing.T) {
 	tunnel, err := client.UpdateTunnelVirtualNetwork(context.Background(), TunnelVirtualNetworkUpdateParams{
 		AccountID:        testAccountID,
 		VnetID:           "f70ff985-a4ef-4643-bbbc-4a0ed4fc8415",
-		VnetName:         "us-east-1-vpc",
+		Name:             "us-east-1-vpc",
 		IsDefaultNetwork: BoolPtr(true),
 		Comment:          "Staging VPC for data science",
 	})


### PR DESCRIPTION
## Description

1) Fix misspelled vnet param
2) Make default network param required

[Docs](https://api.cloudflare.com/#tunnel-virtual-network-create-virtual-network) are misleading.
1. `vnet_name` is actually `name`
![image](https://user-images.githubusercontent.com/10233442/171920522-730d6d6f-13fa-46d0-8bf4-32d75d241cbf.png)
![image](https://user-images.githubusercontent.com/10233442/171920561-0dfe9287-6ef8-4bb2-bab9-8ef4f2aabf14.png)
2. `is_default` is actually **required** during creation
![Insomnia_YhEvZdfOc6](https://user-images.githubusercontent.com/10233442/171920647-20667a52-7c2b-4642-a9a5-e6d1a17734d3.png)


## Has your change been tested?

Covered with unit tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.


#913
cloudflare/terraform-provider-cloudflare#1602