### PR TITLE
New API for Managed Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The current feature list includes:
 - [x] Zone cache settings
 - [x] Zone Lockdown and User-Agent Block rules
 - [x] Zones
+- [x] Managed Headers
 
 Pull Requests are welcome, but please open an issue (or comment in an existing
 issue) to discuss any non-trivial changes before submitting code.

--- a/managed_headers.go
+++ b/managed_headers.go
@@ -1,0 +1,68 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+type ListManagedHeadersResponse struct {
+	Response
+	Result ManagedHeaders `json:"result"`
+}
+
+type ManagedHeaders struct {
+	ManagedRequestHeaders  []ManagedHeader `json:"managed_request_headers"`
+	ManagedResponseHeaders []ManagedHeader `json:"managed_response_headers"`
+}
+
+type ManagedHeader struct {
+	ID            string   `json:"id"`
+	Enabled       bool     `json:"enabled"`
+	HasCoflict    bool     `json:"has_conflict,omitempty"`
+	ConflictsWith []string `json:"conflicts_with,omitempty"`
+}
+
+type ManagedHeadersOptions struct {
+	ZoneID string
+}
+
+func (api *API) ListZoneManagedHeaders(ctx context.Context, opts ManagedHeadersOptions) (ManagedHeaders, error) {
+	uri := fmt.Sprintf("/zones/%s/managed_headers", opts.ZoneID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return ManagedHeaders{}, err
+	}
+
+	result := ListManagedHeadersResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return ManagedHeaders{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}
+
+func (api *API) UpdateZoneManagedHeaders(ctx context.Context, headers ManagedHeaders, opts ManagedHeadersOptions) (ManagedHeaders, error) {
+	uri := fmt.Sprintf("/zones/%s/managed_headers", opts.ZoneID)
+
+	request, err := json.Marshal(headers)
+	if err != nil {
+		return ManagedHeaders{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, request)
+	if err != nil {
+		return ManagedHeaders{}, err
+	}
+
+	result := ListManagedHeadersResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return ManagedHeaders{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return result.Result, nil
+}

--- a/managed_headers_test.go
+++ b/managed_headers_test.go
@@ -79,7 +79,7 @@ func TestListManagedHeaders(t *testing.T) {
 		},
 	}
 
-	zoneActual, err := client.ListZoneManagedHeaders(context.Background(), ManagedHeadersOptions{
+	zoneActual, err := client.ListZoneManagedHeaders(context.Background(), ListManagedHeadersParams{
 		ZoneID: testZoneID,
 	})
 	if assert.NoError(t, err) {
@@ -170,8 +170,9 @@ func TestUpdateManagedHeaders(t *testing.T) {
 			},
 		},
 	}
-	zoneActual, err := client.UpdateZoneManagedHeaders(context.Background(), managedHeadersForUpdate, ManagedHeadersOptions{
-		ZoneID: testZoneID,
+	zoneActual, err := client.UpdateZoneManagedHeaders(context.Background(), UpdateManagedHeadersParams{
+		ZoneID:         testZoneID,
+		ManagedHeaders: managedHeadersForUpdate,
 	})
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, zoneActual)

--- a/managed_headers_test.go
+++ b/managed_headers_test.go
@@ -1,0 +1,179 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListManagedHeaders(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "result": {
+        "managed_request_headers": [
+          {
+            "id": "add_true_client_ip_headers",
+            "enabled": false,
+            "has_conflict": false,
+            "conflicts_with": ["remove_visitor_ip_headers"]
+          },
+          {
+            "id": "add_visitor_location_headers",
+            "enabled": true,
+            "has_conflict": false
+          }
+        ],
+        "managed_response_headers": [
+          {
+            "id": "add_security_headers",
+            "enabled": false,
+            "has_conflict": false
+          },
+          {
+            "id": "remove_x-powered-by_header",
+            "enabled": true,
+            "has_conflict": false
+          }
+        ]
+      },
+      "success": true,
+      "errors": [],
+      "messages": []
+    }`)
+	}
+	mux.HandleFunc("/zones/"+testZoneID+"/managed_headers", handler)
+
+	want := ManagedHeaders{
+		ManagedRequestHeaders: []ManagedHeader{
+			{
+				ID:            "add_true_client_ip_headers",
+				Enabled:       false,
+				HasCoflict:    false,
+				ConflictsWith: []string{"remove_visitor_ip_headers"},
+			},
+			{
+				ID:         "add_visitor_location_headers",
+				Enabled:    true,
+				HasCoflict: false,
+			},
+		},
+		ManagedResponseHeaders: []ManagedHeader{
+			{
+				ID:         "add_security_headers",
+				Enabled:    false,
+				HasCoflict: false,
+			},
+			{
+				ID:         "remove_x-powered-by_header",
+				Enabled:    true,
+				HasCoflict: false,
+			},
+		},
+	}
+
+	zoneActual, err := client.ListZoneManagedHeaders(context.Background(), ManagedHeadersOptions{
+		ZoneID: testZoneID,
+	})
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, zoneActual)
+	}
+}
+
+func TestUpdateManagedHeaders(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method, "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "result": {
+        "managed_request_headers": [
+          {
+            "id": "add_true_client_ip_headers",
+            "enabled": true,
+            "has_conflict": false,
+            "conflicts_with": ["remove_visitor_ip_headers"]
+          },
+          {
+            "id": "add_visitor_location_headers",
+            "enabled": true,
+            "has_conflict": false
+          }
+        ],
+        "managed_response_headers": [
+          {
+            "id": "add_security_headers",
+            "enabled": false,
+            "has_conflict": false
+          },
+          {
+            "id": "remove_x-powered-by_header",
+            "enabled": false,
+            "has_conflict": false
+          }
+        ]
+      },
+      "success": true,
+      "errors": [],
+      "messages": []
+    }`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/managed_headers", handler)
+	managedHeadersForUpdate := ManagedHeaders{
+		ManagedRequestHeaders: []ManagedHeader{
+			{
+				ID:      "add_visitor_location_headers",
+				Enabled: true,
+			},
+		},
+		ManagedResponseHeaders: []ManagedHeader{
+			{
+				ID:      "remove_x-powered-by_header",
+				Enabled: false,
+			},
+		},
+	}
+	want := ManagedHeaders{
+		ManagedRequestHeaders: []ManagedHeader{
+			{
+				ID:            "add_true_client_ip_headers",
+				Enabled:       true,
+				HasCoflict:    false,
+				ConflictsWith: []string{"remove_visitor_ip_headers"},
+			},
+			{
+				ID:         "add_visitor_location_headers",
+				Enabled:    true,
+				HasCoflict: false,
+			},
+		},
+		ManagedResponseHeaders: []ManagedHeader{
+			{
+				ID:         "add_security_headers",
+				Enabled:    false,
+				HasCoflict: false,
+			},
+			{
+				ID:         "remove_x-powered-by_header",
+				Enabled:    false,
+				HasCoflict: false,
+			},
+		},
+	}
+	zoneActual, err := client.UpdateZoneManagedHeaders(context.Background(), managedHeadersForUpdate, ManagedHeadersOptions{
+		ZoneID: testZoneID,
+	})
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, zoneActual)
+	}
+}


### PR DESCRIPTION
Add support of List and Update methods for Managed Headers Product

## Description

This product exists only on a Zone level. No need for Create of Delete methods: managed headers API always provides a list of possible headers. The only difference is the state of particular header rule in this list, which can be changed by Update method.

## Has your change been tested?

Unittests are added