### PR TITLE
Add support for load balancing weighted random pools

### DIFF
--- a/load_balancing.go
+++ b/load_balancing.go
@@ -87,6 +87,7 @@ type LoadBalancer struct {
 	PersistenceTTL            int                        `json:"session_affinity_ttl,omitempty"`
 	SessionAffinityAttributes *SessionAffinityAttributes `json:"session_affinity_attributes,omitempty"`
 	Rules                     []*LoadBalancerRule        `json:"rules,omitempty"`
+	RandomSteering            *RandomSteering            `json:"random_steering,omitempty"`
 
 	// SteeringPolicy controls pool selection logic.
 	// "off" select pools in DefaultPools order
@@ -161,6 +162,15 @@ type LoadBalancerRuleOverrides struct {
 	PoPPools     map[string][]string `json:"pop_pools,omitempty"`
 	RegionPools  map[string][]string `json:"region_pools,omitempty"`
 	CountryPools map[string][]string `json:"country_pools,omitempty"`
+
+	RandomSteering *RandomSteering `json:"random_steering,omitempty"`
+}
+
+// RandomSteering represents fields used to set pool weights on a load balancer
+// with "random" steering policy.
+type RandomSteering struct {
+	DefaultWeight float64            `json:"default_weight,omitempty"`
+	PoolWeights   map[string]float64 `json:"pool_weights,omitempty"`
 }
 
 // LoadBalancerRuleOverridesSessionAffinityAttrs mimics SessionAffinityAttributes without the

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -931,6 +931,13 @@ func TestCreateLoadBalancer(t *testing.T) {
                   "00920f38ce07c2e2f4df50b1f61d4194"
                 ]
 			  },
+			  "random_steering": {
+			    "default_weight": 0.2,
+			    "pool_weights": {
+			        "9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+			        "de90f38ced07c2e2f4df50b1f61d4194": 0.4
+			    }
+			  },
 			  "rules": [
 				  {
 					  "name": "example rule",
@@ -1002,6 +1009,13 @@ func TestCreateLoadBalancer(t *testing.T) {
                     "00920f38ce07c2e2f4df50b1f61d4194"
                   ]
 				},
+				"random_steering": {
+				   "default_weight": 0.2,
+				    "pool_weights": {
+				        "9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+				        "de90f38ced07c2e2f4df50b1f61d4194": 0.4
+				    }
+				},
 				"rules": [
 				  {
 					  "name": "example rule",
@@ -1072,6 +1086,13 @@ func TestCreateLoadBalancer(t *testing.T) {
 				"00920f38ce07c2e2f4df50b1f61d4194",
 			},
 		},
+		RandomSteering: &RandomSteering{
+			DefaultWeight: 0.2,
+			PoolWeights: map[string]float64{
+				"9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+				"de90f38ced07c2e2f4df50b1f61d4194": 0.4,
+			},
+		},
 		Rules: []*LoadBalancerRule{
 			{
 				Name:      "example rule",
@@ -1131,6 +1152,13 @@ func TestCreateLoadBalancer(t *testing.T) {
 			},
 			"SJC": {
 				"00920f38ce07c2e2f4df50b1f61d4194",
+			},
+		},
+		RandomSteering: &RandomSteering{
+			DefaultWeight: 0.2,
+			PoolWeights: map[string]float64{
+				"9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+				"de90f38ced07c2e2f4df50b1f61d4194": 0.4,
 			},
 		},
 		Rules: []*LoadBalancerRule{
@@ -1216,6 +1244,13 @@ func TestListLoadBalancers(t *testing.T) {
                         "00920f38ce07c2e2f4df50b1f61d4194"
                       ]
                     },
+                    "random_steering": {
+                        "default_weight": 0.2,
+                        "pool_weights": {
+                            "9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+                            "de90f38ced07c2e2f4df50b1f61d4194": 0.4
+                        }
+                    },
                     "proxied": true
                 }
             ],
@@ -1273,6 +1308,13 @@ func TestListLoadBalancers(t *testing.T) {
 				},
 				"SJC": {
 					"00920f38ce07c2e2f4df50b1f61d4194",
+				},
+			},
+			RandomSteering: &RandomSteering{
+				DefaultWeight: 0.2,
+				PoolWeights: map[string]float64{
+					"9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+					"de90f38ced07c2e2f4df50b1f61d4194": 0.4,
 				},
 			},
 			Proxied: true,
@@ -1339,6 +1381,13 @@ func TestLoadBalancerDetails(t *testing.T) {
                     "00920f38ce07c2e2f4df50b1f61d4194"
                   ]
                 },
+                "random_steering": {
+                    "default_weight": 0.2,
+                    "pool_weights": {
+                        "9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+                        "de90f38ced07c2e2f4df50b1f61d4194": 0.4
+                    }
+                },
                 "proxied": true
             }
         }`)
@@ -1388,6 +1437,13 @@ func TestLoadBalancerDetails(t *testing.T) {
 			},
 			"SJC": {
 				"00920f38ce07c2e2f4df50b1f61d4194",
+			},
+		},
+		RandomSteering: &RandomSteering{
+			DefaultWeight: 0.2,
+			PoolWeights: map[string]float64{
+				"9290f38c5d07c2e2f4df57b1f61d4196": 0.6,
+				"de90f38ced07c2e2f4df50b1f61d4194": 0.4,
 			},
 		},
 		Proxied: true,
@@ -1470,6 +1526,12 @@ func TestModifyLoadBalancer(t *testing.T) {
                     "00920f38ce07c2e2f4df50b1f61d4194"
                   ]
                 },
+                "random_steering": {
+                    "default_weight": 0.5,
+                    "pool_weights": {
+                        "9290f38c5d07c2e2f4df57b1f61d4196": 0.2
+                    }
+                },
                 "proxied": true,
                 "session_affinity": "none",
                 "session_affinity_attributes": {
@@ -1520,6 +1582,12 @@ func TestModifyLoadBalancer(t *testing.T) {
                   "SJC": [
                     "00920f38ce07c2e2f4df50b1f61d4194"
                   ]
+                },
+                "random_steering": {
+                    "default_weight": 0.5,
+                    "pool_weights": {
+                        "9290f38c5d07c2e2f4df57b1f61d4196": 0.2
+                    }
                 },
                 "proxied": true,
                 "session_affinity": "none",
@@ -1573,6 +1641,12 @@ func TestModifyLoadBalancer(t *testing.T) {
 				"00920f38ce07c2e2f4df50b1f61d4194",
 			},
 		},
+		RandomSteering: &RandomSteering{
+			DefaultWeight: 0.5,
+			PoolWeights: map[string]float64{
+				"9290f38c5d07c2e2f4df57b1f61d4196": 0.2,
+			},
+		},
 		Proxied:     true,
 		Persistence: "none",
 		SessionAffinityAttributes: &SessionAffinityAttributes{
@@ -1615,6 +1689,12 @@ func TestModifyLoadBalancer(t *testing.T) {
 			},
 			"SJC": {
 				"00920f38ce07c2e2f4df50b1f61d4194",
+			},
+		},
+		RandomSteering: &RandomSteering{
+			DefaultWeight: 0.5,
+			PoolWeights: map[string]float64{
+				"9290f38c5d07c2e2f4df57b1f61d4196": 0.2,
 			},
 		},
 		Proxied:     true,


### PR DESCRIPTION
## Description

`random_steering` is used to configure pool weights for random steering. When the steering policy is `random`, a random pool is selected with probability proportional to the pool weights. The `default_weight` field has a default value of 1 unless specified/set.

## Has your change been tested?

Added new fields to load balancing tests which verifies the input struct matches the returning JSON/struct.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
