### PR TITLE
rulesets: add support for `http_request_redirect` phase and `redirect` action

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -26,9 +26,10 @@ const (
 	RulesetPhaseHTTPRequestLateTransform        RulesetPhase = "http_request_late_transform"
 	RulesetPhaseHTTPRequestLateTransformManaged RulesetPhase = "http_request_late_transform_managed"
 	RulesetPhaseHTTPRequestMain                 RulesetPhase = "http_request_main"
+	RulesetPhaseHTTPRequestOrigin               RulesetPhase = "http_request_origin"
+	RulesetPhaseHTTPRequestRedirect             RulesetPhase = "http_request_redirect"
 	RulesetPhaseHTTPRequestSanitize             RulesetPhase = "http_request_sanitize"
 	RulesetPhaseHTTPRequestTransform            RulesetPhase = "http_request_transform"
-	RulesetPhaseHTTPRequestOrigin               RulesetPhase = "http_request_origin"
 	RulesetPhaseHTTPResponseFirewallManaged     RulesetPhase = "http_response_firewall_managed"
 	RulesetPhaseHTTPResponseHeadersTransform    RulesetPhase = "http_response_headers_transform"
 	RulesetPhaseMagicTransit                    RulesetPhase = "magic_transit"
@@ -41,14 +42,15 @@ const (
 	RulesetRuleActionExecute              RulesetRuleAction = "execute"
 	RulesetRuleActionForceConnectionClose RulesetRuleAction = "force_connection_close"
 	RulesetRuleActionJSChallenge          RulesetRuleAction = "js_challenge"
-	RulesetRuleActionManagedChallenge     RulesetRuleAction = "managed_challenge"
 	RulesetRuleActionLog                  RulesetRuleAction = "log"
 	RulesetRuleActionLogCustomField       RulesetRuleAction = "log_custom_field"
+	RulesetRuleActionManagedChallenge     RulesetRuleAction = "managed_challenge"
+	RulesetRuleActionRedirect             RulesetRuleAction = "redirect"
 	RulesetRuleActionRewrite              RulesetRuleAction = "rewrite"
-	RulesetRuleActionScore                RulesetRuleAction = "score"
-	RulesetRuleActionSkip                 RulesetRuleAction = "skip"
 	RulesetRuleActionRoute                RulesetRuleAction = "route"
+	RulesetRuleActionScore                RulesetRuleAction = "score"
 	RulesetRuleActionSetCacheSettings     RulesetRuleAction = "set_cache_settings"
+	RulesetRuleActionSkip                 RulesetRuleAction = "skip"
 
 	RulesetActionParameterProductBIC           RulesetActionParameterProduct = "bic"
 	RulesetActionParameterProductHOT           RulesetActionParameterProduct = "hot"
@@ -88,6 +90,7 @@ func RulesetPhaseValues() []string {
 		string(RulesetPhaseHTTPRequestLateTransformManaged),
 		string(RulesetPhaseHTTPRequestMain),
 		string(RulesetPhaseHTTPRequestOrigin),
+		string(RulesetPhaseHTTPRequestRedirect),
 		string(RulesetPhaseHTTPRequestSanitize),
 		string(RulesetPhaseHTTPRequestTransform),
 		string(RulesetPhaseHTTPResponseFirewallManaged),
@@ -108,14 +111,15 @@ func RulesetRuleActionValues() []string {
 		string(RulesetRuleActionExecute),
 		string(RulesetRuleActionForceConnectionClose),
 		string(RulesetRuleActionJSChallenge),
-		string(RulesetRuleActionManagedChallenge),
 		string(RulesetRuleActionLog),
 		string(RulesetRuleActionLogCustomField),
+		string(RulesetRuleActionManagedChallenge),
+		string(RulesetRuleActionRedirect),
 		string(RulesetRuleActionRewrite),
-		string(RulesetRuleActionScore),
-		string(RulesetRuleActionSkip),
 		string(RulesetRuleActionRoute),
+		string(RulesetRuleActionScore),
 		string(RulesetRuleActionSetCacheSettings),
+		string(RulesetRuleActionSkip),
 	}
 }
 
@@ -210,6 +214,14 @@ type RulesetRuleActionParameters struct {
 	RespectStrongETags      *bool                                            `json:"respect_strong_etags,omitempty"`
 	CacheKey                *RulesetRuleActionParametersCacheKey             `json:"cache_key,omitempty"`
 	OriginErrorPagePassthru *bool                                            `json:"origin_error_page_passthru,omitempty"`
+	FromList                *RulesetRuleActionParametersFromList             `json:"from_list,omitempty"`
+}
+
+// RulesetRuleActionParametersFromList holds the FromList struct for
+// actions which pull data from a list.
+type RulesetRuleActionParametersFromList struct {
+	Name string `json:"name"`
+	Key  string `json:"key"`
 }
 
 type RulesetRuleActionParametersEdgeTTL struct {


### PR DESCRIPTION
## Description

The `from_list` parameter is used in the `redirect` action (see https://developers.cloudflare.com/rules/bulk-redirects/create-api/#3-create-a-bulk-redirect-rule-via-api), among others.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
