### PR TITLE
fix marshalling of LogpushJob with no filter

### DIFF
--- a/logpush.go
+++ b/logpush.go
@@ -12,18 +12,18 @@ import (
 
 // LogpushJob describes a Logpush job.
 type LogpushJob struct {
-	ID                 int               `json:"id,omitempty"`
-	Dataset            string            `json:"dataset"`
-	Enabled            bool              `json:"enabled"`
-	Name               string            `json:"name"`
-	LogpullOptions     string            `json:"logpull_options"`
-	DestinationConf    string            `json:"destination_conf"`
-	OwnershipChallenge string            `json:"ownership_challenge,omitempty"`
-	LastComplete       *time.Time        `json:"last_complete,omitempty"`
-	LastError          *time.Time        `json:"last_error,omitempty"`
-	ErrorMessage       string            `json:"error_message,omitempty"`
-	Frequency          string            `json:"frequency,omitempty"`
-	Filter             LogpushJobFilters `json:"filter,omitempty"`
+	ID                 int                `json:"id,omitempty"`
+	Dataset            string             `json:"dataset"`
+	Enabled            bool               `json:"enabled"`
+	Name               string             `json:"name"`
+	LogpullOptions     string             `json:"logpull_options"`
+	DestinationConf    string             `json:"destination_conf"`
+	OwnershipChallenge string             `json:"ownership_challenge,omitempty"`
+	LastComplete       *time.Time         `json:"last_complete,omitempty"`
+	LastError          *time.Time         `json:"last_error,omitempty"`
+	ErrorMessage       string             `json:"error_message,omitempty"`
+	Frequency          string             `json:"frequency,omitempty"`
+	Filter             *LogpushJobFilters `json:"filter,omitempty"`
 }
 
 type LogpushJobFilters struct {
@@ -131,17 +131,23 @@ type LogpushDestinationExistsRequest struct {
 func (f LogpushJob) MarshalJSON() ([]byte, error) {
 	type Alias LogpushJob
 
-	filter, err := json.Marshal(f.Filter)
+	var filter string
 
-	if err != nil {
-		return nil, err
+	if f.Filter != nil {
+		b, err := json.Marshal(f.Filter)
+
+		if err != nil {
+			return nil, err
+		}
+
+		filter = string(b)
 	}
 
 	return json.Marshal(&struct {
 		Filter string `json:"filter,omitempty"`
 		Alias
 	}{
-		Filter: string(filter),
+		Filter: filter,
 		Alias:  (Alias)(f),
 	})
 }
@@ -167,7 +173,7 @@ func (f *LogpushJob) UnmarshalJSON(data []byte) error {
 		if err := filter.Where.Validate(); err != nil {
 			return err
 		}
-		f.Filter = filter
+		f.Filter = &filter
 	}
 	return nil
 }

--- a/logpush_example_test.go
+++ b/logpush_example_test.go
@@ -180,7 +180,7 @@ func ExampleLogpushJob_MarshalJSON() {
 		LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339&CVE-2021-44228=true",
 		Dataset:         "http_requests",
 		DestinationConf: "s3://<BUCKET_PATH>?region=us-west-2/",
-		Filter: cloudflare.LogpushJobFilters{
+		Filter: &cloudflare.LogpushJobFilters{
 			Where: cloudflare.LogpushJobFilter{
 				And: []cloudflare.LogpushJobFilter{
 					{Key: "ClientRequestPath", Operator: cloudflare.Contains, Value: "/static\\"},

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -448,6 +448,21 @@ func TestLogPushJob_Marshall(t *testing.T) {
 				"filter":"{\"where\":{\"key\":\"ClientRequestHost\",\"operator\":\"eq\",\"value\":\"example.com\"}}"
 			}`,
 		},
+		{
+			job: LogpushJob{
+				Dataset:         "http_requests",
+				Name:            "no filter",
+				LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
+				DestinationConf: "https://example.com",
+			},
+			want: `{
+				"dataset": "http_requests",
+				"enabled": false,
+				"name": "no filter",
+				"logpull_options": "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
+				"destination_conf": "https://example.com"
+			}`,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -389,7 +389,7 @@ func TestLogpushJob_Unmarshall(t *testing.T) {
 			LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339&CVE-2021-44228=true",
 			Dataset:         "http_requests",
 			DestinationConf: "s3://<BUCKET_PATH>?region=us-west-2/",
-			Filter: LogpushJobFilters{
+			Filter: &LogpushJobFilters{
 				Where: LogpushJobFilter{
 					And: []LogpushJobFilter{
 						{Key: "ClientRequestPath", Operator: Contains, Value: "/static\\"},
@@ -435,7 +435,7 @@ func TestLogPushJob_Marshall(t *testing.T) {
 				Name:            "valid filter",
 				LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
 				DestinationConf: "https://example.com",
-				Filter: LogpushJobFilters{
+				Filter: &LogpushJobFilters{
 					Where: LogpushJobFilter{Key: "ClientRequestHost", Operator: Equal, Value: "example.com"},
 				},
 			},


### PR DESCRIPTION
## Description

A LogpushJob with no filter incorrectly marshals the filter as `"{\"where\":{}}"` instead of omitting it.

Changing the field to a pointer allows us to test for presence and omit it entirely.

## Has your change been tested?

I've added a marshalling test that initially tests the valid and not present cases.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

> **Warning** this is technically a breaking change and will require changes in the terraform provider to use the pointer instead of the value as has been done in other updates.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
