### PR TITLE
Support the "allow_null_cipher" option in Magic Transit IPsec tunnels.

### DIFF
--- a/magic_transit_ipsec_tunnel.go
+++ b/magic_transit_ipsec_tunnel.go
@@ -41,6 +41,7 @@ type MagicTransitIPsecTunnel struct {
 	Psk                string                              `json:"psk,omitempty"`
 	PskMetadata        *MagicTransitIPsecTunnelPskMetadata `json:"psk_metadata,omitempty"`
 	RemoteIdentities   *RemoteIdentities                   `json:"remote_identities,omitempty"`
+	AllowNullCipher    bool                                `json:"allow_null_cipher"`
 }
 
 // ListMagicTransitIPsecTunnelsResponse contains a response including IPsec tunnels.

--- a/magic_transit_ipsec_tunnel_test.go
+++ b/magic_transit_ipsec_tunnel_test.go
@@ -82,7 +82,8 @@ func TestGetMagicTransitIPsecTunnel(t *testing.T) {
           "customer_endpoint": "203.0.113.1",
           "cloudflare_endpoint": "203.0.113.2",
           "interface_address": "192.0.2.0/31",
-          "description": "Tunnel for ISP X"
+          "description": "Tunnel for ISP X",
+          "allow_null_cipher": true
         }
       }
     }`)
@@ -102,6 +103,7 @@ func TestGetMagicTransitIPsecTunnel(t *testing.T) {
 		CloudflareEndpoint: "203.0.113.2",
 		InterfaceAddress:   "192.0.2.0/31",
 		Description:        "Tunnel for ISP X",
+		AllowNullCipher:    true,
 	}
 
 	actual, err := client.GetMagicTransitIPsecTunnel(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821")
@@ -181,7 +183,8 @@ func TestUpdateMagicTransitIPsecTunnel(t *testing.T) {
           "customer_endpoint": "203.0.113.1",
           "cloudflare_endpoint": "203.0.113.2",
           "interface_address": "192.0.2.0/31",
-          "description": "Tunnel for ISP X"
+          "description": "Tunnel for ISP X",
+          "allow_null_cipher": true
         }
       }
     }`)
@@ -201,6 +204,7 @@ func TestUpdateMagicTransitIPsecTunnel(t *testing.T) {
 		CloudflareEndpoint: "203.0.113.2",
 		InterfaceAddress:   "192.0.2.0/31",
 		Description:        "Tunnel for ISP X",
+		AllowNullCipher:    true,
 	}
 
 	actual, err := client.UpdateMagicTransitIPsecTunnel(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821", want)


### PR DESCRIPTION
Magic Transit IPsec tunnel configuration now has a boolean flag "allow_null_cipher" which affects how the tunnels are negotiated between the peer and cloudflare. When true, the tunnels can be set up to send packets in plaintext (IKE calls this ENCR_NULL) and 

## Description

This brings cloudflare-go to parity with the API options. The change adds a field: `AllowNullCipher` to the `MagicTransitIPsecTunnel` struct to support the option in the API.

## Has your change been tested?

Unit tests were modified so this flag is exercised in them.

Additionally I wrote a small program against my branch to verify this code worked against the live API.

## Screenshots (if appropriate):
N/A

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
