### PR TITLE
Add support for Service Bindings to Worker uploads

### DIFF
--- a/workers_test.go
+++ b/workers_test.go
@@ -128,6 +128,12 @@ const (
 				"type": "secret_text"
 			},
 			{
+				"name": "MY_SERVICE_BINDING",
+				"type": "service",
+				"service": "MY_SERVICE",
+				"environment": "MY_ENVIRONMENT"
+			},
+			{
 				"name": "MY_NEW_BINDING",
 				"type": "some_imaginary_new_binding_type"
 			}
@@ -669,6 +675,54 @@ func TestWorkers_UploadWorkerWithSecretTextBinding(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWorkers_UploadWorkerWithServiceBinding(t *testing.T) {
+	setup(UsingAccount("foo"))
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+
+		mpUpload, err := parseMultipartUpload(r)
+		assert.NoError(t, err)
+
+		expectedBindings := map[string]workerBindingMeta{
+			"b1": {
+				"name":    "b1",
+				"type":    "service",
+				"service": "the_service",
+			},
+			"b2": {
+				"name":        "b2",
+				"type":        "service",
+				"service":     "the_service",
+				"environment": "the_environment",
+			},
+		}
+		assert.Equal(t, workerScript, mpUpload.Script)
+		assert.Equal(t, expectedBindings, mpUpload.BindingMeta)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, uploadWorkerResponseData) //nolint
+	}
+	mux.HandleFunc("/accounts/foo/workers/scripts/bar", handler)
+
+	environment := "the_environment"
+	scriptParams := WorkerScriptParams{
+		Script: workerScript,
+		Bindings: map[string]WorkerBinding{
+			"b1": WorkerServiceBinding{
+				Service: "the_service",
+			},
+			"b2": WorkerServiceBinding{
+				Service:     "the_service",
+				Environment: &environment,
+			},
+		},
+	}
+	_, err := client.UploadWorkerWithBindings(context.Background(), &WorkerRequestParams{ScriptName: "bar"}, &scriptParams)
+	assert.NoError(t, err)
+}
+
 func TestWorkers_CreateWorkerRoute(t *testing.T) {
 	setup()
 	defer teardown()
@@ -936,7 +990,7 @@ func TestWorkers_ListWorkerBindingsMultiScript(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, successResponse, res.Response)
-	assert.Equal(t, 5, len(res.BindingList))
+	assert.Equal(t, 6, len(res.BindingList))
 
 	assert.Equal(t, res.BindingList[0], WorkerBindingListItem{
 		Name: "MY_KV",
@@ -967,11 +1021,21 @@ func TestWorkers_ListWorkerBindingsMultiScript(t *testing.T) {
 	})
 	assert.Equal(t, WorkerSecretTextBindingType, res.BindingList[3].Binding.Type())
 
+	environment := "MY_ENVIRONMENT"
 	assert.Equal(t, res.BindingList[4], WorkerBindingListItem{
+		Name: "MY_SERVICE_BINDING",
+		Binding: WorkerServiceBinding{
+			Service:     "MY_SERVICE",
+			Environment: &environment,
+		},
+	})
+	assert.Equal(t, WorkerServiceBindingType, res.BindingList[4].Binding.Type())
+
+	assert.Equal(t, res.BindingList[5], WorkerBindingListItem{
 		Name:    "MY_NEW_BINDING",
 		Binding: WorkerInheritBinding{},
 	})
-	assert.Equal(t, WorkerInheritBindingType, res.BindingList[4].Binding.Type())
+	assert.Equal(t, WorkerInheritBindingType, res.BindingList[5].Binding.Type())
 }
 
 func TestWorkers_UpdateWorkerRouteErrorsWhenMixingSingleAndMultiScriptProperties(t *testing.T) {


### PR DESCRIPTION
This adds support for Service Bindings to Worker uploads, needed so we can support Service Bindings in our Terraform provider.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
