### PR TITLE
Adding ruleset phase http_response_headers_transform_managed

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -17,24 +17,25 @@ const (
 	RulesetKindSchema  RulesetKind = "schema"
 	RulesetKindZone    RulesetKind = "zone"
 
-	RulesetPhaseDDoSL4                          RulesetPhase = "ddos_l4"
-	RulesetPhaseDDoSL7                          RulesetPhase = "ddos_l7"
-	RulesetPhaseHTTPLogCustomFields             RulesetPhase = "http_log_custom_fields"
-	RulesetPhaseHTTPRequestCacheSettings        RulesetPhase = "http_request_cache_settings"
-	RulesetPhaseHTTPRequestFirewallCustom       RulesetPhase = "http_request_firewall_custom"
-	RulesetPhaseHTTPRequestFirewallManaged      RulesetPhase = "http_request_firewall_managed"
-	RulesetPhaseHTTPRequestLateTransform        RulesetPhase = "http_request_late_transform"
-	RulesetPhaseHTTPRequestLateTransformManaged RulesetPhase = "http_request_late_transform_managed"
-	RulesetPhaseHTTPRequestMain                 RulesetPhase = "http_request_main"
-	RulesetPhaseHTTPRequestOrigin               RulesetPhase = "http_request_origin"
-	RulesetPhaseHTTPRequestRedirect             RulesetPhase = "http_request_redirect"
-	RulesetPhaseHTTPRequestSanitize             RulesetPhase = "http_request_sanitize"
-	RulesetPhaseHTTPRequestTransform            RulesetPhase = "http_request_transform"
-	RulesetPhaseHTTPResponseFirewallManaged     RulesetPhase = "http_response_firewall_managed"
-	RulesetPhaseHTTPResponseHeadersTransform    RulesetPhase = "http_response_headers_transform"
-	RulesetPhaseMagicTransit                    RulesetPhase = "magic_transit"
-	RulesetPhaseRateLimit                       RulesetPhase = "http_ratelimit"
-	RulesetPhaseSuperBotFightMode               RulesetPhase = "http_request_sbfm"
+	RulesetPhaseDDoSL4                              RulesetPhase = "ddos_l4"
+	RulesetPhaseDDoSL7                              RulesetPhase = "ddos_l7"
+	RulesetPhaseHTTPLogCustomFields                 RulesetPhase = "http_log_custom_fields"
+	RulesetPhaseHTTPRequestCacheSettings            RulesetPhase = "http_request_cache_settings"
+	RulesetPhaseHTTPRequestFirewallCustom           RulesetPhase = "http_request_firewall_custom"
+	RulesetPhaseHTTPRequestFirewallManaged          RulesetPhase = "http_request_firewall_managed"
+	RulesetPhaseHTTPRequestLateTransform            RulesetPhase = "http_request_late_transform"
+	RulesetPhaseHTTPRequestLateTransformManaged     RulesetPhase = "http_request_late_transform_managed"
+	RulesetPhaseHTTPRequestMain                     RulesetPhase = "http_request_main"
+	RulesetPhaseHTTPRequestOrigin                   RulesetPhase = "http_request_origin"
+	RulesetPhaseHTTPRequestRedirect                 RulesetPhase = "http_request_redirect"
+	RulesetPhaseHTTPRequestSanitize                 RulesetPhase = "http_request_sanitize"
+	RulesetPhaseHTTPRequestTransform                RulesetPhase = "http_request_transform"
+	RulesetPhaseHTTPResponseFirewallManaged         RulesetPhase = "http_response_firewall_managed"
+	RulesetPhaseHTTPResponseHeadersTransform        RulesetPhase = "http_response_headers_transform"
+	RulesetPhaseHTTPResponseHeadersTransformManaged RulesetPhase = "http_response_headers_transform_managed"
+	RulesetPhaseMagicTransit                        RulesetPhase = "magic_transit"
+	RulesetPhaseRateLimit                           RulesetPhase = "http_ratelimit"
+	RulesetPhaseSuperBotFightMode                   RulesetPhase = "http_request_sbfm"
 
 	RulesetRuleActionBlock                RulesetRuleAction = "block"
 	RulesetRuleActionChallenge            RulesetRuleAction = "challenge"
@@ -95,6 +96,7 @@ func RulesetPhaseValues() []string {
 		string(RulesetPhaseHTTPRequestTransform),
 		string(RulesetPhaseHTTPResponseFirewallManaged),
 		string(RulesetPhaseHTTPResponseHeadersTransform),
+		string(RulesetPhaseHTTPResponseHeadersTransformManaged),
 		string(RulesetPhaseMagicTransit),
 		string(RulesetPhaseRateLimit),
 		string(RulesetPhaseSuperBotFightMode),


### PR DESCRIPTION
## Description

Adding ruleset phase http_response_headers_transform_managed should solve the following error:

Error: expected phase to be one of [ddos_l4 ddos_l7 http_log_custom_fields http_request_firewall_custom http_request_firewall_managed http_request_late_transform http_request_main http_request_sanitize http_request_transform http_response_firewall_managed http_response_headers_transform magic_transit http_ratelimit], got http_response_headers_transform_managed

## Has your change been tested?

Yes, I have verified that I no longer see the error on my local machine.

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
