### PR TITLE
Revert DNSRecord.Proxied type into bool and remove `omitempty` tag

### DIFF
--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -19,7 +19,7 @@ func formatDNSRecord(record cloudflare.DNSRecord) []string {
 		record.Content,
 		strconv.FormatInt(int64(record.TTL), 10),
 		strconv.FormatBool(record.Proxiable),
-		strconv.FormatBool(*record.Proxied),
+		strconv.FormatBool(record.Proxied),
 		strconv.FormatBool(record.Locked),
 	}
 }
@@ -46,7 +46,7 @@ func dnsCreate(c *cli.Context) error {
 		Type:    strings.ToUpper(rtype),
 		Content: content,
 		TTL:     ttl,
-		Proxied: &proxy,
+		Proxied: proxy,
 	}
 	resp, err := api.CreateDNSRecord(context.Background(), zoneID, record)
 	if err != nil {
@@ -102,7 +102,7 @@ func dnsCreateOrUpdate(c *cli.Context) error {
 				rr.Type = r.Type
 				rr.Content = content
 				rr.TTL = ttl
-				rr.Proxied = &proxy
+				rr.Proxied = proxy
 
 				err := api.UpdateDNSRecord(context.Background(), zoneID, r.ID, rr)
 				if err != nil {
@@ -119,7 +119,7 @@ func dnsCreateOrUpdate(c *cli.Context) error {
 		rr.Type = rtype
 		rr.Content = content
 		rr.TTL = ttl
-		rr.Proxied = &proxy
+		rr.Proxied = proxy
 		// TODO: Print the response.
 		resp, err = api.CreateDNSRecord(context.Background(), zoneID, rr)
 		if err != nil {
@@ -162,7 +162,7 @@ func dnsUpdate(c *cli.Context) error {
 		Type:    strings.ToUpper(rtype),
 		Content: content,
 		TTL:     ttl,
-		Proxied: &proxy,
+		Proxied: proxy,
 	}
 	err = api.UpdateDNSRecord(context.Background(), zoneID, recordID, record)
 	if err != nil {

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -320,7 +320,7 @@ func zoneRecords(c *cli.Context) error {
 			r.Type,
 			r.Name,
 			r.Content,
-			strconv.FormatBool(*r.Proxied),
+			strconv.FormatBool(r.Proxied),
 			fmt.Sprintf("%d", r.TTL),
 		})
 	}

--- a/dns.go
+++ b/dns.go
@@ -27,7 +27,7 @@ type DNSRecord struct {
 	ZoneName   string      `json:"zone_name,omitempty"`
 	Priority   *uint16     `json:"priority,omitempty"`
 	TTL        int         `json:"ttl,omitempty"`
-	Proxied    *bool       `json:"proxied,omitempty"`
+	Proxied    bool        `json:"proxied,omitempty"`
 	Proxiable  bool        `json:"proxiable,omitempty"`
 	Locked     bool        `json:"locked,omitempty"`
 }

--- a/dns.go
+++ b/dns.go
@@ -27,7 +27,7 @@ type DNSRecord struct {
 	ZoneName   string      `json:"zone_name,omitempty"`
 	Priority   *uint16     `json:"priority,omitempty"`
 	TTL        int         `json:"ttl,omitempty"`
-	Proxied    bool        `json:"proxied,omitempty"`
+	Proxied    bool        `json:"proxied"`
 	Proxiable  bool        `json:"proxiable,omitempty"`
 	Locked     bool        `json:"locked,omitempty"`
 }

--- a/dns.go
+++ b/dns.go
@@ -27,7 +27,7 @@ type DNSRecord struct {
 	ZoneName   string      `json:"zone_name,omitempty"`
 	Priority   *uint16     `json:"priority,omitempty"`
 	TTL        int         `json:"ttl,omitempty"`
-	Proxied    bool        `json:"proxied"`
+	Proxied    bool        `json:"proxied" default:"false"`
 	Proxiable  bool        `json:"proxiable,omitempty"`
 	Locked     bool        `json:"locked,omitempty"`
 }

--- a/dns_test.go
+++ b/dns_test.go
@@ -74,7 +74,7 @@ func TestCreateDNSRecord(t *testing.T) {
 		Content:  "198.51.100.4",
 		TTL:      120,
 		Priority: &priority,
-		Proxied:  &proxied,
+		Proxied:  proxied,
 	}
 	asciiInput := DNSRecord{
 		Type:     "A",
@@ -82,7 +82,7 @@ func TestCreateDNSRecord(t *testing.T) {
 		Content:  "198.51.100.4",
 		TTL:      120,
 		Priority: &priority,
-		Proxied:  &proxied,
+		Proxied:  proxied,
 	}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -217,7 +217,7 @@ func TestDNSRecords(t *testing.T) {
 		Name:       asciiInput.Name,
 		Content:    asciiInput.Content,
 		Proxiable:  true,
-		Proxied:    &proxied,
+		Proxied:    proxied,
 		TTL:        120,
 		Locked:     false,
 		ZoneID:     testZoneID,
@@ -284,7 +284,7 @@ func TestDNSRecord(t *testing.T) {
 		Name:       "example.com",
 		Content:    "198.51.100.4",
 		Proxiable:  true,
-		Proxied:    &proxied,
+		Proxied:    proxied,
 		TTL:        120,
 		ZoneID:     testZoneID,
 		ZoneName:   "example.com",
@@ -313,7 +313,7 @@ func TestUpdateDNSRecord(t *testing.T) {
 		Name:    "example.com",
 		Content: "198.51.100.4",
 		TTL:     120,
-		Proxied: &proxied,
+		Proxied: proxied,
 	}
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -370,7 +370,7 @@ func TestUpdateDNSRecordWithoutName(t *testing.T) {
 		Type:    "A",
 		Content: "198.51.100.4",
 		TTL:     120,
-		Proxied: &proxied,
+		Proxied: proxied,
 	}
 
 	unicodeInput := DNSRecord{
@@ -378,7 +378,7 @@ func TestUpdateDNSRecordWithoutName(t *testing.T) {
 		Type:    "A",
 		Content: "198.51.100.4",
 		TTL:     120,
-		Proxied: &proxied,
+		Proxied: proxied,
 	}
 
 	handleUpdateDNSRecord := func(w http.ResponseWriter, r *http.Request) {
@@ -478,7 +478,7 @@ func TestUpdateDNSRecordWithoutType(t *testing.T) {
 		Name:    "😺.example.com",
 		Content: "198.51.100.4",
 		TTL:     120,
-		Proxied: &proxied,
+		Proxied: proxied,
 	}
 
 	completedASCIIInput := DNSRecord{
@@ -486,7 +486,7 @@ func TestUpdateDNSRecordWithoutType(t *testing.T) {
 		Type:    "A",
 		Content: "198.51.100.4",
 		TTL:     120,
-		Proxied: &proxied,
+		Proxied: proxied,
 	}
 
 	handleUpdateDNSRecord := func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description

Here are some reasons that motivated me to do this commitments.

### Previously pointer type causes difficulty to approach to the API

Current version require a _pointer_ to assign boolean value into DNSRecord.Proxied. So to assign a truthy value, instead of `true`, I must use `&[]bool{true}[0]` or any other equal item, which is a strange view in code written in golang.

### Clearer is better

In this pull request I removed `omitempty` tag and added `default` tag. The reason is `proxied` attribute in CloudFlare DNS API (Client Payload) is either required or optional but default is falsy. I supposed that it might be a better solution to make `DNSRecord.Proxied` explicit in order to call functions more clearly.

### BTW

 - It's a breaking change
 - Related pull request is: #595 

## Has your change been tested?

Yes, via given GitHub Actions workflows.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

