### PR TITLE
experimental: swap out custom retry logic for go-retryablehttp

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -26,9 +26,13 @@ const (
 	errResultInfo                             = "incorrect pagination info (result_info) in responses"
 	errManualPagination                       = "unexpected pagination options passed to functions that handle pagination automatically"
 	errInvalidZoneIdentifer                   = "invalid zone identifier: %s"
+	errAPIKeysAndTokensAreMutuallyExclusive   = "API keys and tokens are mutually exclusive"
+	errMissingCredentials                     = "no credentials provided"
 )
 
 var (
+	ErrAPIKeysAndTokensAreMutuallyExclusive   = errors.New(errAPIKeysAndTokensAreMutuallyExclusive)
+	ErrMissingCredentials                     = errors.New(errMissingCredentials)
 	ErrMissingAccountID                       = errors.New(errMissingAccountID)
 	ErrMissingZoneID                          = errors.New(errMissingZoneID)
 	ErrAccountIDOrZoneIDAreRequired           = errors.New(errMissingAccountOrZoneID)

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.17
 
 require (
 	github.com/cweill/gotests v1.6.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/go-delve/delve v1.8.3
 	github.com/golangci/golangci-lint v1.46.2
 	github.com/google/go-querystring v1.1.0
+	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/orijtech/structslop v0.0.6
 	github.com/pkg/errors v0.9.1
@@ -47,7 +49,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/daixiang0/gci v0.3.3 // indirect
 	github.com/dave/dst v0.26.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect
 	github.com/derekparker/trie v0.0.0-20200317170641-1fdf38b7b0e9 // indirect
 	github.com/esimonov/ifshort v1.0.4 // indirect
@@ -87,6 +88,7 @@ require (
 	github.com/gostaticanalysis/forcetypeassert v0.1.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
@@ -177,7 +179,7 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
+	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11-0.20220513164230-dfee1649af67 // indirect
 	golang.org/x/vuln v0.0.0-20220503210553-a5481fb0c8be // indirect

--- a/go.sum
+++ b/go.sum
@@ -454,9 +454,12 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
 github.com/hashicorp/go-hclog v1.2.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -466,6 +469,8 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
@@ -1240,8 +1245,9 @@ golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220403020550-483a9cbc67c0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220406163625-3f8b81556e12/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/logger.go
+++ b/logger.go
@@ -3,8 +3,13 @@ package cloudflare
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 )
+
+// silentRetryLogger is the logger provided with retryable client to stop it
+// displaying the retry attempts.
+var silentRetryLogger = log.New(io.Discard, "", log.LstdFlags)
 
 const (
 	// LevelNull sets a logger to show no messages at all.
@@ -28,18 +33,13 @@ const (
 
 // DefaultLeveledLogger is the default logger that the library will use to log
 // errors, warnings, and informational messages.
-//
-// LeveledLoggerInterface is implemented by LeveledLogger, and one can be
-// initialized at the desired level of logging.  LeveledLoggerInterface also
-// provides out-of-the-box compatibility with a Logrus Logger, but may require
-// a thin shim for use with other logging libraries that use less standard
-// conventions like Zap.
-//
-// This Logger will be inherited by any backends created by default, but will
-// be overridden if a backend is created with GetBackendWithConfig with a
-// custom LeveledLogger set.
 var DefaultLeveledLogger LeveledLoggerInterface = &LeveledLogger{
 	Level: LevelError,
+}
+
+// SilentLeveledLogger is a logger for disregarding all logs written.
+var SilentLeveledLogger LeveledLoggerInterface = &LeveledLogger{
+	Level: LevelNull,
 }
 
 // Level represents a logging level.
@@ -67,7 +67,7 @@ type LeveledLogger struct {
 // Debugf logs a debug message using Printf conventions.
 func (l *LeveledLogger) Debugf(format string, v ...interface{}) {
 	if l.Level >= LevelDebug {
-		fmt.Fprintf(l.stdout(), "[DEBUG] "+format+"\n", v...)
+		fmt.Fprintf(l.stdout(), "[debug] "+format, v...)
 	}
 }
 
@@ -75,21 +75,21 @@ func (l *LeveledLogger) Debugf(format string, v ...interface{}) {
 func (l *LeveledLogger) Errorf(format string, v ...interface{}) {
 	// Infof logs a debug message using Printf conventions.
 	if l.Level >= LevelError {
-		fmt.Fprintf(l.stderr(), "[ERROR] "+format+"\n", v...)
+		fmt.Fprintf(l.stderr(), "[error] "+format, v...)
 	}
 }
 
 // Infof logs an informational message using Printf conventions.
 func (l *LeveledLogger) Infof(format string, v ...interface{}) {
 	if l.Level >= LevelInfo {
-		fmt.Fprintf(l.stdout(), "[INFO] "+format+"\n", v...)
+		fmt.Fprintf(l.stdout(), "[info] "+format, v...)
 	}
 }
 
 // Warnf logs a warning message using Printf conventions.
 func (l *LeveledLogger) Warnf(format string, v ...interface{}) {
 	if l.Level >= LevelWarn {
-		fmt.Fprintf(l.stderr(), "[WARN] "+format+"\n", v...)
+		fmt.Fprintf(l.stderr(), "[warn] "+format, v...)
 	}
 }
 

--- a/zones.go
+++ b/zones.go
@@ -74,10 +74,13 @@ func (s *ZonesService) Get(ctx context.Context, zoneID ZoneIdentifier) (Zone, er
 		return Zone{}, err
 	}
 
-	res, _ := s.client.Call(ctx, http.MethodGet, "/zones/"+zoneID.String(), nil)
+	res, err := s.client.Call(ctx, http.MethodGet, "/zones/"+zoneID.String(), nil)
+	if err != nil {
+		return Zone{}, fmt.Errorf("failed to fetch zones: %w", err)
+	}
 
 	var r ZoneResponse
-	err := json.Unmarshal(res, &r)
+	err = json.Unmarshal(res, &r)
 	if err != nil {
 		return Zone{}, fmt.Errorf("failed to unmarshal zone JSON data: %w", err)
 	}


### PR DESCRIPTION
Remove homegrown retry logic in favour of go-retryable instead.