### PR TITLE
improve parameter conventions for simple operations Get/Delete

### DIFF
--- a/cloudflare_experimental.go
+++ b/cloudflare_experimental.go
@@ -307,3 +307,23 @@ func (c *Client) makeRequest(ctx context.Context, method, uri string, params int
 
 	return respBody, nil
 }
+
+func (c *Client) get(ctx context.Context, path string, payload interface{}) ([]byte, error) {
+	return c.makeRequest(ctx, http.MethodGet, path, payload, nil)
+}
+
+func (c *Client) post(ctx context.Context, path string, payload interface{}) ([]byte, error) {
+	return c.makeRequest(ctx, http.MethodPost, path, payload, nil)
+}
+
+func (c *Client) patch(ctx context.Context, path string, payload interface{}) ([]byte, error) {
+	return c.makeRequest(ctx, http.MethodPatch, path, payload, nil)
+}
+
+func (c *Client) put(ctx context.Context, path string, payload interface{}) ([]byte, error) {
+	return c.makeRequest(ctx, http.MethodPut, path, payload, nil)
+}
+
+func (c *Client) delete(ctx context.Context, path string, payload interface{}) ([]byte, error) {
+	return c.makeRequest(ctx, http.MethodDelete, path, payload, nil)
+}

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -10,13 +10,13 @@ and consistent experience.
 Majority of entities follow a standard method signature (where `$entity` is the
 resource such as `Zone`, `DNSRecord`, ...).
 
-| Signature                                             | Purpose                                            | Return value                                                                                                                   |
-| ----------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `Get(ctx, id) ($entity, error)`                       | Fetches a single entity by an identifer.           | Returns the entity and `error` based on the listing parameters.                                                                |
-| `List(ctx, ...params) ([]$entity, ResultInfo, error)` | Fetches all entities.                              | Returns the list of matching entities, the result information (pagination, fail/success and additional metadata), and `error`. |
-| `New(ctx, ...params) ($entity, error)`                | Creates a new entity with the provided parameters. | Returns the newly created entity and `error`.                                                                                  |
-| `Update(ctx, id, ...params) ($entity, error)`         | Updates an existing entity.                        | Returns the updated entity and `error`.                                                                                        |
-| `Delete(ctx, id) (error)`                             | Deletes a single entity.                           | Returns `error`.                                                                                                               |
+| Signature                                             | Purpose                                                                                                                              | Return value                                                                                                                   |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `Get(ctx, *Resource) ($entity, error)`                | Fetches a single entity by a `Resource`. Should use `ZoneIdentifier` and `AccountIdentifier` respectively (not \*Resource directly). | Returns the entity and `error` based on the listing parameters.                                                                |
+| `List(ctx, ...params) ([]$entity, ResultInfo, error)` | Fetches all entities.                                                                                                                | Returns the list of matching entities, the result information (pagination, fail/success and additional metadata), and `error`. |
+| `New(ctx, ...params) ($entity, error)`                | Creates a new entity with the provided parameters.                                                                                   | Returns the newly created entity and `error`.                                                                                  |
+| `Update(ctx, ...params) ($entity, error)`             | Updates an existing entity.                                                                                                          | Returns the updated entity and `error`.                                                                                        |
+| `Delete(ctx, *Resource) (error)`                      | Deletes a single entity by a `Resource`. Should use `ZoneIdentifier` and `AccountIdentifier` respectively (not \*Resource directly). | Returns `error`.                                                                                                               |
 
 ### Why no iterator for `List` operations?
 
@@ -90,7 +90,7 @@ params := cloudflare.ClientParams{
 }
 c, err := cloudflare.NewExperimental(params)
 
-z, _ := c.Zones.Get(ctx, "3e7705498e8be60520841409ebc69bc1")
+z, _ := c.Zones.Get(ctx, cloudflare.ZoneIdentifier("3e7705498e8be60520841409ebc69bc1"))
 ```
 
 ### Fetching all zones matching a single account ID
@@ -118,12 +118,13 @@ params := cloudflare.ClientParams{
 c, err := cloudflare.NewExperimental(params)
 
 zParams := &cloudflare.ZoneParams{
+  ID: "3e7705498e8be60520841409ebc69bc1",
   Nameservers: cloudflare.StringSlice([]string{
     "ns1.example.com",
     "ns2.example.com"
   })
 }
-z, _ := c.Zones.Update(ctx, "b5163cf270a3fbac34827c4a2713eef4", zParams)
+z, _ := c.Zones.Update(ctx, zParams)
 ```
 
 ### Delete a zone
@@ -135,5 +136,5 @@ params := cloudflare.ClientParams{
 }
 c, err := cloudflare.NewExperimental(params)
 
-z, _ := c.Zones.Delete(ctx, "b5163cf270a3fbac34827c4a2713eef4")
+z, _ := c.Zones.Delete(ctx, cloudflare.ZoneIdentifier("b5163cf270a3fbac34827c4a2713eef4"))
 ```

--- a/errors.go
+++ b/errors.go
@@ -25,6 +25,7 @@ const (
 	errOperationUnexpectedStatus              = "bulk operation returned an unexpected status"
 	errResultInfo                             = "incorrect pagination info (result_info) in responses"
 	errManualPagination                       = "unexpected pagination options passed to functions that handle pagination automatically"
+	errInvalidResourceIdentifer               = "invalid resource identifier: %s"
 	errInvalidZoneIdentifer                   = "invalid zone identifier: %s"
 	errAPIKeysAndTokensAreMutuallyExclusive   = "API keys and tokens are mutually exclusive"
 	errMissingCredentials                     = "no credentials provided"

--- a/pagination.go
+++ b/pagination.go
@@ -1,0 +1,19 @@
+package cloudflare
+
+// Done returns true for the last page and false otherwise.
+func (p ResultInfo) Done() bool {
+	return p.Page > 1 && p.Page > p.TotalPages
+}
+
+// Next advances the page of a paginated API response, but does not fetch the
+// next page of results.
+func (p ResultInfo) Next() *ResultInfo {
+	p.Page++
+	return &p
+}
+
+// HasMorePages returns whether there is another page of results after the
+// current one.
+func (p ResultInfo) HasMorePages() bool {
+	return p.Page < p.TotalPages
+}

--- a/resource.go
+++ b/resource.go
@@ -1,0 +1,42 @@
+package cloudflare
+
+// RouteLevel holds the "level" where the resource resides.
+type RouteLevel string
+
+const (
+	AccountRouteLevel RouteLevel = "accounts"
+	ZoneRouteLevel    RouteLevel = "zones"
+	UserRouteLevel    RouteLevel = "user"
+)
+
+// Resource defines an API resource you wish to target. Should not be used
+// directly, use `UserIdentifer`, `ZoneIdentifier` and `AccountIdentifier`
+// instead.
+type Resource struct {
+	Level      RouteLevel
+	Identifier string
+}
+
+// UserIdentifer returns a user level *Resource.
+func UserIdentifer(id string) *Resource {
+	return &Resource{
+		Level:      UserRouteLevel,
+		Identifier: id,
+	}
+}
+
+// ZoneIdentifer returns a zone level *Resource.
+func ZoneIdentifer(id string) *Resource {
+	return &Resource{
+		Level:      ZoneRouteLevel,
+		Identifier: id,
+	}
+}
+
+// AccountIdentifer returns an account level *Resource.
+func AccountIdentifer(id string) *Resource {
+	return &Resource{
+		Level:      AccountRouteLevel,
+		Identifier: id,
+	}
+}

--- a/zones.go
+++ b/zones.go
@@ -4,11 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"regexp"
 )
-
-type ZoneIdentifier string
 
 type ZonesService service
 
@@ -19,7 +15,7 @@ type ZoneCreateParams struct {
 	Account   *Account `json:"organization,omitempty"`
 }
 
-type ZoneParams struct {
+type ZoneListParams struct {
 	Match       string `url:"match,omitempty"`
 	Name        string `url:"name,omitempty"`
 	AccountName string `url:"account.name,omitempty"`
@@ -30,29 +26,19 @@ type ZoneParams struct {
 	PerPage     int    `json:"per_page,omitempty" url:"per_page,omitempty"`
 }
 
-// ZoneIdentifierValue accepts a string and returns a ZoneIdentifier for use in
-// methods that require the stricter type.
-func ZoneIdentifierValue(z string) ZoneIdentifier {
-	return ZoneIdentifier(z)
-}
-
-func (z ZoneIdentifier) String() string {
-	return string(z)
-}
-
-func (z ZoneIdentifier) Validate() error {
-	matches, _ := regexp.MatchString(`^[0-9a-fA-F]{32}$`, z.String())
-	if !matches {
-		return fmt.Errorf(errInvalidZoneIdentifer, z)
-	}
-	return nil
+type ZoneUpdateParams struct {
+	ID                string
+	Paused            *bool    `json:"paused"`
+	VanityNameServers []string `json:"vanity_name_servers,omitempty"`
+	Plan              ZonePlan `json:"plan,omitempty"`
+	Type              string   `json:"type,omitempty"`
 }
 
 // New creates a new zone.
 //
 // API reference: https://api.cloudflare.com/#zone-zone-details
 func (s *ZonesService) New(ctx context.Context, zone *ZoneCreateParams) (Zone, error) {
-	res, err := s.client.Call(ctx, http.MethodPost, "/zones", zone)
+	res, err := s.client.post(ctx, "/zones", zone)
 	if err != nil {
 		return Zone{}, err
 	}
@@ -69,12 +55,9 @@ func (s *ZonesService) New(ctx context.Context, zone *ZoneCreateParams) (Zone, e
 // Get fetches a single zone.
 //
 // API reference: https://api.cloudflare.com/#zone-zone-details
-func (s *ZonesService) Get(ctx context.Context, zoneID ZoneIdentifier) (Zone, error) {
-	if err := zoneID.Validate(); err != nil {
-		return Zone{}, err
-	}
-
-	res, err := s.client.Call(ctx, http.MethodGet, "/zones/"+zoneID.String(), nil)
+func (s *ZonesService) Get(ctx context.Context, resource *Resource) (Zone, error) {
+	uri := fmt.Sprintf("/%s/%s", resource.Level, resource.Identifier)
+	res, err := s.client.get(ctx, uri, nil)
 	if err != nil {
 		return Zone{}, fmt.Errorf("failed to fetch zones: %w", err)
 	}
@@ -91,8 +74,8 @@ func (s *ZonesService) Get(ctx context.Context, zoneID ZoneIdentifier) (Zone, er
 // List returns all zones that match the provided `ZoneParams` struct.
 //
 // API reference: https://api.cloudflare.com/#zone-list-zones
-func (s *ZonesService) List(ctx context.Context, params *ZoneParams) ([]Zone, *ResultInfo, error) {
-	res, _ := s.client.Call(ctx, http.MethodGet, buildURI("/zones", params), nil)
+func (s *ZonesService) List(ctx context.Context, params *ZoneListParams) ([]Zone, *ResultInfo, error) {
+	res, _ := s.client.get(ctx, buildURI("/zones", params), nil)
 
 	var r ZonesResponse
 	err := json.Unmarshal(res, &r)
@@ -103,15 +86,28 @@ func (s *ZonesService) List(ctx context.Context, params *ZoneParams) ([]Zone, *R
 	return r.Result, &r.ResultInfo, nil
 }
 
+// Update modifies an existing zone.
+//
+// API reference: https://api.cloudflare.com/#zone-edit-zone
+func (s *ZonesService) Update(ctx context.Context, params *ZoneUpdateParams) ([]Zone, error) {
+	uri := fmt.Sprintf("/zones/%s", params.ID)
+	res, _ := s.client.patch(ctx, uri, params)
+
+	var r ZonesResponse
+	err := json.Unmarshal(res, &r)
+	if err != nil {
+		return []Zone{}, fmt.Errorf("failed to unmarshal zone JSON data: %w", err)
+	}
+
+	return r.Result, nil
+}
+
 // Delete deletes a zone based on ID.
 //
 // API reference: https://api.cloudflare.com/#zone-delete-zone
-func (s *ZonesService) Delete(ctx context.Context, zoneID ZoneIdentifier) error {
-	if err := zoneID.Validate(); err != nil {
-		return err
-	}
-
-	res, _ := s.client.Call(ctx, http.MethodDelete, "/zones/"+zoneID.String(), nil)
+func (s *ZonesService) Delete(ctx context.Context, resource *Resource) error {
+	uri := fmt.Sprintf("/%s/%s", resource.Level, resource.Identifier)
+	res, _ := s.client.delete(ctx, uri, nil)
 
 	var r ZoneResponse
 	err := json.Unmarshal(res, &r)


### PR DESCRIPTION
Updates the recommendations to use a slightly refined convention of passing in a
*Resource object (via a helper method) to Get/Delete methods in order to reduce
the boilerplate for simple methods. This will allow the simple methods to
convey the route level (accounts vs zones) along with the identifier without
the verbosity.