### PR TITLE
Fixes .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 .vscode/
 cmd/flarectl/dist/
-cmd/flarectl/flarectl*
+cmd/flarectl/flarectl
+cmd/flarectl/flarectl.exe


### PR DESCRIPTION
When editing flarectl for #976, I made the `.gitignore` too aggressive. Only mean to ignore flarectl.exe for Windows, but it also ignores `flarectl.go`.
## Has your change been tested?

`flarectl.go` is no longer ignored


## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

