### PR TITLE
fix: remove accountid property from TunnelListParams

### DIFF
--- a/tunnel.go
+++ b/tunnel.go
@@ -183,7 +183,6 @@ type TunnelConfigurationParams struct {
 }
 
 type TunnelListParams struct {
-	AccountID string     `url:"-"`
 	Name      string     `url:"name,omitempty"`
 	UUID      string     `url:"uuid,omitempty"` // the tunnel ID
 	IsDeleted *bool      `url:"is_deleted,omitempty"`


### PR DESCRIPTION
A trivial PR to remove the AccountID property from the TunnelListParams struct in `tunnel.go`.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
