### PR TITLE
Change bypass_cache to cache parameter for Cache Rules

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -210,7 +210,7 @@ type RulesetRuleActionParameters struct {
 	RequestFields           []RulesetActionParametersLogCustomField          `json:"request_fields,omitempty"`
 	ResponseFields          []RulesetActionParametersLogCustomField          `json:"response_fields,omitempty"`
 	CookieFields            []RulesetActionParametersLogCustomField          `json:"cookie_fields,omitempty"`
-	BypassCache             *bool                                            `json:"bypass_cache,omitempty"`
+	Cache                   *bool                                            `json:"cache,omitempty"`
 	EdgeTTL                 *RulesetRuleActionParametersEdgeTTL              `json:"edge_ttl,omitempty"`
 	BrowserTTL              *RulesetRuleActionParametersBrowserTTL           `json:"browser_ttl,omitempty"`
 	ServeStale              *RulesetRuleActionParametersServeStale           `json:"serve_stale,omitempty"`

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -219,7 +219,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
             "version": "1",
             "action": "set_cache_settings",
             "action_parameters": {
-				"bypass_cache": false,
+				"cache": true,
 				"edge_ttl":{"mode":"respect_origin","default":60,"status_code_ttl":[{"status_code":200,"value":30},{"status_code_range":{"from":201,"to":300},"value":20}]},
 				"browser_ttl":{"mode":"override_origin","default":10},
 				"serve_stale":{"disable_stale_while_updating":true},
@@ -268,7 +268,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 		Version: "1",
 		Action:  string(RulesetRuleActionSetCacheSettings),
 		ActionParameters: &RulesetRuleActionParameters{
-			BypassCache: BoolPtr(false),
+			Cache: BoolPtr(true),
 			EdgeTTL: &RulesetRuleActionParametersEdgeTTL{
 				Mode:    "respect_origin",
 				Default: UintPtr(60),


### PR DESCRIPTION
Flip the cache enabling flag to opposite one, since it will be changed in the API

(This product is still under unstable entitlement and no actual customers are using it, so it is safe to rename parameters without any migrations)