### PR TITLE
Support ServeError action and http_custom_errors phase

### DIFF
--- a/.changelog/998.txt
+++ b/.changelog/998.txt
@@ -1,4 +1,7 @@
-```release-note:bug
-rulesets: add http_custom_errors phase and serve_error action
+```release-note:enhancement
+rulesets: add support for `http_custom_errors` phase
 ```
 
+```release-note:enhancement
+rulesets: add support for `serve_error` action
+```

--- a/.changelog/998.txt
+++ b/.changelog/998.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+rulesets: add http_custom_errors phase and serve_error action
+```
+

--- a/rulesets.go
+++ b/rulesets.go
@@ -19,6 +19,7 @@ const (
 
 	RulesetPhaseDDoSL4                              RulesetPhase = "ddos_l4"
 	RulesetPhaseDDoSL7                              RulesetPhase = "ddos_l7"
+	RulesetPhaseHTTPCustomErrors                    RulesetPhase = "http_custom_errors"
 	RulesetPhaseHTTPLogCustomFields                 RulesetPhase = "http_log_custom_fields"
 	RulesetPhaseHTTPRequestCacheSettings            RulesetPhase = "http_request_cache_settings"
 	RulesetPhaseHTTPRequestFirewallCustom           RulesetPhase = "http_request_firewall_custom"
@@ -52,6 +53,7 @@ const (
 	RulesetRuleActionRoute                RulesetRuleAction = "route"
 	RulesetRuleActionScore                RulesetRuleAction = "score"
 	RulesetRuleActionSetCacheSettings     RulesetRuleAction = "set_cache_settings"
+	RulesetRuleActionServeError           RulesetRuleAction = "serve_error"
 	RulesetRuleActionSkip                 RulesetRuleAction = "skip"
 
 	RulesetActionParameterProductBIC           RulesetActionParameterProduct = "bic"
@@ -84,6 +86,7 @@ func RulesetPhaseValues() []string {
 	return []string{
 		string(RulesetPhaseDDoSL4),
 		string(RulesetPhaseDDoSL7),
+		string(RulesetPhaseHTTPCustomErrors),
 		string(RulesetPhaseHTTPLogCustomFields),
 		string(RulesetPhaseHTTPRequestCacheSettings),
 		string(RulesetPhaseHTTPRequestFirewallCustom),
@@ -123,6 +126,7 @@ func RulesetRuleActionValues() []string {
 		string(RulesetRuleActionRoute),
 		string(RulesetRuleActionScore),
 		string(RulesetRuleActionSetCacheSettings),
+		string(RulesetRuleActionServeError),
 		string(RulesetRuleActionSkip),
 	}
 }
@@ -216,6 +220,9 @@ type RulesetRuleActionParameters struct {
 	EdgeTTL                 *RulesetRuleActionParametersEdgeTTL              `json:"edge_ttl,omitempty"`
 	BrowserTTL              *RulesetRuleActionParametersBrowserTTL           `json:"browser_ttl,omitempty"`
 	ServeStale              *RulesetRuleActionParametersServeStale           `json:"serve_stale,omitempty"`
+	Content                 string                                           `json:"content,omitempty"`
+	ContentType             string                                           `json:"content_type,omitempty"`
+	StatusCode              uint16                                           `json:"status_code,omitempty"`
 	RespectStrongETags      *bool                                            `json:"respect_strong_etags,omitempty"`
 	CacheKey                *RulesetRuleActionParametersCacheKey             `json:"cache_key,omitempty"`
 	OriginErrorPagePassthru *bool                                            `json:"origin_error_page_passthru,omitempty"`


### PR DESCRIPTION
Add support for the new http_custom_errors phase, that uses the serve_error action. This action supports action parameters content, content_type and status_code.