### PR TITLE
filter/firewall_rules: update methods to automatically paginate

### DIFF
--- a/.changelog/1004.txt
+++ b/.changelog/1004.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+firewall_rule: automatically paginate `List` results unless `Page` and `PerPage` are provided
+```
+
+```release-note:enhancement
+filter: automatically paginate `List` results unless `Page` and `PerPage` are provided
+```

--- a/filter_test.go
+++ b/filter_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var pageOpts = PaginationOptions{
-	PerPage: 25,
-	Page:    1,
-}
-
 func TestFilter(t *testing.T) {
 	setup()
 	defer teardown()
@@ -43,7 +38,7 @@ func TestFilter(t *testing.T) {
 		Expression:  "ip.src eq 127.0.0.1",
 	}
 
-	actual, err := client.Filter(context.Background(), "d56084adb405e0b7e32c52321bf07be6", "b7ff25282d394be7b945e23c7106ce8a")
+	actual, err := client.Filter(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), "b7ff25282d394be7b945e23c7106ce8a")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -131,7 +126,7 @@ func TestFilters(t *testing.T) {
 		},
 	}
 
-	actual, err := client.Filters(context.Background(), "d56084adb405e0b7e32c52321bf07be6", pageOpts)
+	actual, _, err := client.Filters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), FilterListParams{})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -171,7 +166,7 @@ func TestCreateSingleFilter(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFilters(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.CreateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -223,7 +218,7 @@ func TestCreateMultipleFilters(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFilters(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.CreateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -259,7 +254,7 @@ func TestUpdateSingleFilter(t *testing.T) {
 		Expression:  "ip.src eq 93.184.216.0",
 	}
 
-	actual, err := client.UpdateFilter(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.UpdateFilter(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -311,7 +306,7 @@ func TestUpdateMultipleFilters(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateFilters(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.UpdateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -336,7 +331,7 @@ func TestDeleteFilter(t *testing.T) {
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110", handler)
 
-	err := client.DeleteFilter(context.Background(), "d56084adb405e0b7e32c52321bf07be6", "60ee852f9cbb4802978d15600c7f3110")
+	err := client.DeleteFilter(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), "60ee852f9cbb4802978d15600c7f3110")
 	assert.Nil(t, err)
 	assert.NoError(t, err)
 }
@@ -345,6 +340,6 @@ func TestDeleteFilterWithMissingID(t *testing.T) {
 	setup()
 	defer teardown()
 
-	err := client.DeleteFilter(context.Background(), "d56084adb405e0b7e32c52321bf07be6", "")
+	err := client.DeleteFilter(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), "")
 	assert.EqualError(t, err, "filter ID cannot be empty")
 }

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -38,31 +38,60 @@ type FirewallRuleResponse struct {
 	Response
 }
 
+type FirewallRuleListParams struct {
+	ResultInfo
+}
+
 // FirewallRules returns all firewall rules.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/get/#get-all-rules
-func (api *API) FirewallRules(ctx context.Context, zoneID string, pageOpts PaginationOptions) ([]FirewallRule, error) {
-	uri := buildURI(fmt.Sprintf("/zones/%s/firewall/rules", zoneID), pageOpts)
+func (api *API) FirewallRules(ctx context.Context, rc *ResourceContainer, params FirewallRuleListParams) ([]FirewallRule, *ResultInfo, error) {
+	uri := buildURI(fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier), params)
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
-		return []FirewallRule{}, err
+		return []FirewallRule{}, &ResultInfo{}, err
 	}
 
 	var firewallDetailResponse FirewallRulesDetailResponse
 	err = json.Unmarshal(res, &firewallDetailResponse)
 	if err != nil {
-		return []FirewallRule{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return []FirewallRule{}, &ResultInfo{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return firewallDetailResponse.Result, nil
+	if params.PerPage < 1 && params.Page < 1 {
+		var firewallRules []FirewallRule
+		params.PerPage = 50
+		params.Page = 1
+
+		for !params.ResultInfo.Done() {
+			uri := buildURI(fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier), params)
+
+			res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+			if err != nil {
+				return []FirewallRule{}, &ResultInfo{}, err
+			}
+
+			var fResponse FirewallRulesDetailResponse
+			err = json.Unmarshal(res, &fResponse)
+			if err != nil {
+				return []FirewallRule{}, &ResultInfo{}, fmt.Errorf("failed to unmarshal filters JSON data: %w", err)
+			}
+
+			firewallRules = append(firewallRules, fResponse.Result...)
+			params.ResultInfo = fResponse.ResultInfo.Next()
+		}
+		firewallDetailResponse.Result = firewallRules
+	}
+
+	return firewallDetailResponse.Result, &firewallDetailResponse.ResultInfo, nil
 }
 
 // FirewallRule returns a single firewall rule based on the ID.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/get/#get-by-rule-id
-func (api *API) FirewallRule(ctx context.Context, zoneID, firewallRuleID string) (FirewallRule, error) {
-	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", zoneID, firewallRuleID)
+func (api *API) FirewallRule(ctx context.Context, rc *ResourceContainer, firewallRuleID string) (FirewallRule, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", rc.Identifier, firewallRuleID)
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
@@ -81,8 +110,8 @@ func (api *API) FirewallRule(ctx context.Context, zoneID, firewallRuleID string)
 // CreateFirewallRules creates new firewall rules.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/post/
-func (api *API) CreateFirewallRules(ctx context.Context, zoneID string, firewallRules []FirewallRule) ([]FirewallRule, error) {
-	uri := fmt.Sprintf("/zones/%s/firewall/rules", zoneID)
+func (api *API) CreateFirewallRules(ctx context.Context, rc *ResourceContainer, firewallRules []FirewallRule) ([]FirewallRule, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier)
 
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, firewallRules)
 	if err != nil {
@@ -101,12 +130,12 @@ func (api *API) CreateFirewallRules(ctx context.Context, zoneID string, firewall
 // UpdateFirewallRule updates a single firewall rule.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/put/#update-a-single-rule
-func (api *API) UpdateFirewallRule(ctx context.Context, zoneID string, firewallRule FirewallRule) (FirewallRule, error) {
+func (api *API) UpdateFirewallRule(ctx context.Context, rc *ResourceContainer, firewallRule FirewallRule) (FirewallRule, error) {
 	if firewallRule.ID == "" {
 		return FirewallRule{}, fmt.Errorf("firewall rule ID cannot be empty")
 	}
 
-	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", zoneID, firewallRule.ID)
+	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", rc.Identifier, firewallRule.ID)
 
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, firewallRule)
 	if err != nil {
@@ -125,14 +154,14 @@ func (api *API) UpdateFirewallRule(ctx context.Context, zoneID string, firewallR
 // UpdateFirewallRules updates a single firewall rule.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/put/#update-multiple-rules
-func (api *API) UpdateFirewallRules(ctx context.Context, zoneID string, firewallRules []FirewallRule) ([]FirewallRule, error) {
+func (api *API) UpdateFirewallRules(ctx context.Context, rc *ResourceContainer, firewallRules []FirewallRule) ([]FirewallRule, error) {
 	for _, firewallRule := range firewallRules {
 		if firewallRule.ID == "" {
 			return []FirewallRule{}, fmt.Errorf("firewall ID cannot be empty")
 		}
 	}
 
-	uri := fmt.Sprintf("/zones/%s/firewall/rules", zoneID)
+	uri := fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier)
 
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, firewallRules)
 	if err != nil {
@@ -151,12 +180,12 @@ func (api *API) UpdateFirewallRules(ctx context.Context, zoneID string, firewall
 // DeleteFirewallRule deletes a single firewall rule.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/delete/#delete-a-single-rule
-func (api *API) DeleteFirewallRule(ctx context.Context, zoneID, firewallRuleID string) error {
+func (api *API) DeleteFirewallRule(ctx context.Context, rc *ResourceContainer, firewallRuleID string) error {
 	if firewallRuleID == "" {
 		return fmt.Errorf("firewall rule ID cannot be empty")
 	}
 
-	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", zoneID, firewallRuleID)
+	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", rc.Identifier, firewallRuleID)
 
 	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {
@@ -169,14 +198,14 @@ func (api *API) DeleteFirewallRule(ctx context.Context, zoneID, firewallRuleID s
 // DeleteFirewallRules deletes multiple firewall rules at once.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/delete/#delete-multiple-rules
-func (api *API) DeleteFirewallRules(ctx context.Context, zoneID string, firewallRuleIDs []string) error {
+func (api *API) DeleteFirewallRules(ctx context.Context, rc *ResourceContainer, firewallRuleIDs []string) error {
 	v := url.Values{}
 
 	for _, ruleID := range firewallRuleIDs {
 		v.Add("id", ruleID)
 	}
 
-	uri := fmt.Sprintf("/zones/%s/firewall/rules?%s", zoneID, v.Encode())
+	uri := fmt.Sprintf("/zones/%s/firewall/rules?%s", rc.Identifier, v.Encode())
 
 	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -173,7 +173,7 @@ func TestFirewallRules(t *testing.T) {
 		},
 	}
 
-	actual, err := client.FirewallRules(context.Background(), "d56084adb405e0b7e32c52321bf07be6", firewallRulePageOpts)
+	actual, _, err := client.FirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), FirewallRuleListParams{})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -223,7 +223,7 @@ func TestFirewallRule(t *testing.T) {
 		},
 	}
 
-	actual, err := client.FirewallRule(context.Background(), "d56084adb405e0b7e32c52321bf07be6", "f2d427378e7542acb295380d352e2ebd")
+	actual, err := client.FirewallRule(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), "f2d427378e7542acb295380d352e2ebd")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -277,7 +277,7 @@ func TestCreateSingleFirewallRule(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFirewallRules(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.CreateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -357,7 +357,7 @@ func TestCreateMultipleFirewallRules(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFirewallRules(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.CreateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -382,7 +382,7 @@ func TestUpdateFirewallRuleWithMissingID(t *testing.T) {
 		},
 	}
 
-	_, err := client.UpdateFirewallRule(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	_, err := client.UpdateFirewallRule(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 	assert.EqualError(t, err, "firewall rule ID cannot be empty")
 }
 
@@ -429,7 +429,7 @@ func TestUpdateSingleFirewallRule(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateFirewallRule(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.UpdateFirewallRule(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -509,7 +509,7 @@ func TestUpdateMultipleFirewallRules(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateFirewallRules(context.Background(), "d56084adb405e0b7e32c52321bf07be6", want)
+	actual, err := client.UpdateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -534,7 +534,7 @@ func TestDeleteSingleFirewallRule(t *testing.T) {
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/f2d427378e7542acb295380d352e2ebd", handler)
 
-	err := client.DeleteFirewallRule(context.Background(), "d56084adb405e0b7e32c52321bf07be6", "f2d427378e7542acb295380d352e2ebd")
+	err := client.DeleteFirewallRule(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), "f2d427378e7542acb295380d352e2ebd")
 	assert.NoError(t, err)
 }
 
@@ -542,6 +542,6 @@ func TestDeleteFirewallRuleWithMissingID(t *testing.T) {
 	setup()
 	defer teardown()
 
-	err := client.DeleteFirewallRule(context.Background(), "d56084adb405e0b7e32c52321bf07be6", "")
+	err := client.DeleteFirewallRule(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), "")
 	assert.EqualError(t, err, "firewall rule ID cannot be empty")
 }


### PR DESCRIPTION
Updates the filter and firewall rule methods to automatically paginate
all results unless `PerPage` and `Page` are provided.

