### PR TITLE
filter/firewall-rules fix for double API calls

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -126,6 +126,99 @@ func TestFilters(t *testing.T) {
 		},
 	}
 
+	var filterListParams = FilterListParams{
+		PerPage: 25,
+		Page:    1,
+	}
+
+	actual, _, err := client.Filters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), filterListParams)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestPaginatedFilters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": [
+					{
+						"id": "b7ff25282d394be7b945e23c7106ce8a",
+						"paused": false,
+						"description": "Login from office",
+						"expression": "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
+					},
+					{
+						"id": "c218c536b2bd406f958f278cf0fa8c0f",
+						"paused": false,
+						"description": "Login",
+						"expression": "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")"
+					},
+					{
+						"id": "f2a64520581a4209aab12187a0081364",
+						"paused": false,
+						"description": "not /api",
+						"expression": "not http.request.uri.path matches \"^/api/.*$\""
+			}, {
+						"id": "14217d7bd5ab435e84b1bd468bf4fb9f",
+						"paused": false,
+						"description": "/api",
+						"expression": "http.request.uri.path matches \"^/api/.*$\""
+			}, {
+						"id": "60ee852f9cbb4802978d15600c7f3110",
+						"paused": false,
+						"expression": "ip.src eq 93.184.216.0"
+			} ],
+				"success": true,
+				"errors": null,
+				"messages": null,
+				"result_info": {
+					"page": 1,
+					"per_page": 25,
+					"count": 5,
+					"total_count": 5,
+					"total_pages": 1
+			} }
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	want := []Filter{
+		{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from office",
+			Expression:  "ip.src eq 93.184.216.0 and (http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+		},
+		{
+			ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+			Paused:      false,
+			Description: "Login",
+			Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\" or http.request.uri.path ~ \"^.*/xmlrpc.php$\")",
+		},
+		{
+			ID:          "f2a64520581a4209aab12187a0081364",
+			Paused:      false,
+			Description: "not /api",
+			Expression:  "not http.request.uri.path matches \"^/api/.*$\"",
+		},
+		{
+			ID:          "14217d7bd5ab435e84b1bd468bf4fb9f",
+			Paused:      false,
+			Description: "/api",
+			Expression:  "http.request.uri.path matches \"^/api/.*$\"",
+		}, {
+			ID:         "60ee852f9cbb4802978d15600c7f3110",
+			Paused:     false,
+			Expression: "ip.src eq 93.184.216.0",
+		},
+	}
+
 	actual, _, err := client.Filters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), FilterListParams{})
 
 	if assert.NoError(t, err) {

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -9,12 +9,178 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var firewallRulePageOpts = PaginationOptions{
-	PerPage: 25,
-	Page:    1,
+func TestFirewallRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result":[
+				{
+					"id":"2ae338944d6143383c3cf05a7c80d984",
+					"paused":false,
+					"description":"allow uploads without waf",
+					"action":"bypass",
+					"products": ["waf"],
+					"priority":null,
+					"filter":{
+						"id":"74217d7bd5ab435e84b1bd473bf4fb9f",
+						"expression":"http.request.uri.path matches \"^/upload$\"",
+						"paused":false,
+						"description":"/upload"
+					}
+				},
+				{
+					"id":"4ae338944d6143378c3cf05a7c77d983",
+					"paused":false,
+					"description":"allow API traffic without challenge",
+					"action":"allow",
+					"priority":null,
+					"filter":{
+						"id":"14217d7bd5ab435e84b1bd468bf4fb9f",
+						"expression":"http.request.uri.path matches \"^/api/.*$\"",
+						"paused":false,
+						"description":"/api"
+					}
+				},
+				{
+					"id":"f2d427378e7542acb295380d352e2ebd",
+					"paused":false,
+					"description":"do not challenge login from office",
+					"action":"allow",
+					"priority":null,
+					"filter":{
+						"id":"b7ff25282d394be7b945e23c7106ce8a",
+						"expression":"(http.request.uri.path ~ \"^.*/xmlrpc.php$\"",
+						"paused":false,
+						"description":"wordpress xmlrpc"
+					}
+				},
+				{
+					"id":"cbf4b7a5a2a24e59a03044d6d44ceb09",
+					"paused":false,
+					"description":"challenge login",
+					"action":"challenge",
+					"priority":null,
+					"filter":{
+						"id":"c218c536b2bd406f958f278cf0fa8c0f",
+						"expression":"(http.request.uri.path ~ \"^.*/wp-login.php$\"",
+						"paused":false,
+						"description":"Login"
+					}
+				},
+				{
+					"id":"52161eb6af4241bb9d4b32394be72fdf",
+					"paused":false,
+					"description":"JS challenge site",
+					"action":"js_challenge",
+					"priority":null,
+					"filter":{
+						"id":"f2a64520581a4209aab12187a0081364",
+						"expression":"not http.request.uri.path matches \"^/api/.*$\"",
+						"paused":false,
+						"description":"not /api"
+					}
+				}
+			],
+			"success":true,
+			"errors":null,
+			"messages":null,
+			"result_info":{
+				"page":1,
+				"per_page":25,
+				"count":5,
+				"total_count":5
+			}
+		}
+		`)
+	}
+
+	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	want := []FirewallRule{
+		{
+			ID:          "2ae338944d6143383c3cf05a7c80d984",
+			Paused:      false,
+			Description: "allow uploads without waf",
+			Action:      "bypass",
+			Priority:    nil,
+			Products:    []string{"waf"},
+			Filter: Filter{
+				ID:          "74217d7bd5ab435e84b1bd473bf4fb9f",
+				Expression:  "http.request.uri.path matches \"^/upload$\"",
+				Paused:      false,
+				Description: "/upload",
+			},
+		},
+		{
+			ID:          "4ae338944d6143378c3cf05a7c77d983",
+			Paused:      false,
+			Description: "allow API traffic without challenge",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "14217d7bd5ab435e84b1bd468bf4fb9f",
+				Expression:  "http.request.uri.path matches \"^/api/.*$\"",
+				Paused:      false,
+				Description: "/api",
+			},
+		},
+		{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "(http.request.uri.path ~ \"^.*/xmlrpc.php$\"",
+				Paused:      false,
+				Description: "wordpress xmlrpc",
+			},
+		},
+		{
+			ID:          "cbf4b7a5a2a24e59a03044d6d44ceb09",
+			Paused:      false,
+			Description: "challenge login",
+			Action:      "challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+				Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\"",
+				Paused:      false,
+				Description: "Login",
+			},
+		},
+		{
+			ID:          "52161eb6af4241bb9d4b32394be72fdf",
+			Paused:      false,
+			Description: "JS challenge site",
+			Action:      "js_challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "f2a64520581a4209aab12187a0081364",
+				Expression:  "not http.request.uri.path matches \"^/api/.*$\"",
+				Paused:      false,
+				Description: "not /api",
+			},
+		},
+	}
+
+	var firewallRuleListParams = FirewallRuleListParams{
+		PerPage: 25,
+		Page:    1,
+	}
+
+	actual, _, err := client.FirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), firewallRuleListParams)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
 }
 
-func TestFirewallRules(t *testing.T) {
+func TestPaginatedFirewallRules(t *testing.T) {
 	setup()
 	defer teardown()
 


### PR DESCRIPTION
## Description

Recent pagination updates to these APIs are causing endpoints to be called twice. This PR aims to fix them.

## Has your change been tested?

Unit tests are passing, and I tried this version in cf-terraforming, where it's working as expected

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
