### PR TITLE
filter/firewall-rules fix for double API calls

### DIFF
--- a/.changelog/1016.txt
+++ b/.changelog/1016.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+firewall_rule: fix double endpoint calls & moving towards common method signature
+```
+
+```release-note:bug
+filter: fix double endpoint calls & moving towards common method signature
+```

--- a/.changelog/1016.txt
+++ b/.changelog/1016.txt
@@ -1,7 +1,7 @@
-```release-note:bug
+```release-note:enhancement
 firewall_rule: fix double endpoint calls & moving towards common method signature
 ```
 
-```release-note:bug
+```release-note:enhancement
 filter: fix double endpoint calls & moving towards common method signature
 ```

--- a/filter_test.go
+++ b/filter_test.go
@@ -157,6 +157,15 @@ func TestCreateSingleFilter(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	params := []FilterCreateParams{
+		{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from office",
+			Expression:  "ip.src eq 127.0.0.1",
+		},
+	}
+
 	want := []Filter{
 		{
 			ID:          "b7ff25282d394be7b945e23c7106ce8a",
@@ -166,7 +175,7 @@ func TestCreateSingleFilter(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.CreateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -203,6 +212,21 @@ func TestCreateMultipleFilters(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	params := []FilterCreateParams{
+		{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from office",
+			Expression:  "ip.src eq 127.0.0.1",
+		},
+		{
+			ID:          "b7ff25282d394be7b945e23c7106ce8a",
+			Paused:      false,
+			Description: "Login from second office",
+			Expression:  "ip.src eq 10.0.0.1",
+		},
+	}
+
 	want := []Filter{
 		{
 			ID:          "b7ff25282d394be7b945e23c7106ce8a",
@@ -218,7 +242,7 @@ func TestCreateMultipleFilters(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.CreateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -247,6 +271,13 @@ func TestUpdateSingleFilter(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters/60ee852f9cbb4802978d15600c7f3110", handler)
+	params := FilterUpdateParams{
+		ID:          "60ee852f9cbb4802978d15600c7f3110",
+		Paused:      false,
+		Description: "IP of example.org",
+		Expression:  "ip.src eq 93.184.216.0",
+	}
+
 	want := Filter{
 		ID:          "60ee852f9cbb4802978d15600c7f3110",
 		Paused:      false,
@@ -254,7 +285,7 @@ func TestUpdateSingleFilter(t *testing.T) {
 		Expression:  "ip.src eq 93.184.216.0",
 	}
 
-	actual, err := client.UpdateFilter(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.UpdateFilter(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -291,6 +322,21 @@ func TestUpdateMultipleFilters(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/filters", handler)
+	params := []FilterUpdateParams{
+		{
+			ID:          "60ee852f9cbb4802978d15600c7f3110",
+			Paused:      false,
+			Description: "IP of example.org",
+			Expression:  "ip.src eq 93.184.216.0",
+		},
+		{
+			ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+			Paused:      false,
+			Description: "IP of example.com",
+			Expression:  "ip.src ne 127.0.0.1",
+		},
+	}
+
 	want := []Filter{
 		{
 			ID:          "60ee852f9cbb4802978d15600c7f3110",
@@ -306,7 +352,7 @@ func TestUpdateMultipleFilters(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.UpdateFilters(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -18,6 +18,7 @@ type FirewallRule struct {
 	Priority    interface{} `json:"priority"`
 	Filter      Filter      `json:"filter"`
 	Products    []string    `json:"products,omitempty"`
+	Ref         string      `json:"ref,omitempty"`
 	CreatedOn   time.Time   `json:"created_on,omitempty"`
 	ModifiedOn  time.Time   `json:"modified_on,omitempty"`
 }
@@ -38,53 +39,78 @@ type FirewallRuleResponse struct {
 	Response
 }
 
+// FirewallRuleCreateParams contains required and optional params
+// for creating a firewall rule.
+type FirewallRuleCreateParams struct {
+	ID          string      `json:"id,omitempty"`
+	Paused      bool        `json:"paused"`
+	Description string      `json:"description"`
+	Action      string      `json:"action"`
+	Priority    interface{} `json:"priority"`
+	Filter      Filter      `json:"filter"`
+	Products    []string    `json:"products,omitempty"`
+	Ref         string      `json:"ref,omitempty"`
+}
+
+// FirewallRuleUpdateParams contains required and optional params
+// for updating a firewall rule.
+type FirewallRuleUpdateParams struct {
+	ID          string      `json:"id"`
+	Paused      bool        `json:"paused"`
+	Description string      `json:"description"`
+	Action      string      `json:"action"`
+	Priority    interface{} `json:"priority"`
+	Filter      Filter      `json:"filter"`
+	Products    []string    `json:"products,omitempty"`
+	Ref         string      `json:"ref,omitempty"`
+}
+
 type FirewallRuleListParams struct {
 	ResultInfo
 }
 
 // FirewallRules returns all firewall rules.
 //
+// Automatically paginates all results unless `params.PerPage` and `params.Page`
+// is set.
+//
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/get/#get-all-rules
 func (api *API) FirewallRules(ctx context.Context, rc *ResourceContainer, params FirewallRuleListParams) ([]FirewallRule, *ResultInfo, error) {
-	uri := buildURI(fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier), params)
-
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return []FirewallRule{}, &ResultInfo{}, err
+	autoPaginate := true
+	if params.PerPage >= 1 || params.Page >= 1 {
+		autoPaginate = false
 	}
-
-	var firewallDetailResponse FirewallRulesDetailResponse
-	err = json.Unmarshal(res, &firewallDetailResponse)
-	if err != nil {
-		return []FirewallRule{}, &ResultInfo{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
-	}
-
-	if params.PerPage < 1 && params.Page < 1 {
-		var firewallRules []FirewallRule
+	if params.PerPage < 1 {
 		params.PerPage = 50
+	}
+	if params.Page < 1 {
 		params.Page = 1
-
-		for !params.ResultInfo.Done() {
-			uri := buildURI(fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier), params)
-
-			res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-			if err != nil {
-				return []FirewallRule{}, &ResultInfo{}, err
-			}
-
-			var fResponse FirewallRulesDetailResponse
-			err = json.Unmarshal(res, &fResponse)
-			if err != nil {
-				return []FirewallRule{}, &ResultInfo{}, fmt.Errorf("failed to unmarshal filters JSON data: %w", err)
-			}
-
-			firewallRules = append(firewallRules, fResponse.Result...)
-			params.ResultInfo = fResponse.ResultInfo.Next()
-		}
-		firewallDetailResponse.Result = firewallRules
 	}
 
-	return firewallDetailResponse.Result, &firewallDetailResponse.ResultInfo, nil
+	var firewallRules []FirewallRule
+	var fResponse FirewallRulesDetailResponse
+	for {
+		uri := buildURI(fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier), params)
+
+		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+		if err != nil {
+			return []FirewallRule{}, &ResultInfo{}, err
+		}
+
+		err = json.Unmarshal(res, &fResponse)
+		if err != nil {
+			return []FirewallRule{}, &ResultInfo{}, fmt.Errorf("failed to unmarshal filters JSON data: %w", err)
+		}
+
+		firewallRules = append(firewallRules, fResponse.Result...)
+		params.ResultInfo = fResponse.ResultInfo.Next()
+
+		if params.ResultInfo.Done() || !autoPaginate {
+			break
+		}
+	}
+
+	return firewallRules, &fResponse.ResultInfo, nil
 }
 
 // FirewallRule returns a single firewall rule based on the ID.
@@ -110,10 +136,10 @@ func (api *API) FirewallRule(ctx context.Context, rc *ResourceContainer, firewal
 // CreateFirewallRules creates new firewall rules.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/post/
-func (api *API) CreateFirewallRules(ctx context.Context, rc *ResourceContainer, firewallRules []FirewallRule) ([]FirewallRule, error) {
+func (api *API) CreateFirewallRules(ctx context.Context, rc *ResourceContainer, params []FirewallRuleCreateParams) ([]FirewallRule, error) {
 	uri := fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier)
 
-	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, firewallRules)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
 	if err != nil {
 		return []FirewallRule{}, err
 	}
@@ -130,14 +156,14 @@ func (api *API) CreateFirewallRules(ctx context.Context, rc *ResourceContainer, 
 // UpdateFirewallRule updates a single firewall rule.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/put/#update-a-single-rule
-func (api *API) UpdateFirewallRule(ctx context.Context, rc *ResourceContainer, firewallRule FirewallRule) (FirewallRule, error) {
-	if firewallRule.ID == "" {
+func (api *API) UpdateFirewallRule(ctx context.Context, rc *ResourceContainer, params FirewallRuleUpdateParams) (FirewallRule, error) {
+	if params.ID == "" {
 		return FirewallRule{}, fmt.Errorf("firewall rule ID cannot be empty")
 	}
 
-	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", rc.Identifier, firewallRule.ID)
+	uri := fmt.Sprintf("/zones/%s/firewall/rules/%s", rc.Identifier, params.ID)
 
-	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, firewallRule)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
 		return FirewallRule{}, err
 	}
@@ -154,8 +180,8 @@ func (api *API) UpdateFirewallRule(ctx context.Context, rc *ResourceContainer, f
 // UpdateFirewallRules updates a single firewall rule.
 //
 // API reference: https://developers.cloudflare.com/firewall/api/cf-firewall-rules/put/#update-multiple-rules
-func (api *API) UpdateFirewallRules(ctx context.Context, rc *ResourceContainer, firewallRules []FirewallRule) ([]FirewallRule, error) {
-	for _, firewallRule := range firewallRules {
+func (api *API) UpdateFirewallRules(ctx context.Context, rc *ResourceContainer, params []FirewallRuleUpdateParams) ([]FirewallRule, error) {
+	for _, firewallRule := range params {
 		if firewallRule.ID == "" {
 			return []FirewallRule{}, fmt.Errorf("firewall ID cannot be empty")
 		}
@@ -163,7 +189,7 @@ func (api *API) UpdateFirewallRules(ctx context.Context, rc *ResourceContainer, 
 
 	uri := fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier)
 
-	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, firewallRules)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
 		return []FirewallRule{}, err
 	}

--- a/firewall_rules_test.go
+++ b/firewall_rules_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var firewallRulePageOpts = PaginationOptions{
-	PerPage: 25,
-	Page:    1,
-}
-
 func TestFirewallRules(t *testing.T) {
 	setup()
 	defer teardown()
@@ -261,6 +256,22 @@ func TestCreateSingleFirewallRule(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	params := []FirewallRuleCreateParams{
+		{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "ip.src in {127.0.0.0/24}",
+				Paused:      false,
+				Description: "Login from office",
+			},
+		},
+	}
+
 	want := []FirewallRule{
 		{
 			ID:          "f2d427378e7542acb295380d352e2ebd",
@@ -277,7 +288,7 @@ func TestCreateSingleFirewallRule(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.CreateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -328,6 +339,35 @@ func TestCreateMultipleFirewallRules(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	params := []FirewallRuleCreateParams{
+		{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "ip.src in {127.0.0.0/24}",
+				Paused:      false,
+				Description: "Login from office",
+			},
+		},
+		{
+			ID:          "cbf4b7a5a2a24e59a03044d6d44ceb09",
+			Paused:      false,
+			Description: "challenge login",
+			Action:      "challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+				Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\")",
+				Paused:      false,
+				Description: "Login",
+			},
+		},
+	}
+
 	want := []FirewallRule{
 		{
 			ID:          "f2d427378e7542acb295380d352e2ebd",
@@ -357,7 +397,7 @@ func TestCreateMultipleFirewallRules(t *testing.T) {
 		},
 	}
 
-	actual, err := client.CreateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.CreateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -368,7 +408,7 @@ func TestUpdateFirewallRuleWithMissingID(t *testing.T) {
 	setup()
 	defer teardown()
 
-	want := FirewallRule{
+	want := FirewallRuleUpdateParams{
 		ID:          "",
 		Paused:      false,
 		Description: "challenge site",
@@ -415,6 +455,20 @@ func TestUpdateSingleFirewallRule(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules/52161eb6af4241bb9d4b32394be72fdf", handler)
+	params := FirewallRuleUpdateParams{
+		ID:          "52161eb6af4241bb9d4b32394be72fdf",
+		Paused:      false,
+		Description: "challenge site",
+		Action:      "challenge",
+		Priority:    nil,
+		Filter: Filter{
+			ID:          "f2a64520581a4209aab12187a0081364",
+			Expression:  "not http.request.uri.path matches \"^/api/.*$\"",
+			Paused:      false,
+			Description: "not /api",
+		},
+	}
+
 	want := FirewallRule{
 		ID:          "52161eb6af4241bb9d4b32394be72fdf",
 		Paused:      false,
@@ -429,7 +483,7 @@ func TestUpdateSingleFirewallRule(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateFirewallRule(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.UpdateFirewallRule(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -480,6 +534,35 @@ func TestUpdateMultipleFirewallRules(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/d56084adb405e0b7e32c52321bf07be6/firewall/rules", handler)
+	params := []FirewallRuleUpdateParams{
+		{
+			ID:          "f2d427378e7542acb295380d352e2ebd",
+			Paused:      false,
+			Description: "do not challenge login from office",
+			Action:      "allow",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "b7ff25282d394be7b945e23c7106ce8a",
+				Expression:  "ip.src in {127.0.0.0/24}",
+				Paused:      false,
+				Description: "Login from office",
+			},
+		},
+		{
+			ID:          "cbf4b7a5a2a24e59a03044d6d44ceb09",
+			Paused:      false,
+			Description: "challenge login",
+			Action:      "challenge",
+			Priority:    nil,
+			Filter: Filter{
+				ID:          "c218c536b2bd406f958f278cf0fa8c0f",
+				Expression:  "(http.request.uri.path ~ \"^.*/wp-login.php$\")",
+				Paused:      false,
+				Description: "Login",
+			},
+		},
+	}
+
 	want := []FirewallRule{
 		{
 			ID:          "f2d427378e7542acb295380d352e2ebd",
@@ -509,7 +592,7 @@ func TestUpdateMultipleFirewallRules(t *testing.T) {
 		},
 	}
 
-	actual, err := client.UpdateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), want)
+	actual, err := client.UpdateFirewallRules(context.Background(), ZoneIdentifier("d56084adb405e0b7e32c52321bf07be6"), params)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)


### PR DESCRIPTION
## Description

Recent pagination updates to these APIs are causing endpoints to be called twice. This PR aims to fix them.

## Has your change been tested?

Unit tests are passing, and I tried this version in cf-terraforming, where it's working as expected

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/

Closes #1024