### PR TITLE
zone-lockdown: paginating list response

### DIFF
--- a/.changelog/1017.txt
+++ b/.changelog/1017.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+lockdown: automatically paginate `List` results unless `Page` and `PerPage` are provided
+```

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -133,21 +133,25 @@ func zoneCreateLockdown(c *cli.Context) error {
 			Value:  c.StringSlice("values")[index],
 		})
 	}
-	lockdown := cloudflare.ZoneLockdown{
+	params := cloudflare.ZoneLockdownCreateParams{
 		Description:    c.String("description"),
 		URLs:           c.StringSlice("urls"),
 		Configurations: zonelockdownconfigs,
 	}
 
-	var resp *cloudflare.ZoneLockdownResponse
-
-	resp, err = api.CreateZoneLockdown(context.Background(), zoneID, lockdown)
+	resp, err := api.CreateZoneLockdown(context.Background(), cloudflare.ZoneIdentifier(zoneID), params)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error creating ZONE lock down: ", err)
 		return err
 	}
+
 	output := make([][]string, 0, 1)
-	output = append(output, formatLockdownResponse(resp))
+
+	format := []string{
+		resp.ID,
+	}
+
+	output = append(output, format)
 
 	writeTable(c, output, "ID")
 
@@ -330,12 +334,6 @@ func zoneRecords(c *cli.Context) error {
 }
 
 func formatCacheResponse(resp cloudflare.PurgeCacheResponse) []string {
-	return []string{
-		resp.Result.ID,
-	}
-}
-
-func formatLockdownResponse(resp *cloudflare.ZoneLockdownResponse) []string {
 	return []string{
 		resp.Result.ID,
 	}

--- a/lockdown.go
+++ b/lockdown.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
-	"strconv"
 	"time"
 )
 
@@ -46,109 +44,145 @@ type ZoneLockdownListResponse struct {
 	ResultInfo `json:"result_info"`
 }
 
+// ZoneLockdownCreateParams contains required and optional params
+// for creating a zone lockdown.
+type ZoneLockdownCreateParams struct {
+	Description    string               `json:"description"`
+	URLs           []string             `json:"urls"`
+	Configurations []ZoneLockdownConfig `json:"configurations"`
+	Paused         bool                 `json:"paused"`
+}
+
+// ZoneLockdownUpdateParams contains required and optional params
+// for updating a zone lockdown.
+type ZoneLockdownUpdateParams struct {
+	ID             string               `json:"id"`
+	Description    string               `json:"description"`
+	URLs           []string             `json:"urls"`
+	Configurations []ZoneLockdownConfig `json:"configurations"`
+	Paused         bool                 `json:"paused"`
+}
+
+type LockdownListParams struct {
+	ResultInfo
+}
+
 // CreateZoneLockdown creates a Zone ZoneLockdown rule for the given zone ID.
 //
 // API reference: https://api.cloudflare.com/#zone-ZoneLockdown-create-a-ZoneLockdown-rule
-func (api *API) CreateZoneLockdown(ctx context.Context, zoneID string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
-	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns", zoneID)
-	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, ld)
+func (api *API) CreateZoneLockdown(ctx context.Context, rc *ResourceContainer, params ZoneLockdownCreateParams) (ZoneLockdown, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns", rc.Identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
 	if err != nil {
-		return nil, err
+		return ZoneLockdown{}, err
 	}
 
 	response := &ZoneLockdownResponse{}
 	err = json.Unmarshal(res, &response)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return ZoneLockdown{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return response, nil
+	return response.Result, nil
 }
 
-// UpdateZoneLockdown updates a Zone ZoneLockdown rule (based on the ID) for the
-// given zone ID.
+// UpdateZoneLockdown updates a Zone ZoneLockdown rule (based on the ID) for the given zone ID.
 //
 // API reference: https://api.cloudflare.com/#zone-ZoneLockdown-update-ZoneLockdown-rule
-func (api *API) UpdateZoneLockdown(ctx context.Context, zoneID string, id string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
-	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns/%s", zoneID, id)
-	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, ld)
+func (api *API) UpdateZoneLockdown(ctx context.Context, rc *ResourceContainer, params ZoneLockdownUpdateParams) (ZoneLockdown, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns/%s", rc.Identifier, params.ID)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
-		return nil, err
+		return ZoneLockdown{}, err
 	}
 
 	response := &ZoneLockdownResponse{}
 	err = json.Unmarshal(res, &response)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return ZoneLockdown{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return response, nil
+	return response.Result, nil
 }
 
-// DeleteZoneLockdown deletes a Zone ZoneLockdown rule (based on the ID) for the
-// given zone ID.
+// DeleteZoneLockdown deletes a Zone ZoneLockdown rule (based on the ID) for the given zone ID.
 //
 // API reference: https://api.cloudflare.com/#zone-ZoneLockdown-delete-ZoneLockdown-rule
-func (api *API) DeleteZoneLockdown(ctx context.Context, zoneID string, id string) (*ZoneLockdownResponse, error) {
-	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns/%s", zoneID, id)
+func (api *API) DeleteZoneLockdown(ctx context.Context, rc *ResourceContainer, id string) (ZoneLockdown, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns/%s", rc.Identifier, id)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {
-		return nil, err
+		return ZoneLockdown{}, err
 	}
 
 	response := &ZoneLockdownResponse{}
 	err = json.Unmarshal(res, &response)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return ZoneLockdown{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return response, nil
+	return response.Result, nil
 }
 
-// ZoneLockdown retrieves a Zone ZoneLockdown rule (based on the ID) for the
-// given zone ID.
+// ZoneLockdown retrieves a Zone ZoneLockdown rule (based on the ID) for the given zone ID.
 //
 // API reference: https://api.cloudflare.com/#zone-ZoneLockdown-ZoneLockdown-rule-details
-func (api *API) ZoneLockdown(ctx context.Context, zoneID string, id string) (*ZoneLockdownResponse, error) {
-	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns/%s", zoneID, id)
+func (api *API) ZoneLockdown(ctx context.Context, rc *ResourceContainer, id string) (ZoneLockdown, error) {
+	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns/%s", rc.Identifier, id)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
-		return nil, err
+		return ZoneLockdown{}, err
 	}
 
 	response := &ZoneLockdownResponse{}
 	err = json.Unmarshal(res, &response)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return ZoneLockdown{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return response, nil
+	return response.Result, nil
 }
 
-// ListZoneLockdowns retrieves a list of Zone ZoneLockdown rules for a given
-// zone ID by page number.
+// ListZoneLockdowns retrieves every Zone ZoneLockdown rules for a given zone ID.
+//
+// Automatically paginates all results unless `params.PerPage` and `params.Page`
+// is set.
 //
 // API reference: https://api.cloudflare.com/#zone-ZoneLockdown-list-ZoneLockdown-rules
-func (api *API) ListZoneLockdowns(ctx context.Context, zoneID string, page int) (*ZoneLockdownListResponse, error) {
-	v := url.Values{}
-	if page <= 0 {
-		page = 1
+func (api *API) ListZoneLockdowns(ctx context.Context, rc *ResourceContainer, params LockdownListParams) ([]ZoneLockdown, *ResultInfo, error) {
+	autoPaginate := true
+	if params.PerPage >= 1 || params.Page >= 1 {
+		autoPaginate = false
+	}
+	if params.PerPage < 1 {
+		params.PerPage = 50
+	}
+	if params.Page < 1 {
+		params.Page = 1
 	}
 
-	v.Set("page", strconv.Itoa(page))
-	v.Set("per_page", strconv.Itoa(100))
+	var zoneLockdowns []ZoneLockdown
+	var zResponse ZoneLockdownListResponse
+	for {
+		uri := buildURI(fmt.Sprintf("/zones/%s/firewall/lockdowns", rc.Identifier), params)
 
-	uri := fmt.Sprintf("/zones/%s/firewall/lockdowns?%s", zoneID, v.Encode())
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
-	if err != nil {
-		return nil, err
+		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+		if err != nil {
+			return []ZoneLockdown{}, &ResultInfo{}, err
+		}
+
+		err = json.Unmarshal(res, &zResponse)
+		if err != nil {
+			return []ZoneLockdown{}, &ResultInfo{}, fmt.Errorf("failed to unmarshal filters JSON data: %w", err)
+		}
+
+		zoneLockdowns = append(zoneLockdowns, zResponse.Result...)
+		params.ResultInfo = zResponse.ResultInfo.Next()
+
+		if params.ResultInfo.Done() || !autoPaginate {
+			break
+		}
 	}
 
-	response := &ZoneLockdownListResponse{}
-	err = json.Unmarshal(res, &response)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
-	}
-
-	return response, nil
+	return zoneLockdowns, &zResponse.ResultInfo, nil
 }

--- a/lockdown_example_test.go
+++ b/lockdown_example_test.go
@@ -21,12 +21,12 @@ func ExampleAPI_ListZoneLockdowns_all() {
 	}
 
 	// Fetch all Zone Lockdown rules for a zone, by page.
-	rules, err := api.ListZoneLockdowns(context.Background(), zoneID, 1)
+	rules, _, err := api.ListZoneLockdowns(context.Background(), cloudflare.ZoneIdentifier(zoneID), cloudflare.LockdownListParams{})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, r := range rules.Result {
+	for _, r := range rules {
 		fmt.Printf("%s: %s\n", strings.Join(r.URLs, ", "), r.Configurations)
 	}
 }
@@ -42,7 +42,7 @@ func ExampleAPI_CreateZoneLockdown() {
 		log.Fatal(err)
 	}
 
-	newZoneLockdown := cloudflare.ZoneLockdown{
+	newZoneLockdown := cloudflare.ZoneLockdownCreateParams{
 		Description: "Test Zone Lockdown Rule",
 		URLs: []string{
 			"*.example.org/test",
@@ -53,11 +53,10 @@ func ExampleAPI_CreateZoneLockdown() {
 				Value:  "127.0.0.1",
 			},
 		},
-		Paused:   false,
-		Priority: 1,
+		Paused: false,
 	}
 
-	response, err := api.CreateZoneLockdown(context.Background(), zoneID, newZoneLockdown)
+	response, err := api.CreateZoneLockdown(context.Background(), cloudflare.ZoneIdentifier(zoneID), newZoneLockdown)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

I'm adding pagination for `ListZoneLockdowns` API. Additionally, I'm bringing Lockdown APIs to a common pattern. Instead of returning `ZoneLockdownResponse` they will return `ZoneLockdown` so they are easier to use.

## Has your change been tested?

Unit tests are working

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
