### PR TITLE
Add support for count statistics listing DNS records or zones

### DIFF
--- a/.changelog/1018.txt
+++ b/.changelog/1018.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+flarectl: add support for querying count statistics on zones and DNS records
+```

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -83,6 +83,13 @@ func main() {
 					Aliases: []string{"l"},
 					Action:  zoneList,
 					Usage:   "List all zones on an account",
+					Flags: []cli.Flag{
+						&cli.IntFlag{
+							Name:  "with-days-stats",
+							Usage: "add a total count stats for the last specified number of days",
+							Value: 0,
+						},
+					},
 				},
 				{
 					Name:    "create",
@@ -281,6 +288,11 @@ func main() {
 						&cli.StringFlag{
 							Name:  "content",
 							Usage: "record content",
+						},
+						&cli.IntFlag{
+							Name:  "with-days-stats",
+							Usage: "add a total count stats for the last specified number of days",
+							Value: 0,
 						},
 					},
 				},


### PR DESCRIPTION
Adding support for count statistics over httpRequestsAdaptiveGroups while listing zones or DNS records

## Description

This change allows to quickly verify usage of zones or DNS records from `flarectl`.  Behind the scenes, it calls GraphQL API for counting `httpRequestsAdaptiveGroups` and adds an extra column if `--with-days-stats nbDays` argument is specified 

## Has your change been tested?

Change has been tested with token privileged for multi-account and multi-zone setup mixing various Cloudflare plans.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
