### PR TITLE
Removing read-only managed ruleset phases

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -17,27 +17,23 @@ const (
 	RulesetKindSchema  RulesetKind = "schema"
 	RulesetKindZone    RulesetKind = "zone"
 
-	RulesetPhaseDDoSL4                              RulesetPhase = "ddos_l4"
-	RulesetPhaseDDoSL7                              RulesetPhase = "ddos_l7"
-	RulesetPhaseHTTPCustomErrors                    RulesetPhase = "http_custom_errors"
-	RulesetPhaseHTTPLogCustomFields                 RulesetPhase = "http_log_custom_fields"
-	RulesetPhaseHTTPRequestCacheSettings            RulesetPhase = "http_request_cache_settings"
-	RulesetPhaseHTTPRequestFirewallCustom           RulesetPhase = "http_request_firewall_custom"
-	RulesetPhaseHTTPRequestFirewallManaged          RulesetPhase = "http_request_firewall_managed"
-	RulesetPhaseHTTPRequestLateTransform            RulesetPhase = "http_request_late_transform"
-	RulesetPhaseHTTPRequestLateTransformManaged     RulesetPhase = "http_request_late_transform_managed"
-	RulesetPhaseHTTPRequestMain                     RulesetPhase = "http_request_main"
-	RulesetPhaseHTTPRequestOrigin                   RulesetPhase = "http_request_origin"
-	RulesetPhaseHTTPRequestDynamicRedirect          RulesetPhase = "http_request_dynamic_redirect"
-	RulesetPhaseHTTPRequestRedirect                 RulesetPhase = "http_request_redirect"
-	RulesetPhaseHTTPRequestSanitize                 RulesetPhase = "http_request_sanitize"
-	RulesetPhaseHTTPRequestTransform                RulesetPhase = "http_request_transform"
-	RulesetPhaseHTTPResponseFirewallManaged         RulesetPhase = "http_response_firewall_managed"
-	RulesetPhaseHTTPResponseHeadersTransform        RulesetPhase = "http_response_headers_transform"
-	RulesetPhaseHTTPResponseHeadersTransformManaged RulesetPhase = "http_response_headers_transform_managed"
-	RulesetPhaseMagicTransit                        RulesetPhase = "magic_transit"
-	RulesetPhaseRateLimit                           RulesetPhase = "http_ratelimit"
-	RulesetPhaseSuperBotFightMode                   RulesetPhase = "http_request_sbfm"
+	RulesetPhaseDDoSL4                       RulesetPhase = "ddos_l4"
+	RulesetPhaseDDoSL7                       RulesetPhase = "ddos_l7"
+	RulesetPhaseHTTPCustomErrors             RulesetPhase = "http_custom_errors"
+	RulesetPhaseHTTPLogCustomFields          RulesetPhase = "http_log_custom_fields"
+	RulesetPhaseHTTPRequestCacheSettings     RulesetPhase = "http_request_cache_settings"
+	RulesetPhaseHTTPRequestFirewallCustom    RulesetPhase = "http_request_firewall_custom"
+	RulesetPhaseHTTPRequestLateTransform     RulesetPhase = "http_request_late_transform"
+	RulesetPhaseHTTPRequestMain              RulesetPhase = "http_request_main"
+	RulesetPhaseHTTPRequestOrigin            RulesetPhase = "http_request_origin"
+	RulesetPhaseHTTPRequestDynamicRedirect   RulesetPhase = "http_request_dynamic_redirect"
+	RulesetPhaseHTTPRequestRedirect          RulesetPhase = "http_request_redirect"
+	RulesetPhaseHTTPRequestSanitize          RulesetPhase = "http_request_sanitize"
+	RulesetPhaseHTTPRequestTransform         RulesetPhase = "http_request_transform"
+	RulesetPhaseHTTPResponseHeadersTransform RulesetPhase = "http_response_headers_transform"
+	RulesetPhaseMagicTransit                 RulesetPhase = "magic_transit"
+	RulesetPhaseRateLimit                    RulesetPhase = "http_ratelimit"
+	RulesetPhaseSuperBotFightMode            RulesetPhase = "http_request_sbfm"
 
 	RulesetRuleActionBlock                RulesetRuleAction = "block"
 	RulesetRuleActionChallenge            RulesetRuleAction = "challenge"
@@ -90,18 +86,14 @@ func RulesetPhaseValues() []string {
 		string(RulesetPhaseHTTPLogCustomFields),
 		string(RulesetPhaseHTTPRequestCacheSettings),
 		string(RulesetPhaseHTTPRequestFirewallCustom),
-		string(RulesetPhaseHTTPRequestFirewallManaged),
 		string(RulesetPhaseHTTPRequestLateTransform),
-		string(RulesetPhaseHTTPRequestLateTransformManaged),
 		string(RulesetPhaseHTTPRequestMain),
 		string(RulesetPhaseHTTPRequestOrigin),
 		string(RulesetPhaseHTTPRequestDynamicRedirect),
 		string(RulesetPhaseHTTPRequestRedirect),
 		string(RulesetPhaseHTTPRequestSanitize),
 		string(RulesetPhaseHTTPRequestTransform),
-		string(RulesetPhaseHTTPResponseFirewallManaged),
 		string(RulesetPhaseHTTPResponseHeadersTransform),
-		string(RulesetPhaseHTTPResponseHeadersTransformManaged),
 		string(RulesetPhaseMagicTransit),
 		string(RulesetPhaseRateLimit),
 		string(RulesetPhaseSuperBotFightMode),


### PR DESCRIPTION
## Description

Managed ruleset phases are read-only, therefore it does not make sense to keep them here. The Cloudflare terraform provider would fail, if it'd receive such resources to create.

This PR removes the following managed ruleset phases:

- http_response_headers_transform_managed
- http_response_firewall_managed
- http_request_late_transform_managed
- http_request_firewall_managed

## Has your change been tested?

no

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
