### PR TITLE
certificate_packs: deprecate "custom" in favour of ACM

### DIFF
--- a/.changelog/1032.txt
+++ b/.changelog/1032.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+certificate_packs: deprecate "custom" configuration for ACM everywhere
+```

--- a/certificate_packs_test.go
+++ b/certificate_packs_test.go
@@ -15,10 +15,13 @@ var (
 	expiresOn, _  = time.Parse(time.RFC3339, "2016-01-01T05:20:00Z")
 
 	desiredCertificatePack = CertificatePack{
-		ID:                 "3822ff90-ea29-44df-9e55-21300bb9419b",
-		Type:               "custom",
-		Hosts:              []string{"example.com", "*.example.com", "www.example.com"},
-		PrimaryCertificate: "b2cfa4183267af678ea06c7407d4d6d8",
+		ID:                   "3822ff90-ea29-44df-9e55-21300bb9419b",
+		Type:                 "advanced",
+		Hosts:                []string{"example.com", "*.example.com", "www.example.com"},
+		PrimaryCertificate:   "b2cfa4183267af678ea06c7407d4d6d8",
+		ValidationMethod:     "txt",
+		ValidityDays:         90,
+		CertificateAuthority: "lets_encrypt",
 		Certificates: []CertificatePackCertificate{{
 			ID:              "3822ff90-ea29-44df-9e55-21300bb9419b",
 			Hosts:           []string{"example.com"},
@@ -27,12 +30,21 @@ var (
 			Status:          "active",
 			BundleMethod:    "ubiquitous",
 			GeoRestrictions: CertificatePackGeoRestrictions{Label: "us"},
-			ZoneID:          "023e105f4ecef8ad9ca31a8372d0c353",
+			ZoneID:          testZoneID,
 			UploadedOn:      uploadedOn,
 			ModifiedOn:      uploadedOn,
 			ExpiresOn:       expiresOn,
 			Priority:        1,
 		}},
+	}
+
+	pendingCertificatePack = CertificatePack{
+		ID:                   "3822ff90-ea29-44df-9e55-21300bb9419b",
+		Type:                 "advanced",
+		Hosts:                []string{"example.com", "*.example.com", "www.example.com"},
+		ValidationMethod:     "txt",
+		ValidityDays:         90,
+		CertificateAuthority: "lets_encrypt",
 	}
 )
 
@@ -50,12 +62,15 @@ func TestListCertificatePacks(t *testing.T) {
   "result": [
     {
       "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
-      "type": "custom",
+      "type": "advanced",
       "hosts": [
         "example.com",
         "*.example.com",
         "www.example.com"
       ],
+      "validity_days": 90,
+      "validation_method": "txt",
+      "certificate_authority": "lets_encrypt",
       "certificates": [
         {
           "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
@@ -69,7 +84,7 @@ func TestListCertificatePacks(t *testing.T) {
           "geo_restrictions": {
             "label": "us"
           },
-          "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
+          "zone_id": "%[1]s",
           "uploaded_on": "2014-01-01T05:20:00Z",
           "modified_on": "2014-01-01T05:20:00Z",
           "expires_on": "2016-01-01T05:20:00Z",
@@ -80,13 +95,13 @@ func TestListCertificatePacks(t *testing.T) {
     }
   ]
 }
-		`)
+		`, testZoneID)
 	}
 
-	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/certificate_packs", handler)
 
 	want := []CertificatePack{desiredCertificatePack}
-	actual, err := client.ListCertificatePacks(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353")
+	actual, err := client.ListCertificatePacks(context.Background(), testZoneID)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -106,7 +121,10 @@ func TestListCertificatePack(t *testing.T) {
   "messages": [],
   "result": {
     "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
-    "type": "custom",
+    "type": "advanced",
+    "validity_days": 90,
+    "validation_method": "txt",
+    "certificate_authority": "lets_encrypt",
     "hosts": [
       "example.com",
       "*.example.com",
@@ -125,7 +143,7 @@ func TestListCertificatePack(t *testing.T) {
         "geo_restrictions": {
           "label": "us"
         },
-        "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
+        "zone_id": "%[1]s",
         "uploaded_on": "2014-01-01T05:20:00Z",
         "modified_on": "2014-01-01T05:20:00Z",
         "expires_on": "2016-01-01T05:20:00Z",
@@ -135,12 +153,12 @@ func TestListCertificatePack(t *testing.T) {
     "primary_certificate": "b2cfa4183267af678ea06c7407d4d6d8"
   }
 }
-		`)
+		`, testZoneID)
 	}
 
-	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b", handler)
 
-	actual, err := client.CertificatePack(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353", "3822ff90-ea29-44df-9e55-21300bb9419b")
+	actual, err := client.CertificatePack(context.Background(), testZoneID, "3822ff90-ea29-44df-9e55-21300bb9419b")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, desiredCertificatePack, actual)
@@ -155,97 +173,40 @@ func TestCreateCertificatePack(t *testing.T) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
-    "type": "custom",
-    "hosts": [
-      "example.com",
-      "*.example.com",
-      "www.example.com"
-    ],
-    "certificates": [
-      {
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
         "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
+        "type": "advanced",
         "hosts": [
-          "example.com"
+          "example.com",
+          "*.example.com",
+          "www.example.com"
         ],
-        "issuer": "GlobalSign",
-        "signature": "SHA256WithRSA",
-        "status": "active",
-        "bundle_method": "ubiquitous",
-        "geo_restrictions": {
-          "label": "us"
-        },
-        "zone_id": "023e105f4ecef8ad9ca31a8372d0c353",
-        "uploaded_on": "2014-01-01T05:20:00Z",
-        "modified_on": "2014-01-01T05:20:00Z",
-        "expires_on": "2016-01-01T05:20:00Z",
-        "priority": 1
+        "status": "initializing",
+        "validation_method": "txt",
+        "validity_days": 90,
+        "certificate_authority": "lets_encrypt",
+        "cloudflare_branding": false
       }
-    ],
-    "primary_certificate": "b2cfa4183267af678ea06c7407d4d6d8"
-  }
-}
+    }
 		`)
 	}
 
-	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/certificate_packs/order", handler)
 
-	certificate := CertificatePackRequest{Type: "custom", Hosts: []string{"example.com", "*.example.com", "www.example.com"}}
-	actual, err := client.CreateCertificatePack(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353", certificate)
-
-	if assert.NoError(t, err) {
-		assert.Equal(t, desiredCertificatePack, actual)
-	}
-}
-
-func TestCreateAdvancedCertificatePack(t *testing.T) {
-	setup()
-	defer teardown()
-
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
-		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, `{
-  "success": true,
-  "errors": [],
-  "messages": [],
-  "result": {
-    "id": "3822ff90-ea29-44df-9e55-21300bb9419b",
-    "type": "advanced",
-    "hosts": [
-      "example.com",
-      "*.example.com",
-      "www.example.com"
-    ],
-    "status": "initializing",
-    "validation_method": "txt",
-    "validity_days": 365,
-    "certificate_authority": "digicert",
-    "cloudflare_branding": false
-  }
-}`)
-	}
-
-	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs/order", handler)
-
-	certificate := CertificatePackAdvancedCertificate{
-		ID:                   "3822ff90-ea29-44df-9e55-21300bb9419b",
+	certificate := CertificatePackRequest{
 		Type:                 "advanced",
 		Hosts:                []string{"example.com", "*.example.com", "www.example.com"},
-		ValidityDays:         365,
 		ValidationMethod:     "txt",
-		CertificateAuthority: "digicert",
-		CloudflareBranding:   false,
+		ValidityDays:         90,
+		CertificateAuthority: "lets_encrypt",
 	}
-
-	actual, err := client.CreateAdvancedCertificatePack(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353", certificate)
+	actual, err := client.CreateCertificatePack(context.Background(), testZoneID, certificate)
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, certificate, actual)
+		assert.Equal(t, pendingCertificatePack, actual)
 	}
 }
 
@@ -271,25 +232,25 @@ func TestRestartAdvancedCertificateValidation(t *testing.T) {
     "status": "initializing",
     "validation_method": "txt",
     "validity_days": 365,
-    "certificate_authority": "digicert",
+    "certificate_authority": "lets_encrypt",
     "cloudflare_branding": false
   }
 }`)
 	}
 
-	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b", handler)
 
-	certificate := CertificatePackAdvancedCertificate{
+	certificate := CertificatePack{
 		ID:                   "3822ff90-ea29-44df-9e55-21300bb9419b",
 		Type:                 "advanced",
 		Hosts:                []string{"example.com", "*.example.com", "www.example.com"},
 		ValidityDays:         365,
 		ValidationMethod:     "txt",
-		CertificateAuthority: "digicert",
+		CertificateAuthority: "lets_encrypt",
 		CloudflareBranding:   false,
 	}
 
-	actual, err := client.RestartAdvancedCertificateValidation(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353", "3822ff90-ea29-44df-9e55-21300bb9419b")
+	actual, err := client.RestartCertificateValidation(context.Background(), testZoneID, "3822ff90-ea29-44df-9e55-21300bb9419b")
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, certificate, actual)
@@ -314,9 +275,9 @@ func TestDeleteCertificatePack(t *testing.T) {
 		`)
 	}
 
-	mux.HandleFunc("/zones/023e105f4ecef8ad9ca31a8372d0c353/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/ssl/certificate_packs/3822ff90-ea29-44df-9e55-21300bb9419b", handler)
 
-	err := client.DeleteCertificatePack(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353", "3822ff90-ea29-44df-9e55-21300bb9419b")
+	err := client.DeleteCertificatePack(context.Background(), testZoneID, "3822ff90-ea29-44df-9e55-21300bb9419b")
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Triggered by cloudflare/cf-terraforming#443 validation mismatches, I
went ahead and updated `CertificatePacks` to only reference ACM
configuration now that dedicated custom/custom certificates are no more.
