### PR TITLE
Add support for multipart downloads for module-format Worker scripts

### DIFF
--- a/.changelog/1040.txt
+++ b/.changelog/1040.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers: Support for multipart encoding for DownloadWorker on a module-format Worker script
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -176,21 +176,42 @@ func (api *API) makeRequestContextWithHeaders(ctx context.Context, method, uri s
 	return api.makeRequestWithAuthTypeAndHeaders(ctx, method, uri, params, api.authType, headers)
 }
 
-// Deprecated: Use `makeRequestContextWithHeaders` instead.
-//nolint:unused
-func (api *API) makeRequestWithHeaders(method, uri string, params interface{}, headers http.Header) ([]byte, error) {
-	return api.makeRequestWithAuthTypeAndHeaders(context.Background(), method, uri, params, api.authType, headers)
-}
-
 func (api *API) makeRequestWithAuthType(ctx context.Context, method, uri string, params interface{}, authType int) ([]byte, error) {
 	return api.makeRequestWithAuthTypeAndHeaders(ctx, method, uri, params, authType, nil)
 }
 
+// Struct for makeRequestWithAuthTypeAndHeaders's return value.
+// Wrapper methods can return just the Body if that's all the caller needs.
+//
+// Allows callers to see the Content-Type header and HTTP Status codes in case
+// there is additional meaning for particular API calls. This is especially
+// useful if the response is a multipart/form-data because the boundary string
+// is stored as a parameter of the content type header. Caller can parse using mime/multipart.
+type APIResponse struct {
+	Body        []byte
+	ContentType string
+	StatusCode  int
+}
+
 func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, uri string, params interface{}, authType int, headers http.Header) ([]byte, error) {
+	res, err := api.makeRequestWithAuthTypeAndHeadersComplete(ctx, method, uri, params, api.authType, headers)
+	if err != nil {
+		return nil, err
+	}
+	return res.Body, err
+}
+
+// Use this method if an API response can have different Content-Type headers and different body formats.
+func (api *API) makeRequestContextWithHeadersComplete(ctx context.Context, method, uri string, params interface{}, headers http.Header) (*APIResponse, error) {
+	return api.makeRequestWithAuthTypeAndHeadersComplete(ctx, method, uri, params, api.authType, headers)
+}
+
+func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, method, uri string, params interface{}, authType int, headers http.Header) (*APIResponse, error) {
 	var err error
 	var resp *http.Response
 	var respErr error
 	var respBody []byte
+
 	for i := 0; i <= api.retryPolicy.MaxRetries; i++ {
 		var reqBody io.Reader
 		if params != nil {
@@ -277,13 +298,15 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, u
 			}
 			break
 		}
-	}
+	} // for loop
+
+	// still had an error after all retries
 	if respErr != nil {
 		return nil, respErr
 	}
 
 	if api.Debug {
-		fmt.Printf("cloudflare-go [DEBUG] RESPONSE StatusCode:%d Body:%#v RayID:%s\n", resp.StatusCode, string(respBody), resp.Header.Get("cf-ray"))
+		fmt.Printf("cloudflare-go [DEBUG] RESPONSE StatusCode:%d RayID:%s ContentType:%s Body:%#v\n", resp.StatusCode, resp.Header.Get("cf-ray"), resp.Header.Get("content-type"), string(respBody))
 	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
@@ -341,7 +364,11 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, u
 		}
 	}
 
-	return respBody, nil
+	return &APIResponse{
+		Body:        respBody,
+		StatusCode:  resp.StatusCode,
+		ContentType: resp.Header.Get("content-type"),
+	}, nil
 }
 
 // request makes a HTTP request to the given API endpoint, returning the raw

--- a/images.go
+++ b/images.go
@@ -138,12 +138,11 @@ func (api *API) UploadImage(ctx context.Context, accountID string, upload ImageU
 	}
 	_ = w.Close()
 
-	res, err := api.makeRequestWithAuthTypeAndHeaders(
+	res, err := api.makeRequestContextWithHeaders(
 		ctx,
 		http.MethodPost,
 		uri,
 		body,
-		api.authType,
 		http.Header{
 			"Accept":       []string{"application/json"},
 			"Content-Type": []string{w.FormDataContentType()},

--- a/workers.go
+++ b/workers.go
@@ -8,9 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"strings"
 	"time"
 
 	"errors"
@@ -82,6 +85,7 @@ type WorkerListResponse struct {
 // WorkerScriptResponse wrapper struct for API response to worker script calls.
 type WorkerScriptResponse struct {
 	Response
+	Module       bool
 	WorkerScript `json:"result"`
 }
 
@@ -417,6 +421,7 @@ func (api *API) DownloadWorker(ctx context.Context, requestParams *WorkerRequest
 		return r, err
 	}
 	r.Script = string(res)
+	r.Module = false
 	r.Success = true
 	return r, nil
 }
@@ -429,12 +434,32 @@ func (api *API) downloadWorkerWithName(ctx context.Context, scriptName string) (
 		return WorkerScriptResponse{}, errors.New("account ID required")
 	}
 	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s", api.AccountID, scriptName)
-	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	res, err := api.makeRequestContextWithHeadersComplete(ctx, http.MethodGet, uri, nil, nil)
 	var r WorkerScriptResponse
 	if err != nil {
 		return r, err
 	}
-	r.Script = string(res)
+
+	// Check if the response type is multipart, in which case this was a module worker
+	mediaType, mediaParams, _ := mime.ParseMediaType(res.ContentType)
+	if strings.HasPrefix(mediaType, "multipart/") {
+		bytesReader := bytes.NewReader(res.Body)
+		mimeReader := multipart.NewReader(bytesReader, mediaParams["boundary"])
+		mimePart, err := mimeReader.NextPart()
+		if err != nil {
+			return r, fmt.Errorf("could not get multipart response body: %w", err)
+		}
+		mimePartBody, err := ioutil.ReadAll(mimePart)
+		if err != nil {
+			return r, fmt.Errorf("could not read multipart response body: %w", err)
+		}
+		r.Script = string(mimePartBody)
+		r.Module = true
+	} else {
+		r.Script = string(res.Body)
+		r.Module = false
+	}
+
 	r.Success = true
 	return r, nil
 }
@@ -497,6 +522,7 @@ func (api *API) ListWorkerBindings(ctx context.Context, requestParams *WorkerReq
 		case WorkerWebAssemblyBindingType:
 			bindingListItem.Binding = WorkerWebAssemblyBinding{
 				Module: &bindingContentReader{
+					ctx:           ctx,
 					api:           api,
 					requestParams: requestParams,
 					bindingName:   name,
@@ -537,6 +563,7 @@ func (api *API) ListWorkerBindings(ctx context.Context, requestParams *WorkerReq
 type bindingContentReader struct {
 	api           *API
 	requestParams *WorkerRequestParams
+	ctx           context.Context
 	bindingName   string
 	content       []byte
 	position      int
@@ -546,7 +573,7 @@ func (b *bindingContentReader) Read(p []byte) (n int, err error) {
 	// Lazily load the content when Read() is first called
 	if b.content == nil {
 		uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s/bindings/%s/content", b.api.AccountID, b.requestParams.ScriptName, b.bindingName)
-		res, err := b.api.makeRequest(http.MethodGet, uri, nil)
+		res, err := b.api.makeRequestContext(b.ctx, http.MethodGet, uri, nil)
 		if err != nil {
 			return 0, err
 		}

--- a/workers.go
+++ b/workers.go
@@ -441,7 +441,7 @@ func (api *API) downloadWorkerWithName(ctx context.Context, scriptName string) (
 	}
 
 	// Check if the response type is multipart, in which case this was a module worker
-	mediaType, mediaParams, _ := mime.ParseMediaType(res.ContentType)
+	mediaType, mediaParams, _ := mime.ParseMediaType(res.Headers.Get("content-type"))
 	if strings.HasPrefix(mediaType, "multipart/") {
 		bytesReader := bytes.NewReader(res.Body)
 		mimeReader := multipart.NewReader(bytesReader, mediaParams["boundary"])

--- a/workers_test.go
+++ b/workers_test.go
@@ -23,7 +23,7 @@ const (
 }`
 	uploadWorkerResponseData = `{
     "result": {
-        "script": "addEventListener('fetch', event => {\n    event.passThroughOnException()\nevent.respondWith(handleRequest(event.request))\n})\n\nasync function handleRequest(request) {\n    return fetch(request)\n}",
+        "script": "addEventListener('fetch', event => {\n  event.passThroughOnException()\n  event.respondWith(handleRequest(event.request))\n})\n\nasync function handleRequest(request) {\n  return fetch(request)\n}",
         "etag": "279cf40d86d70b82f6cd3ba90a646b3ad995912da446836d7371c21c6a43977a",
         "size": 191,
         "modified_on": "2018-06-09T15:17:01.989141Z"
@@ -35,7 +35,7 @@ const (
 
 	uploadWorkerModuleResponseData = `{
     "result": {
-        "script": "export default {\n    async fetch(request, env, event) {\n     event.passThroughOnException()\n    return fetch(request)\n    }\n}",
+        "script": "export default {\n  async fetch(request, env, event) {\n    event.passThroughOnException()\n    return fetch(request)\n  }\n}",
         "etag": "279cf40d86d70b82f6cd3ba90a646b3ad995912da446836d7371c21c6a43977a",
         "size": 191,
         "modified_on": "2018-06-09T15:17:01.989141Z"
@@ -179,15 +179,38 @@ const (
   "errors": [],
   "messages": []
 }`
+	workerScript = `addEventListener('fetch', event => {
+  event.passThroughOnException()
+  event.respondWith(handleRequest(event.request))
+})
+
+async function handleRequest(request) {
+  return fetch(request)
+}`
+	workerModuleScript = `export default {
+  async fetch(request, env, event) {
+    event.passThroughOnException()
+    return fetch(request)
+  }
+}`
+	workerModuleScriptDownloadResponse = `
+--workermodulescriptdownload
+Content-Disposition: form-data; name="worker.js"
+
+export default {
+  async fetch(request, env, event) {
+    event.passThroughOnException()
+    return fetch(request)
+  }
+}
+--workermodulescriptdownload--
+`
 )
 
 var (
 	successResponse               = Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}}
-	workerScript                  = "addEventListener('fetch', event => {\n    event.passThroughOnException()\nevent.respondWith(handleRequest(event.request))\n})\n\nasync function handleRequest(request) {\n    return fetch(request)\n}"
-	workerModuleScript            = "export default {\n    async fetch(request, env, event) {\n     event.passThroughOnException()\n    return fetch(request)\n    }\n}"
 	deleteWorkerRouteResponseData = createWorkerRouteResponse
-
-	attachWorkerToDomainResponse = fmt.Sprintf(`{
+	attachWorkerToDomainResponse  = fmt.Sprintf(`{
     "result": {
         "id": "e7a57d8746e74ae49c25994dadb421b1",
 	"zone_id": "%s",
@@ -393,8 +416,8 @@ func TestWorkers_DownloadWorkerModule(t *testing.T) {
 
 	mux.HandleFunc("/accounts/foo/workers/scripts/bar", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		w.Header().Set("content-type", "multipart/form-data; boundary=workermoduledownloadresponse")
-		fmt.Fprintf(w, workerModuleDownloadResponse) //nolint
+		w.Header().Set("content-type", "multipart/form-data; boundary=workermodulescriptdownload")
+		fmt.Fprintf(w, workerModuleScriptDownloadResponse) //nolint
 	})
 	res, err := client.DownloadWorker(context.Background(), &WorkerRequestParams{ScriptName: "bar"})
 	want := WorkerScriptResponse{


### PR DESCRIPTION
## Description

Since #1010 allows uploading a Worker script in module format, calling DownloadWorker on the same script will return a multipart/form-data response.

### Asks

1. _Update: still need this; for the moment I'm assuming that any multipart worker is in module format._ Cloudflare API for download a worker should add a Content-Type header to each multipart/form-data section to specify whether the script in that section is application/javascript or application/javascript+module.
2. _Update: took this approach, please review!_ Guidance on a deep change: `makeRequest...` et al should return a content-type header not just the body.
3. _Update: didn't like this approach:_ ~Guidance on a workaround: `makeRequest...` et al continue to just return the response body, so consumers assume the format, or detect the format with a heuristic. For example, `DownloadWorker` can check the first two bytes and if they are `--` then assume the rest of that line is the multipart boundary string and parse the body accordingly. This is so gross.~

### Details

This approach digs into the `makeRequest...` family (`makeRequestWithAuthTypeAndHeaders` is the full implementation) and adds support to return the first body of a multipart response. `makeRequest`, et al, does not return the mime-type of the response. Consuming functions mostly assume it is application/json, except DownloadWorker which implicitly assumes it's application/javascript.

While I've solved the initial problem with #1010 that you can upload a module-format worker but if you try to download it, the DownloadWorker method return raw multipart/form-data, I'm stuck on the next problem: the Module true/false status is _implied_ by whether the download script API returns a javascript content-type or a multipart content-type.

There's no further clue because the Cloudflare API for downloading a worker only gives a Content-Disposition header on its response for a module worker:
```
Content-Type: multipart/form-data; boundary=mimeboundary

--mimeboundary
Content-Disposition: form-data; name="worker.js"

export default { etc etc etc }
--mimeboundary
```
vs. non-module format:
```
Content-Type: application/json

addEventListener( etc etc )
```

This isn't consistent with **uploading** a module worker, where the Content-Type of the mime-part must be set to `application/javascript+module` like this:
```
--mimeboundary
Content-Disposition: form-data; name="worker.js"
Content-Type: application/javascript+module

export default { etc etc etc }
--mimeboundary
```

Sidenote: why was the method `UploadWorkerWithBindings` added? The bindings are in a param structure, isn't the point to add new params without creating a new method? And in fact if you call UploadWorker with Module-format worker, it shunts to UploadWorkerWithBindings! The salient difference is whether the upload is in multipart format or a direct script. The code path I can see that isn't in multipart format is a non-module worker without bindings (the original product, so probably also the most common case). _Per manual testing, the Cloudflare API will accept a multipart/form-data with a plain script as its body -- that is, **UploadWorker** is sufficient for all cases and **UploadWorkerWithBindings** is duplicative._

## Has your change been tested?

_**Works**_ but creates an awkward roundtrip problem in the current iteration:

1. `UploadWorker` with Module: true because it's a module script.
```
        scriptFile, err := os.ReadFile("cool-script.js")
        scriptText := string(scriptFile)

        UploadWorker(ctx,
                &cloudflare.WorkerRequestParams{
                        ScriptName: "modtest",
                },
                &cloudflare.WorkerScriptParams{
                        Script: scriptText,
                        Module: true,
                },
        )
```
4. `DownloadWorker` with the script name and returns the script body. But what format is it?
```
        scriptText = DownloadWorker(ctx,
                &cloudflare.WorkerRequestParams{
                        ScriptName: "modtest",
                },
        )
```
5. `UploadWorker` ... with Module true or false? There's no indication from DownloadWorker which to use.
```
        strings.Replace(scriptText, "foo", "bar", -1)

        UploadWorker(ctx,
                &cloudflare.WorkerRequestParams{
                        ScriptName: "modtest",
                },
                &cloudflare.WorkerScriptParams{
                        Script: scriptText,
                        Module: true,   <---- ?????????????????                },
        )
```


## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
