### PR TITLE
cloudflare: update rate limit exceeded error message

### DIFF
--- a/.changelog/1043.txt
+++ b/.changelog/1043.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+cloudflare: make it clear when the rate limit retries have been exhausted
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -251,6 +251,10 @@ func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, u
 		// retry if the server is rate limiting us or if it failed
 		// assumes server operations are rolled back on failure
 		if respErr != nil || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			if resp.StatusCode == http.StatusTooManyRequests {
+				respErr = errors.New("exceeded available rate limit retries")
+			}
+
 			// if we got a valid http response, try to read body so we can reuse the connection
 			// see https://golang.org/pkg/net/http/#Client.Do
 			if respErr == nil {


### PR DESCRIPTION
Updates the messaging when the rate limit retry policy has been
exhausted to convey the actual failure instead of the generic `could not
read response body` failure.

Closes #1041 
Closes cloudflare/terraform-provider-cloudflare#1834