### PR TITLE
Fix incorrect test from PR 1014

### DIFF
--- a/.changelog/1048.txt
+++ b/.changelog/1048.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+workers_test: Fix incorrect test from PR #1014
+```

--- a/workers_test.go
+++ b/workers_test.go
@@ -1251,7 +1251,7 @@ func TestWorkers_AttachWorkerToDomain(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/workers/domains", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, deleteWorkerResponseData) //nolint
+		fmt.Fprintf(w, attachWorkerToDomainResponse) //nolint
 	})
 	res, err := client.AttachWorkerToDomain(context.Background(), AccountIdentifier(testAccountID), &WorkerDomainParams{
 		ZoneID:      testZoneID,
@@ -1261,7 +1261,13 @@ func TestWorkers_AttachWorkerToDomain(t *testing.T) {
 	})
 	want := WorkerDomainResponse{
 		successResponse,
-		WorkerDomainResult{}}
+		WorkerDomainResult{
+			ID:          "e7a57d8746e74ae49c25994dadb421b1",
+			ZoneID:      testZoneID,
+			Service:     "test_script_1",
+			Hostname:    "api4.example.com",
+			Environment: "production",
+		}}
 	if assert.NoError(t, err) {
 		assert.Equal(t, want.Response, res.Response)
 	}


### PR DESCRIPTION
## Description

PR #1014 used the test response from a different API call. The response has the same structure so it wasn't noticed by the test harness. Add a complete response parse test this time around.

## Has your change been tested?

`go test .` works.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Nit fix (non-breaking change which fixes a non-issue :)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
