### PR TITLE
The content type for JSON is application/json

### DIFF
--- a/.changelog/1049.txt
+++ b/.changelog/1049.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+workers_test: Use application/json mime-type in headers
+```

--- a/workers_test.go
+++ b/workers_test.go
@@ -390,7 +390,7 @@ func TestWorkers_ListWorkerScripts(t *testing.T) {
 
 	mux.HandleFunc("/accounts/foo/workers/scripts", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, listWorkersResponseData) //nolint
 	})
 
@@ -903,7 +903,7 @@ func TestWorkers_CreateWorkerRoute(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/filters", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app1.example.com/*", Enabled: true}
@@ -920,7 +920,7 @@ func TestWorkers_CreateWorkerRouteEnt(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app1.example.com/*", Script: "test_script"}
@@ -937,7 +937,7 @@ func TestWorkers_CreateWorkerRouteSingleScriptWithAccount(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/filters", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app1.example.com/*", Enabled: true}
@@ -962,7 +962,7 @@ func TestWorkers_CreateWorkerRouteWithNoScript(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, createWorkerRouteResponse) //nolint
 	})
 
@@ -977,7 +977,7 @@ func TestWorkers_DeleteWorkerRoute(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, deleteWorkerRouteResponseData) //nolint
 	})
 	res, err := client.DeleteWorkerRoute(context.Background(), "foo", "e7a57d8746e74ae49c25994dadb421b1")
@@ -996,7 +996,7 @@ func TestWorkers_DeleteWorkerRouteEnt(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, deleteWorkerRouteResponseData) //nolint
 	})
 	res, err := client.DeleteWorkerRoute(context.Background(), "foo", "e7a57d8746e74ae49c25994dadb421b1")
@@ -1015,7 +1015,7 @@ func TestWorkers_ListWorkerRoutes(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/filters", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, listRouteResponseData) //nolint
 	})
 
@@ -1037,7 +1037,7 @@ func TestWorkers_ListWorkerRoutesEnt(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, listRouteEntResponseData) //nolint
 	})
 
@@ -1060,7 +1060,7 @@ func TestWorkers_GetWorkerRoute(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes/1234", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, getRouteResponseData) //nolint
 	})
 
@@ -1082,7 +1082,7 @@ func TestWorkers_UpdateWorkerRoute(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/filters/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, updateWorkerRouteResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app3.example.com/*", Enabled: true}
@@ -1104,7 +1104,7 @@ func TestWorkers_UpdateWorkerRouteEnt(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, updateWorkerRouteEntResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app3.example.com/*", Script: "test_script_1"}
@@ -1126,7 +1126,7 @@ func TestWorkers_UpdateWorkerRouteSingleScriptWithAccount(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/filters/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, updateWorkerRouteEntResponse) //nolint
 	})
 	route := WorkerRoute{Pattern: "app3.example.com/*", Enabled: true}
@@ -1148,7 +1148,7 @@ func TestWorkers_ListWorkerBindingsMultiScript(t *testing.T) {
 
 	mux.HandleFunc("/accounts/foo/workers/scripts/my-script/bindings", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, listBindingsResponseData) //nolint
 	})
 
@@ -1235,7 +1235,7 @@ func TestWorkers_UpdateWorkerRouteWithNoScript(t *testing.T) {
 
 	mux.HandleFunc("/zones/foo/workers/routes/e7a57d8746e74ae49c25994dadb421b1", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
-		w.Header().Set("content-type", "application-json")
+		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, updateWorkerRouteEntResponse) //nolint
 	})
 


### PR DESCRIPTION
## Description

Tests were using `application-json` which is not a valid content type. The correct value is `application/json`. There is no strict parser that catches this, but 👋 :airquotes: there should be :airquotes:

## Has your change been tested?

`go test .` still works

## Types of changes

What sort of change does your code introduce/modify?

- [x] Nit fix (meaningful but nitpicky change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
