### PR TITLE
Add compatibility date and compatibility_flags to pages deployment configs

### DIFF
--- a/.changelog/1051.txt
+++ b/.changelog/1051.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+pages_project: Add compatibility date and compatibility_flags to pages deployment configs
+```

--- a/argo.go
+++ b/argo.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
-	"errors"
 )
 
 var validSettingValues = []string{"on", "off"}
@@ -52,7 +50,7 @@ func (api *API) ArgoSmartRouting(ctx context.Context, zoneID string) (ArgoFeatur
 // API reference: https://api.cloudflare.com/#argo-smart-routing-patch-argo-smart-routing-setting
 func (api *API) UpdateArgoSmartRouting(ctx context.Context, zoneID, settingValue string) (ArgoFeatureSetting, error) {
 	if !contains(validSettingValues, settingValue) {
-		return ArgoFeatureSetting{}, errors.New(fmt.Sprintf("invalid setting value '%s'. must be 'on' or 'off'", settingValue))
+		return ArgoFeatureSetting{}, fmt.Errorf("invalid setting value '%s'. must be 'on' or 'off'", settingValue)
 	}
 
 	uri := fmt.Sprintf("/zones/%s/argo/smart_routing", zoneID)
@@ -94,7 +92,7 @@ func (api *API) ArgoTieredCaching(ctx context.Context, zoneID string) (ArgoFeatu
 // API reference: TBA.
 func (api *API) UpdateArgoTieredCaching(ctx context.Context, zoneID, settingValue string) (ArgoFeatureSetting, error) {
 	if !contains(validSettingValues, settingValue) {
-		return ArgoFeatureSetting{}, errors.New(fmt.Sprintf("invalid setting value '%s'. must be 'on' or 'off'", settingValue))
+		return ArgoFeatureSetting{}, fmt.Errorf("invalid setting value '%s'. must be 'on' or 'off'", settingValue)
 	}
 
 	uri := fmt.Sprintf("/zones/%s/argo/tiered_caching", zoneID)

--- a/ip_list.go
+++ b/ip_list.go
@@ -499,7 +499,7 @@ func (api *API) pollIPListBulkOperation(ctx context.Context, accountID, ID strin
 		case "completed":
 			return nil
 		default:
-			return errors.New(fmt.Sprintf("%s: %s", errOperationUnexpectedStatus, bulkResult.Status))
+			return fmt.Errorf("%s: %s", errOperationUnexpectedStatus, bulkResult.Status)
 		}
 	}
 

--- a/list.go
+++ b/list.go
@@ -608,7 +608,7 @@ func (api *API) pollListBulkOperation(ctx context.Context, rc *ResourceContainer
 		case "completed":
 			return nil
 		default:
-			return errors.New(fmt.Sprintf("%s: %s", errOperationUnexpectedStatus, bulkResult.Status))
+			return fmt.Errorf("%s: %s", errOperationUnexpectedStatus, bulkResult.Status)
 		}
 	}
 

--- a/pages_project.go
+++ b/pages_project.go
@@ -59,7 +59,7 @@ type PagesProjectDeploymentConfigEnvironment struct {
 	CompatibilityFlags []string                             `json:"compatibility_flags,omitempty"`
 }
 
-// PagesProjectDeploymentVar represents a value for a BUILD_VERSION.
+// PagesProjectDeploymentVar represents a deployment environment variable
 type PagesProjectDeploymentVar struct {
 	Value string `json:"value"`
 }

--- a/pages_project.go
+++ b/pages_project.go
@@ -59,7 +59,7 @@ type PagesProjectDeploymentConfigEnvironment struct {
 	CompatibilityFlags []string                             `json:"compatibility_flags,omitempty"`
 }
 
-// PagesProjectDeploymentVar represents a deployment environment variable
+// PagesProjectDeploymentVar represents a deployment environment variable.
 type PagesProjectDeploymentVar struct {
 	Value string `json:"value"`
 }

--- a/pages_project.go
+++ b/pages_project.go
@@ -54,31 +54,35 @@ type PagesProjectDeploymentConfigs struct {
 
 // PagesProjectDeploymentConfigEnvironment represents the configuration for preview or production deploys.
 type PagesProjectDeploymentConfigEnvironment struct {
-	EnvVars map[string]PagesProjectDeploymentVar `json:"env_vars"`
+	EnvVars            map[string]PagesProjectDeploymentVar `json:"env_vars"`
+	CompatibilityDate  string                               `json:"compatibility_date,omitempty"`
+	CompatibilityFlags []string                             `json:"compatibility_flags,omitempty"`
 }
 
-// PagesProjectDeploymentConfigBuildVersion represents a value for a BUILD_VERSION.
+// PagesProjectDeploymentVar represents a value for a BUILD_VERSION.
 type PagesProjectDeploymentVar struct {
 	Value string `json:"value"`
 }
 
 // PagesProjectDeployment represents a deployment to a Pages project.
 type PagesProjectDeployment struct {
-	ID                string                        `json:"id"`
-	ShortID           string                        `json:"short_id"`
-	ProjectID         string                        `json:"project_id"`
-	ProjectName       string                        `json:"project_name"`
-	Environment       string                        `json:"environment"`
-	URL               string                        `json:"url"`
-	CreatedOn         *time.Time                    `json:"created_on"`
-	ModifiedOn        *time.Time                    `json:"modified_on"`
-	Aliases           []string                      `json:"aliases,omitempty"`
-	LatestStage       PagesProjectDeploymentStage   `json:"latest_stage"`
-	EnvVars           map[string]map[string]string  `json:"env_vars"`
-	DeploymentTrigger PagesProjectDeploymentTrigger `json:"deployment_trigger"`
-	Stages            []PagesProjectDeploymentStage `json:"stages"`
-	BuildConfig       PagesProjectBuildConfig       `json:"build_config"`
-	Source            PagesProjectSource            `json:"source"`
+	ID                 string                        `json:"id"`
+	ShortID            string                        `json:"short_id"`
+	ProjectID          string                        `json:"project_id"`
+	ProjectName        string                        `json:"project_name"`
+	Environment        string                        `json:"environment"`
+	URL                string                        `json:"url"`
+	CreatedOn          *time.Time                    `json:"created_on"`
+	ModifiedOn         *time.Time                    `json:"modified_on"`
+	Aliases            []string                      `json:"aliases,omitempty"`
+	LatestStage        PagesProjectDeploymentStage   `json:"latest_stage"`
+	EnvVars            map[string]map[string]string  `json:"env_vars"`
+	DeploymentTrigger  PagesProjectDeploymentTrigger `json:"deployment_trigger"`
+	Stages             []PagesProjectDeploymentStage `json:"stages"`
+	BuildConfig        PagesProjectBuildConfig       `json:"build_config"`
+	Source             PagesProjectSource            `json:"source"`
+	CompatibilityDate  string                        `json:"compatibility_date,omitempty"`
+	CompatibilityFlags []string                      `json:"compatibility_flags,omitempty"`
 }
 
 // PagesProjectDeploymentStage represents an individual stage in a Pages project deployment.

--- a/pages_project_test.go
+++ b/pages_project_test.go
@@ -47,7 +47,9 @@ const (
               "ENV": {
                 "value": "preview"
               }
-            }
+            },
+			"compatibility_date": "2022-08-15",
+			"compatibility_flags": ["preview_flag"]
           },
           "production": {
             "env_vars": {
@@ -57,7 +59,9 @@ const (
               "ENV": {
                 "value": "production"
               }
-            }
+            },
+			"compatibility_date": "2022-08-15",
+			"compatibility_flags": ["production_flag"]
           }
         },
         "latest_deployment": {
@@ -86,6 +90,8 @@ const (
               "value": "STAGING"
             }
           },
+		  "compatibility_date": "2022-08-15",
+		  "compatibility_flags": ["deployment_flag"],
           "deployment_trigger": {
             "type": "ad_hoc",
             "metadata": {
@@ -152,6 +158,8 @@ const (
               "value": "STAGING"
             }
           },
+		  "compatibility_date": "2022-08-15",
+		  "compatibility_flags": ["deployment_flag"],
           "deployment_trigger": {
             "type": "ad_hoc",
             "metadata": {
@@ -238,10 +246,12 @@ var (
 				"value": "STAGING",
 			},
 		},
-		DeploymentTrigger: *expectedPagesProjectDeploymentTrigger,
-		Stages:            expectedStages,
-		BuildConfig:       *expectedPagesProjectBuildConfig,
-		Source:            *expectedPagesProjectSource,
+		CompatibilityFlags: []string{"deployment_flag"},
+		CompatibilityDate:  "2022-08-15",
+		DeploymentTrigger:  *expectedPagesProjectDeploymentTrigger,
+		Stages:             expectedStages,
+		BuildConfig:        *expectedPagesProjectBuildConfig,
+		Source:             *expectedPagesProjectSource,
 	}
 
 	latestDeploymentStageStartedOn, _ = time.Parse(time.RFC3339, "2021-03-09T00:55:03.923456Z")
@@ -303,6 +313,8 @@ var (
 				Value: "preview",
 			},
 		},
+		CompatibilityDate:  "2022-08-15",
+		CompatibilityFlags: []string{"preview_flag"},
 	}
 
 	expectedPagesProjectDeploymentConfigProduction = &PagesProjectDeploymentConfigEnvironment{
@@ -314,6 +326,8 @@ var (
 				Value: "production",
 			},
 		},
+		CompatibilityDate:  "2022-08-15",
+		CompatibilityFlags: []string{"production_flag"},
 	}
 
 	expectedPagesProjectSource = &PagesProjectSource{


### PR DESCRIPTION
## Description
Adds compatibility date and compatibility flags to pages deployments
Also fixes a couple cases where `errors.New(fmt.Sprintf())` was being used instead of `fmt.Errorf()`

## Has your change been tested?

Updated unit tests and they pass

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs. (soon)
