### PR TITLE
Expose Blockpage.SuppressFooter field

### DIFF
--- a/.changelog/1053.txt
+++ b/.changelog/1053.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams_account: add support for `suppress_footer`
+```

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -75,6 +75,7 @@ type TeamsBlockPage struct {
 	Name            string `json:"name,omitempty"`
 	MailtoAddress   string `json:"mailto_address,omitempty"`
 	MailtoSubject   string `json:"mailto_subject,omitempty"`
+	SuppressFooter  *bool  `json:"suppress_footer,omitempty"`
 }
 
 type TeamsRuleType = string

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -73,7 +73,8 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 						"mailto_address": "admin@example.com",
 						"mailto_subject": "Blocked User Inquiry",
 						"logo_path": "https://logos.com/a.png",
-						"background_color": "#ff0000"
+						"background_color": "#ff0000",
+						"suppress_footer": true
 					}
 				}
 			}
@@ -101,6 +102,7 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 				Name:            "Cloudflare",
 				MailtoAddress:   "admin@example.com",
 				MailtoSubject:   "Blocked User Inquiry",
+				SuppressFooter:  BoolPtr(true),
 			},
 		})
 	}


### PR DESCRIPTION
## Description

Cloudflare documentation for TeamsAccount blockpage settings exposes `suppress_footer` field.
https://api.cloudflare.com/#zero-trust-accounts-update-zero-trust-account-configuration

## Has your change been tested?

Updated relevant test in teams_accounts.go.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.