### PR TITLE
First pass at attempting to flesh out account-scoped worker APIs.

### DIFF
--- a/.changelog/1056.txt
+++ b/.changelog/1056.txt
@@ -1,0 +1,3 @@
+```release-note:
+Expand Worker methods to support `/accounts/:account_id/workers` API endpoints.
+```


### PR DESCRIPTION
This is an attempt at fleshing this library out so that the Worker-related APIs are able to use the `/accounts/:account_id/workers/` endpoint namespace.

## Description

I wanted to get this PR opened quickly so I could get feedback on whether my approach is harmonious with the goals of the maintainers (and how to correct, if not) -- before I went too far down the wrong path.  I expect there's still quite a bit to do before it's ready for merging.  Feedback and guidance would be appreciated.

## Has your change been tested?

I've run, and updated as appropriate, the regression tests.  I have not yet tried using the library directly.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
