### PR TITLE
Fix typo on email API settings endpoint

### DIFF
--- a/.changelog/1060.txt
+++ b/.changelog/1060.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+email_routing_settings: change enable endpoint from `enabled` to `enable`
+```

--- a/email_routing_settings.go
+++ b/email_routing_settings.go
@@ -58,7 +58,7 @@ func (api *API) EnableEmailRouting(ctx context.Context, rc *ResourceContainer) (
 	if rc.Identifier == "" {
 		return EmailRoutingSettings{}, ErrMissingZoneID
 	}
-	uri := fmt.Sprintf("/zones/%s/email/routing/enabled", rc.Identifier)
+	uri := fmt.Sprintf("/zones/%s/email/routing/enable", rc.Identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, nil)
 	if err != nil {
 		return EmailRoutingSettings{}, err

--- a/email_routing_settings_test.go
+++ b/email_routing_settings_test.go
@@ -64,7 +64,7 @@ func TestEmailRouting_Enable(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/zones/"+testZoneID+"/email/routing/enabled", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/zones/"+testZoneID+"/email/routing/enable", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprint(w, `{


### PR DESCRIPTION
## Description

The endpoint for enabling Email Routing for a zone is `enable` and not `enabled`

## Has your change been tested?

Updated unit tests and they pass

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
