### PR TITLE
Fix nil dereference panic after 8563c7a

### DIFF
--- a/.changelog/1072.txt
+++ b/.changelog/1072.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cloudflare: fix nil dereference error in makeRequestWithAuthTypeAndHeaders
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -271,7 +271,7 @@ func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, m
 		// retry if the server is rate limiting us or if it failed
 		// assumes server operations are rolled back on failure
 		if respErr != nil || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
-			if resp.StatusCode == http.StatusTooManyRequests {
+			if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 				respErr = errors.New("exceeded available rate limit retries")
 			}
 


### PR DESCRIPTION
## Description

Fixes nil panic regression introduced by 8563c7a2, if `respErr != nil` then body is most likely `nil`. 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x73bc4d]
goroutine 1 [running]:
github.com/cloudflare/cloudflare-go.(*API).makeRequestWithAuthTypeAndHeaders(0xc000328000, {0xc33d38, 0xc00027bcc0}, {0xb42aa6, 0xd}, {0xc0004a83c0, 0x17}, {0x0, 0x0}, 0x1, ...)
/go/pkg/mod/github.com/cloudflare/cloudflare-go@v0.48.0/cloudflare.go:254 +0xa2d
github.com/cloudflare/cloudflare-go.(*API).makeRequestWithAuthType(...)
/go/pkg/mod/github.com/cloudflare/cloudflare-go@v0.48.0/cloudflare.go:186
github.com/cloudflare/cloudflare-go.(*API).makeRequestContext(0xb45349, {0xc33d38, 0xc00027bcc0}, {0xb42aa6, 0x54a}, {0xc0004a83c0, 0x0}, {0x0, 0x0})
/go/pkg/mod/github.com/cloudflare/cloudflare-go@v0.48.0/cloudflare.go:172 +0x57
github.com/cloudflare/cloudflare-go.(*API).Accounts(0xb43d08, {0xc33d38, 0xc00027bcc0}, {{0x0, 0x1}, {0xc000333600, 0x54a}})
/go/pkg/mod/github.com/cloudflare/cloudflare-go@v0.48.0/accounts.go:59 +0xe7
main.main()
```


## Has your change been tested?

N/A

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.