### PR TITLE
Add hide_user_logs param to AuditLogFilter

### DIFF
--- a/.changelog/1075.txt
+++ b/.changelog/1075.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+auditlogs: add support for hide_user_logs filter parameter
+```

--- a/auditlogs.go
+++ b/auditlogs.go
@@ -59,15 +59,16 @@ type AuditLogResponse struct {
 
 // AuditLogFilter is an object for filtering the audit log response from the api.
 type AuditLogFilter struct {
-	ID         string
-	ActorIP    string
-	ActorEmail string
-	Direction  string
-	ZoneName   string
-	Since      string
-	Before     string
-	PerPage    int
-	Page       int
+	ID           string
+	ActorIP      string
+	ActorEmail   string
+	HideUserLogs bool
+	Direction    string
+	ZoneName     string
+	Since        string
+	Before       string
+	PerPage      int
+	Page         int
 }
 
 // ToQuery turns an audit log filter in to an HTTP Query Param
@@ -84,6 +85,9 @@ func (a AuditLogFilter) ToQuery() url.Values {
 	}
 	if a.ActorEmail != "" {
 		v.Add("actor.email", a.ActorEmail)
+	}
+	if a.HideUserLogs {
+		v.Add("hide_user_logs", "true")
 	}
 	if a.ZoneName != "" {
 		v.Add("zone.name", a.ZoneName)

--- a/auditlogs_test.go
+++ b/auditlogs_test.go
@@ -18,6 +18,11 @@ func TestAuditLogFilterToQuery(t *testing.T) {
 		t.Fatalf("Did not properly stringify the actor.email field: %s", filter.ToQuery().Encode())
 	}
 
+	filter.HideUserLogs = true
+	if !strings.Contains(filter.ToQuery().Encode(), "hide_user_logs=true") {
+		t.Fatalf("Did not properly stringify the hide_user_logs field: %s", filter.ToQuery().Encode())
+	}
+
 	filter.ActorIP = "192.0.2.0"
 	if !strings.Contains(filter.ToQuery().Encode(), "&actor.ip=192.0.2.0") {
 		t.Fatalf("Did not properly stringify the actorip field: %s", filter.ToQuery().Encode())


### PR DESCRIPTION
## Description

The API supports filtering on this field for the [user](https://api.cloudflare.com/#audit-logs-get-user-audit-logs) as well as the [accounts](https://api.cloudflare.com/#audit-logs-get-account-audit-logs) endpoints for AuditLogs.

## Has your change been tested?

Test case for AuditLogs has been added.
Automated tests have run successfully (verbosity stripped for brevity):
```
$ go test
PASS
ok  	github.com/cloudflare/cloudflare-go	0.651s
```

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

