### PR TITLE
fix per-hostname authenticated origin pull to use bool ptr

### DIFF
--- a/authenticated_origin_pulls_per_hostname.go
+++ b/authenticated_origin_pulls_per_hostname.go
@@ -30,7 +30,7 @@ type PerHostnameAuthenticatedOriginPullsCertificateResponse struct {
 type PerHostnameAuthenticatedOriginPullsDetails struct {
 	Hostname       string    `json:"hostname"`
 	CertID         string    `json:"cert_id"`
-	Enabled        bool      `json:"enabled"`
+	Enabled        *bool     `json:"enabled"`
 	Status         string    `json:"status"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
@@ -66,7 +66,7 @@ type PerHostnameAuthenticatedOriginPullsCertificateParams struct {
 type PerHostnameAuthenticatedOriginPullsConfig struct {
 	Hostname string `json:"hostname"`
 	CertID   string `json:"cert_id"`
-	Enabled  bool   `json:"enabled"`
+	Enabled  *bool  `json:"enabled"`
 }
 
 // PerHostnameAuthenticatedOriginPullsConfigParams represents the expected config param format for Per Hostname AuthenticatedOriginPulls applied on a hostname.

--- a/authenticated_origin_pulls_per_hostname_test.go
+++ b/authenticated_origin_pulls_per_hostname_test.go
@@ -65,7 +65,7 @@ func TestListPerHostnameAuthenticatedOriginPullsCertificate(t *testing.T) {
 	want := []PerHostnameAuthenticatedOriginPullsDetails{
 		{
 			Hostname:       "app.example.com",
-			Enabled:        true,
+			Enabled:        BoolPtr(true),
 			CertStatus:     "active",
 			CreatedAt:      createdAt,
 			UpdatedAt:      updatedAt,
@@ -80,7 +80,7 @@ func TestListPerHostnameAuthenticatedOriginPullsCertificate(t *testing.T) {
 			CertUpdatedAt:  updatedAt,
 		}, {
 			Hostname:       "anotherapp.example.com",
-			Enabled:        true,
+			Enabled:        BoolPtr(true),
 			CertStatus:     "active",
 			CreatedAt:      createdAt,
 			UpdatedAt:      updatedAt,
@@ -274,7 +274,7 @@ func TestEditPerHostnameAuthenticatedOriginPullsConfig(t *testing.T) {
 		{
 			Hostname:       "app.example.com",
 			CertID:         "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
-			Enabled:        true,
+			Enabled:        BoolPtr(true),
 			Status:         "active",
 			CreatedAt:      createdAt,
 			UpdatedAt:      updatedAt,
@@ -293,7 +293,7 @@ func TestEditPerHostnameAuthenticatedOriginPullsConfig(t *testing.T) {
 		{
 			Hostname: "app.example.com",
 			CertID:   "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
-			Enabled:  true,
+			Enabled:  BoolPtr(true),
 		},
 	}
 	actual, err := client.EditPerHostnameAuthenticatedOriginPullsConfig(context.Background(), "023e105f4ecef8ad9ca31a8372d0c353", config)
@@ -340,7 +340,7 @@ func TestGetPerHostnameAuthenticatedOriginPullsConfig(t *testing.T) {
 	want := PerHostnameAuthenticatedOriginPullsDetails{
 		Hostname:       "app.example.com",
 		CertID:         "2458ce5a-0c35-4c7f-82c7-8e9487d3ff60",
-		Enabled:        true,
+		Enabled:        BoolPtr(true),
 		Status:         "active",
 		CreatedAt:      createdAt,
 		UpdatedAt:      updatedAt,

--- a/authenticated_origin_pulls_per_zone.go
+++ b/authenticated_origin_pulls_per_zone.go
@@ -69,9 +69,7 @@ func (api *API) GetPerZoneAuthenticatedOriginPullsStatus(ctx context.Context, zo
 // API reference: https://api.cloudflare.com/#zone-level-authenticated-origin-pulls-set-enablement-for-zone
 func (api *API) SetPerZoneAuthenticatedOriginPullsStatus(ctx context.Context, zoneID string, enable bool) (PerZoneAuthenticatedOriginPullsSettings, error) {
 	uri := fmt.Sprintf("/zones/%s/origin_tls_client_auth/settings", zoneID)
-	params := struct {
-		Enabled bool `json:"enabled"`
-	}{
+	params := PerZoneAuthenticatedOriginPullsSettings{
 		Enabled: enable,
 	}
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)


### PR DESCRIPTION
from https://api.cloudflare.com/#per-hostname-authenticated-origin-pull-enable-or-disable-a-hostname-for-client-authentication

enabled (boolean | null): Indicates whether hostname-level authenticated origin pulls is enabled. A null value voids the association

## Description

previously it was only possible to provide true or false, but for per-hostname AOP it's a tri-state boolean on the API side.

## Has your change been tested?
yes

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
