### PR TITLE
url_normalization_settings: add delete API

### DIFF
--- a/.changelog/1078.txt
+++ b/.changelog/1078.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+url_normalization_settings: Add API to delete URL normalization settings
+```

--- a/url_normalization_settings.go
+++ b/url_normalization_settings.go
@@ -57,3 +57,15 @@ func (api *API) UpdateURLNormalizationSettings(ctx context.Context, rc *Resource
 
 	return urlNormalizationSettingsResponse.Result, nil
 }
+
+// DeleteURLNormalizationSettings https://api.cloudflare.com/#url-normalization-update-url-normalization-settings
+func (api *API) DeleteURLNormalizationSettings(ctx context.Context, rc *ResourceContainer) error {
+	uri := fmt.Sprintf("/zones/%s/url_normalization", rc.Identifier)
+
+	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/url_normalization_settings.go
+++ b/url_normalization_settings.go
@@ -58,7 +58,7 @@ func (api *API) UpdateURLNormalizationSettings(ctx context.Context, rc *Resource
 	return urlNormalizationSettingsResponse.Result, nil
 }
 
-// DeleteURLNormalizationSettings https://api.cloudflare.com/#url-normalization-update-url-normalization-settings
+// DeleteURLNormalizationSettings https://api.cloudflare.com/#url-normalization-delete-url-normalization-settings
 func (api *API) DeleteURLNormalizationSettings(ctx context.Context, rc *ResourceContainer) error {
 	uri := fmt.Sprintf("/zones/%s/url_normalization", rc.Identifier)
 

--- a/url_normalization_settings_test.go
+++ b/url_normalization_settings_test.go
@@ -84,3 +84,30 @@ func TestUpdateURLNormalizationSettings(t *testing.T) {
 		assert.Equal(t, want, got)
 	}
 }
+
+func TestDeleteURLNormalizationSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		_, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			panic(err)
+		}
+		defer r.Body.Close()
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": {},
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/url_normalization", handler)
+
+	err := client.DeleteURLNormalizationSettings(context.Background(), ZoneIdentifier(testZoneID))
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Description

FL Team will soon add their endpoint for this DELETE API. I went ahead and added it before them to unblock my work with the terraform provider.

## Has your change been tested?

Mocked a unit test and checked with the FL team on the correctness of the API call.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
