### PR TITLE
Add support for account load balancers pools and monitors

### DIFF
--- a/.changelog/1079.txt
+++ b/.changelog/1079.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+load_balancing: Add support for consecutive_up and consecutive_down.
+```

--- a/.changelog/1079.txt
+++ b/.changelog/1079.txt
@@ -1,3 +1,6 @@
 ```release-note:enhancement
-load_balancing: Add support for consecutive_up and consecutive_down.
+account_load_pools: Add support Account Load Balancer Pools.
+```
+```release-note:enhancement
+account_load_monitors: Add support Account Load Balancer Monitors.
 ```

--- a/account_load_balancer_monitors_test.go
+++ b/account_load_balancer_monitors_test.go
@@ -1,0 +1,621 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const testAccountLoadBalancerMonitorIdentifier = "f1aba936b94213e5b8dca0c0dbf1f9cc"
+
+func TestListAccountLoadBalancerMonitors(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/monitors", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": [
+			{
+			  "id": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			  "created_on": "2014-01-01T05:20:00.12345Z",
+			  "modified_on": "2014-02-01T05:20:00.12345Z",
+			  "type": "https",
+			  "description": "Login page monitor",
+			  "method": "GET",
+			  "path": "/health",
+			  "header": {
+				"Host": [
+				  "example.com"
+				],
+				"X-App-ID": [
+				  "abc123"
+				]
+			  },
+			  "port": 8080,
+			  "timeout": 3,
+			  "retries": 0,
+			  "interval": 90,
+			  "expected_body": "alive",
+			  "expected_codes": "2xx",
+			  "follow_redirects": true,
+			  "allow_insecure": true,
+			  "consecutive_up": 3,
+			  "consecutive_down": 2,
+			  "probe_zone": "example.com"
+			}
+		  ]
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	want := []AccountLoadBalancerMonitor{
+		{
+			ID:          testAccountLoadBalancerMonitorIdentifier,
+			CreatedOn:   &createdOn,
+			ModifiedOn:  &modifiedOn,
+			Type:        "https",
+			Description: "Login page monitor",
+			Method:      http.MethodGet,
+			Path:        "/health",
+			Header: map[string][]string{
+				"Host":     {"example.com"},
+				"X-App-ID": {"abc123"},
+			},
+			Port:            8080,
+			Timeout:         3,
+			Retries:         0,
+			Interval:        90,
+			ExpectedBody:    "alive",
+			ExpectedCodes:   "2xx",
+			FollowRedirects: true,
+			AllowInsecure:   true,
+			ConsecutiveUp:   3,
+			ConsecutiveDown: 2,
+			ProbeZone:       "example.com",
+		},
+	}
+
+	_, err := client.ListAccountLoadBalancerMonitors(context.Background(), ResourceIdentifier(""))
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+
+	actual, err := client.ListAccountLoadBalancerMonitors(context.Background(), ResourceIdentifier(testAccountID))
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateAccountLoadBalancerMonitor(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/monitors", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		b, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		if assert.NoError(t, err) {
+			assert.JSONEq(t, `{
+			  "type": "https",
+			  "description": "Login page monitor",
+			  "method": "GET",
+			  "path": "/health",
+			  "header": {
+				"Host": [
+				  "example.com"
+				],
+				"X-App-ID": [
+				  "abc123"
+				]
+			  },
+			  "port": 8080,
+			  "timeout": 3,
+			  "retries": 0,
+			  "interval": 90,
+			  "expected_body": "alive",
+			  "expected_codes": "2xx",
+			  "follow_redirects": true,
+			  "allow_insecure": true,
+			  "consecutive_up": 3,
+			  "consecutive_down": 2,
+			  "probe_zone": "example.com"
+			}`, string(b))
+		}
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"type": "https",
+			"description": "Login page monitor",
+			"method": "GET",
+			"path": "/health",
+			"header": {
+			  "Host": [
+				"example.com"
+			  ],
+			  "X-App-ID": [
+				"abc123"
+			  ]
+			},
+			"port": 8080,
+			"timeout": 3,
+			"retries": 0,
+			"interval": 90,
+			"expected_body": "alive",
+			"expected_codes": "2xx",
+			"follow_redirects": true,
+			"allow_insecure": true,
+			"consecutive_up": 3,
+			"consecutive_down": 2,
+			"probe_zone": "example.com"
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	want := AccountLoadBalancerMonitor{
+		ID:          testAccountLoadBalancerMonitorIdentifier,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Type:        "https",
+		Description: "Login page monitor",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Port:          8080,
+		Timeout:       3,
+		Retries:       0,
+		Interval:      90,
+		ExpectedBody:  "alive",
+		ExpectedCodes: "2xx",
+
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
+		ProbeZone:       "example.com",
+	}
+	request := AccountLoadBalancerMonitor{
+		Type:        "https",
+		Description: "Login page monitor",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Timeout:       3,
+		Retries:       0,
+		Interval:      90,
+		ExpectedBody:  "alive",
+		ExpectedCodes: "2xx",
+		Port:          8080,
+
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
+		ProbeZone:       "example.com",
+	}
+
+	_, err := client.CreateAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(""), request)
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+
+	actual, err := client.CreateAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), request)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetAccountLoadBalancerMonitor(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", testAccountID, testAccountLoadBalancerMonitorIdentifier), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"type": "https",
+			"description": "Login page monitor",
+			"method": "GET",
+			"path": "/health",
+			"header": {
+			  "Host": [
+				"example.com"
+			  ],
+			  "X-App-ID": [
+				"abc123"
+			  ]
+			},
+			"port": 8080,
+			"timeout": 3,
+			"retries": 0,
+			"interval": 90,
+			"expected_body": "alive",
+			"expected_codes": "2xx",
+			"follow_redirects": true,
+			"allow_insecure": true,
+			"consecutive_up": 3,
+			"consecutive_down": 2,
+			"probe_zone": "example.com"
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	want := AccountLoadBalancerMonitor{
+		ID:          testAccountLoadBalancerMonitorIdentifier,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Type:        "https",
+		Description: "Login page monitor",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Port:            8080,
+		Timeout:         3,
+		Retries:         0,
+		Interval:        90,
+		ExpectedBody:    "alive",
+		ExpectedCodes:   "2xx",
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
+		ProbeZone:       "example.com",
+	}
+
+	_, err := client.GetAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(""), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	_, err = client.GetAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerMonitorIdentifier, err)
+	}
+
+	result, err := client.GetAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), testAccountLoadBalancerMonitorIdentifier)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, result)
+	}
+}
+
+func TestModifyAccountLoadBalancerMonitor(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", testAccountID, testAccountLoadBalancerMonitorIdentifier), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		b, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		if assert.NoError(t, err) {
+			assert.JSONEq(t, `{
+			  "id": "f1aba936b94213e5b8dca0c0dbf1f9cc",	
+			  "type": "https",
+			  "description": "Login page monitor",
+			  "method": "GET",
+			  "path": "/health",
+			  "header": {
+				"Host": [
+				  "example.com"
+				],
+				"X-App-ID": [
+				  "abc123"
+				]
+			  },
+			  "port": 8080,
+			  "timeout": 3,
+			  "retries": 0,
+			  "interval": 90,
+			  "expected_body": "kicking",
+			  "expected_codes": "2xx",
+			  "follow_redirects": true,
+			  "allow_insecure": true,
+			  "consecutive_up": 3,
+			  "consecutive_down": 2,
+			  "probe_zone": "example.com"
+			}`, string(b))
+		}
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"type": "https",
+			"description": "Login page monitor",
+			"method": "GET",
+			"path": "/health",
+			"header": {
+			  "Host": [
+				"example.com"
+			  ],
+			  "X-App-ID": [
+				"abc123"
+			  ]
+			},
+			"port": 8080,
+			"timeout": 3,
+			"retries": 0,
+			"interval": 90,
+			"expected_body": "kicking",
+			"expected_codes": "2xx",
+			"follow_redirects": true,
+			"allow_insecure": true,
+			"consecutive_up": 3,
+			"consecutive_down": 2,
+			"probe_zone": "example.com"
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	want := AccountLoadBalancerMonitor{
+		ID:          testAccountLoadBalancerMonitorIdentifier,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Type:        "https",
+		Description: "Login page monitor",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Port:          8080,
+		Timeout:       3,
+		Retries:       0,
+		Interval:      90,
+		ExpectedBody:  "kicking",
+		ExpectedCodes: "2xx",
+
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
+		ProbeZone:       "example.com",
+	}
+	request := AccountLoadBalancerMonitor{
+		ID:          testAccountLoadBalancerMonitorIdentifier,
+		Type:        "https",
+		Description: "Login page monitor",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Port:          8080,
+		Timeout:       3,
+		Retries:       0,
+		Interval:      90,
+		ExpectedBody:  "kicking",
+		ExpectedCodes: "2xx",
+
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
+		ProbeZone:       "example.com",
+	}
+
+	_, err := client.UpdateAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(""), request)
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+
+	_, err = client.UpdateAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerMonitor{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerMonitorIdentifier, err)
+	}
+
+	actual, err := client.UpdateAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), request)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestPatchAccountLoadBalancerMonitor(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", testAccountID, testAccountLoadBalancerMonitorIdentifier), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		b, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		if assert.NoError(t, err) {
+			assert.JSONEq(t, `{
+			  "id": "f1aba936b94213e5b8dca0c0dbf1f9cc",	
+			  "type": "https",
+			  "description": "Login page monitor",
+			  "method": "GET",
+			  "path": "/health",
+			  "header": {
+				"Host": [
+				  "example.com"
+				],
+				"X-App-ID": [
+				  "abc123"
+				]
+			  },
+			  "port": 8080,
+			  "timeout": 3,
+			  "retries": 0,
+			  "interval": 90,
+			  "expected_body": "kicking",
+			  "expected_codes": "2xx",
+			  "follow_redirects": true,
+			  "allow_insecure": true,
+			  "consecutive_up": 3,
+			  "consecutive_down": 2,
+			  "probe_zone": "example.com"
+			}`, string(b))
+		}
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"type": "https",
+			"description": "Login page monitor",
+			"method": "GET",
+			"path": "/health",
+			"header": {
+			  "Host": [
+				"example.com"
+			  ],
+			  "X-App-ID": [
+				"abc123"
+			  ]
+			},
+			"port": 8080,
+			"timeout": 3,
+			"retries": 0,
+			"interval": 90,
+			"expected_body": "kicking",
+			"expected_codes": "2xx",
+			"follow_redirects": true,
+			"allow_insecure": true,
+			"consecutive_up": 3,
+			"consecutive_down": 2,
+			"probe_zone": "example.com"
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	want := AccountLoadBalancerMonitor{
+		ID:          testAccountLoadBalancerMonitorIdentifier,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Type:        "https",
+		Description: "Login page monitor",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Port:          8080,
+		Timeout:       3,
+		Retries:       0,
+		Interval:      90,
+		ExpectedBody:  "kicking",
+		ExpectedCodes: "2xx",
+
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
+		ProbeZone:       "example.com",
+	}
+	request := AccountLoadBalancerMonitor{
+		ID:          testAccountLoadBalancerMonitorIdentifier,
+		Type:        "https",
+		Description: "Login page monitor",
+		Method:      http.MethodGet,
+		Path:        "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Port:          8080,
+		Timeout:       3,
+		Retries:       0,
+		Interval:      90,
+		ExpectedBody:  "kicking",
+		ExpectedCodes: "2xx",
+
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
+		ProbeZone:       "example.com",
+	}
+
+	_, err := client.PatchAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(""), request)
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+
+	_, err = client.PatchAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerMonitor{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerMonitorIdentifier, err)
+	}
+
+	actual, err := client.PatchAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), request)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestDeleteAccountLoadBalancerMonitor(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", testAccountID, testAccountLoadBalancerMonitorIdentifier), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+            "success": true,
+            "errors": [],
+            "messages": [],
+            "result": {
+              "id": "f1aba936b94213e5b8dca0c0dbf1f9cc"
+            }
+        }`)
+	})
+
+	err := client.DeleteAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(""), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	err = client.DeleteAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerMonitorIdentifier, err)
+	}
+
+	assert.NoError(t, client.DeleteAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), testAccountLoadBalancerMonitorIdentifier))
+	assert.Error(t, client.DeleteAccountLoadBalancerMonitor(context.Background(), AccountIdentifier(testAccountID), "invalid"))
+}

--- a/account_load_balancer_montiors.go
+++ b/account_load_balancer_montiors.go
@@ -1,0 +1,269 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var ErrMissingAccountLoadBalancerMonitorIdentifier = errors.New("require missing account load balancer identifier not found")
+
+type AccountLoadBalancerMonitor struct {
+	ID              string              `json:"id,omitempty"`
+	CreatedOn       *time.Time          `json:"created_on,omitempty"`
+	ModifiedOn      *time.Time          `json:"modified_on,omitempty"`
+	Type            string              `json:"type"`
+	Description     string              `json:"description"`
+	Method          string              `json:"method"`
+	Path            string              `json:"path"`
+	Header          map[string][]string `json:"header"`
+	Port            int                 `json:"port"`
+	Timeout         int                 `json:"timeout"`
+	Retries         int                 `json:"retries"`
+	Interval        int                 `json:"interval"`
+	ExpectedBody    string              `json:"expected_body"`
+	ExpectedCodes   string              `json:"expected_codes"`
+	FollowRedirects bool                `json:"follow_redirects"`
+	AllowInsecure   bool                `json:"allow_insecure"`
+	ConsecutiveUp   int                 `json:"consecutive_up,omitempty"`
+	ConsecutiveDown int                 `json:"consecutive_down,omitempty"`
+	ProbeZone       string              `json:"probe_zone"`
+}
+
+type PreviewAccountLoadBalancerMonitor struct {
+	PreviewID string            `json:"preview_id"`
+	Pools     map[string]string `json:"pools"`
+}
+
+// TODO: Check API Response
+type PreviewAccountLoadBalancerMonitorResult struct {
+}
+
+type ListAccountLoadBalancerMonitorResponse struct {
+	Result []AccountLoadBalancerMonitor `json:"result"`
+	Response
+}
+
+type CreateAccountLoadBalancerMonitorResponse struct {
+	Result AccountLoadBalancerMonitor `json:"result"`
+	Response
+}
+type GetAccountLoadBalancerMonitorResponse struct {
+	Result AccountLoadBalancerMonitor `json:"result"`
+	Response
+}
+
+type UpdateAccountLoadBalancerMonitorResponse struct {
+	Result AccountLoadBalancerMonitor `json:"result"`
+	Response
+}
+type PatchAccountLoadBalancerMonitorResponse struct {
+	Result AccountLoadBalancerMonitor `json:"result"`
+	Response
+}
+
+type PreviewAccountLoadBalancerMonitorParameters struct {
+	Identifier string `json:"-"`
+	AccountLoadBalancerMonitor
+}
+
+type PreviewAccountLoadBalancerMonitorResponse struct {
+	Result PreviewAccountLoadBalancerMonitor `json:"result"`
+	Response
+}
+
+type PreviewAccountLoadBalancerMonitorResultResponse struct {
+	Result PreviewAccountLoadBalancerMonitorResult `json:"result"`
+	Response
+}
+
+// ListAccountLoadBalancerMonitors List configured monitors for an account.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-list-monitors
+func (api *API) ListAccountLoadBalancerMonitors(ctx context.Context, rc *ResourceContainer) ([]AccountLoadBalancerMonitor, error) {
+	if rc.Identifier == "" {
+		return []AccountLoadBalancerMonitor{}, ErrMissingAccountID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors", rc.Identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []AccountLoadBalancerMonitor{}, err
+	}
+
+	var result ListAccountLoadBalancerMonitorResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return []AccountLoadBalancerMonitor{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// CreateAccountLoadBalancerMonitor Create a configured monitor.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-create-monitor
+func (api *API) CreateAccountLoadBalancerMonitor(ctx context.Context, rc *ResourceContainer, params AccountLoadBalancerMonitor) (AccountLoadBalancerMonitor, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerMonitor{}, ErrMissingAccountID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors", rc.Identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, err
+	}
+
+	var result CreateAccountLoadBalancerMonitorResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// GetAccountLoadBalancerMonitor List a single configured monitor for an account.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-monitor-details
+func (api *API) GetAccountLoadBalancerMonitor(ctx context.Context, rc *ResourceContainer, identifier string) (AccountLoadBalancerMonitor, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerMonitor{}, ErrMissingAccountID
+	}
+
+	if identifier == "" {
+		return AccountLoadBalancerMonitor{}, ErrMissingAccountLoadBalancerMonitorIdentifier
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", rc.Identifier, identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, err
+	}
+
+	var result GetAccountLoadBalancerMonitorResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// UpdateAccountLoadBalancerMonitor Modify a configured monitor.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-update-monitor
+func (api *API) UpdateAccountLoadBalancerMonitor(ctx context.Context, rc *ResourceContainer, params AccountLoadBalancerMonitor) (AccountLoadBalancerMonitor, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerMonitor{}, ErrMissingAccountID
+	}
+	if params.ID == "" {
+		return AccountLoadBalancerMonitor{}, ErrMissingAccountLoadBalancerMonitorIdentifier
+	}
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", rc.Identifier, params.ID)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, err
+	}
+
+	var result GetAccountLoadBalancerMonitorResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// PatchAccountLoadBalancerMonitor Apply changes to an existing monitor, overwriting the supplied properties.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-patch-monitor
+func (api *API) PatchAccountLoadBalancerMonitor(ctx context.Context, rc *ResourceContainer, params AccountLoadBalancerMonitor) (AccountLoadBalancerMonitor, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerMonitor{}, ErrMissingAccountID
+	}
+	if params.ID == "" {
+		return AccountLoadBalancerMonitor{}, ErrMissingAccountLoadBalancerMonitorIdentifier
+	}
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", rc.Identifier, params.ID)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, err
+	}
+
+	var result GetAccountLoadBalancerMonitorResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return AccountLoadBalancerMonitor{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// DeleteAccountLoadBalancerMonitor Delete a configured monitor.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-delete-monitor
+func (api *API) DeleteAccountLoadBalancerMonitor(ctx context.Context, rc *ResourceContainer, identifier string) error {
+	if rc.Identifier == "" {
+		return ErrMissingAccountID
+	}
+	if identifier == "" {
+		return ErrMissingAccountLoadBalancerMonitorIdentifier
+	}
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s", rc.Identifier, identifier)
+	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	return err
+}
+
+// PreviewAccountLoadBalancerMonitor Preview pools using the specified monitor with provided monitor details. The returned preview_id can be used in the preview endpoint to retrieve the results.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-preview-monitor
+func (api *API) PreviewAccountLoadBalancerMonitor(ctx context.Context, rc *ResourceContainer, params PreviewAccountLoadBalancerMonitorParameters) (PreviewAccountLoadBalancerMonitor, error) {
+	if rc.Identifier == "" {
+		return PreviewAccountLoadBalancerMonitor{}, ErrMissingAccountID
+	}
+	if params.Identifier == "" {
+		return PreviewAccountLoadBalancerMonitor{}, ErrMissingAccountLoadBalancerMonitorIdentifier
+	}
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors/%s/preview", rc.Identifier, params.Identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return PreviewAccountLoadBalancerMonitor{}, err
+	}
+
+	var result PreviewAccountLoadBalancerMonitorResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return PreviewAccountLoadBalancerMonitor{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// PreviewAccountLoadBalancerResult Get the result of a previous preview operation using the provided preview_id.
+// TODO: Verify API RESPONSE
+// API reference: https://api.cloudflare.com/#account-load-balancer-monitors-preview-monitor
+func (api *API) PreviewAccountLoadBalancerResult(ctx context.Context, rc *ResourceContainer, previewID string) (PreviewAccountLoadBalancerMonitorResult, error) {
+	if rc.Identifier == "" {
+		return PreviewAccountLoadBalancerMonitorResult{}, ErrMissingAccountID
+	}
+	if previewID == "" {
+		return PreviewAccountLoadBalancerMonitorResult{}, errors.New("require previewID is missing")
+	}
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/monitors/preview/%s", rc.Identifier, previewID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return PreviewAccountLoadBalancerMonitorResult{}, err
+	}
+
+	var result PreviewAccountLoadBalancerMonitorResultResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return PreviewAccountLoadBalancerMonitorResult{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}

--- a/account_load_balancer_pools.go
+++ b/account_load_balancer_pools.go
@@ -1,0 +1,354 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var ErrMissingAccountLoadBalancerPoolID = errors.New("require missing account load balancer pool ID")
+
+// AccountLoadBalancerPool represents a load balancer pool's properties.
+type AccountLoadBalancerPool struct {
+	ID                 string                                 `json:"id,omitempty"`
+	CreatedOn          *time.Time                             `json:"created_on,omitempty"`
+	ModifiedOn         *time.Time                             `json:"modified_on,omitempty"`
+	Description        string                                 `json:"description"`
+	Name               string                                 `json:"name"`
+	Enabled            bool                                   `json:"enabled"`
+	MinimumOrigins     int                                    `json:"minimum_origins,omitempty"`
+	Monitor            string                                 `json:"monitor,omitempty"`
+	Origins            []AccountLoadBalancerOrigin            `json:"origins"`
+	NotificationEmail  string                                 `json:"notification_email,omitempty"`
+	NotificationFilter *AccountLoadBalancerNotificationFilter `json:"notification_filter,omitempty"`
+	// ToDO: Figure out how to handle these.
+	//Latitude           *float32                               `json:"latitude,omitempty"`
+	//Longitude          *float32                               `json:"longitude,omitempty"`
+	LoadShedding   *AccountLoadBalancerPoolLoadShedding `json:"load_shedding,omitempty"`
+	OriginSteering *AccountLoadBalancerOriginSteering   `json:"origin_steering,omitempty"`
+
+	// CheckRegions defines the geographic region(s) from where to run health-checks from - e.g. "WNAM", "WEU", "SAF", "SAM".
+	// Providing a null/empty value means "all regions", which may not be available to all plan types.
+	CheckRegions []string `json:"check_regions"`
+}
+
+// AccountLoadBalancerOrigin represents a Load Balancer origin's properties.
+type AccountLoadBalancerOrigin struct {
+	Name    string              `json:"name"`
+	Address string              `json:"address"`
+	Enabled bool                `json:"enabled"`
+	Weight  float64             `json:"weight"`
+	Header  map[string][]string `json:"header"`
+}
+
+// AccountLoadBalancerOriginSteering controls origin selection for new sessions and traffic without session affinity.
+type AccountLoadBalancerOriginSteering struct {
+	// Policy defaults to "random" (weighted) when empty or unspecified.
+	Policy string `json:"policy,omitempty"`
+}
+
+// AccountLoadBalancerPoolLoadShedding contains the settings for controlling load shedding.
+type AccountLoadBalancerPoolLoadShedding struct {
+	DefaultPercent float32 `json:"default_percent"`
+	DefaultPolicy  string  `json:"default_policy"`
+	SessionPercent float32 `json:"session_percent"`
+	SessionPolicy  string  `json:"session_policy"`
+}
+
+type AccountLoadBalancerNotificationFilter struct {
+	Origin *AccountLoadBalancerNotificationResourceType `json:"origin"`
+	Pool   *AccountLoadBalancerNotificationResourceType `json:"pool"`
+}
+
+// AccountLoadBalancerPoolHealth represents the healthchecks from different PoPs for a pool.
+type AccountLoadBalancerPoolHealth struct {
+	ID        string                                      `json:"pool_id,omitempty"`
+	PopHealth map[string]AccountLoadBalancerPoolPopHealth `json:"pop_health,omitempty"`
+}
+
+// AccountLoadBalancerPoolPopHealth represents the health of the pool for given PoP.
+type AccountLoadBalancerPoolPopHealth struct {
+	Healthy bool                                         `json:"healthy,omitempty"`
+	Origins []map[string]AccountLoadBalancerOriginHealth `json:"origins,omitempty"`
+}
+
+// AccountLoadBalancerOriginHealth represents the health of the origin.
+type AccountLoadBalancerOriginHealth struct {
+	Healthy       bool     `json:"healthy,omitempty"`
+	RTT           Duration `json:"rtt,omitempty"`
+	FailureReason string   `json:"failure_reason,omitempty"`
+	ResponseCode  int      `json:"response_code,omitempty"`
+}
+
+type AccountLoadBalancerNotificationResourceType struct {
+	Disable bool        `json:"disable"`
+	Healthy interface{} `json:"healthy"`
+}
+
+type AccountLoadBalancerPoolPreviewParameters struct {
+	ID              string              `json:"-"`
+	Port            int                 `json:"port"`
+	Method          string              `json:"method"`
+	Timeout         int                 `json:"timeout"`
+	Path            string              `json:"path"`
+	Retries         int                 `json:"retries"`
+	FollowRedirects bool                `json:"follow_redirects"`
+	ExpectedBody    string              `json:"expected_body"`
+	ExpectedCodes   string              `json:"expected_codes"`
+	Header          map[string][]string `json:"header"`
+	AllowInsecure   bool                `json:"allow_insecure"`
+	Type            string              `json:"type"`
+	ProbeZone       string              `json:"probe_zone"`
+}
+
+type AccountLoadBalancerPoolPreview struct {
+	PreviewID string            `json:"preview_id"`
+	Pools     map[string]string `json:"pools"`
+}
+
+type AccountLoadBalancerPoolReferences struct {
+	ResourceID    string `json:"resource_id"`
+	ResourceName  string `json:"resource_name"`
+	ResourceType  string `json:"resource_type"`
+	ReferenceType string `json:"reference_type"`
+}
+
+// AccountLoadBalancerPoolResponse represents the response from the load balancer pool endpoints.
+type AccountLoadBalancerPoolResponse struct {
+	Result AccountLoadBalancerPool `json:"result"`
+	Response
+}
+
+// ListAccountLoadBalancerPoolResponse represents the response from the load balancer pool endpoints.
+type ListAccountLoadBalancerPoolResponse struct {
+	Result []AccountLoadBalancerPool `json:"result"`
+	Response
+}
+
+type GetAccountLoadBalancerPoolResponse struct {
+	Result AccountLoadBalancerPool `json:"result"`
+	Response
+}
+
+type GetAccountLoadBalancerPoolHealthResponse struct {
+	Result AccountLoadBalancerPoolHealth `json:"result"`
+	Response
+}
+
+type PreviewAccountLoadBalancerPoolResponse struct {
+	Result AccountLoadBalancerPoolPreview `json:"result"`
+	Response
+}
+
+type ListAccountLoadBalancerPoolReferencesResponse struct {
+	Result []AccountLoadBalancerPoolReferences `json:"result"`
+	Response
+}
+
+// CreateAccountLoadBalancerPool creates a new account load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-create-pool
+func (api *API) CreateAccountLoadBalancerPool(ctx context.Context, rc *ResourceContainer, pool AccountLoadBalancerPool) (AccountLoadBalancerPool, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerPool{}, ErrMissingAccountID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools", rc.Identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, pool)
+	if err != nil {
+		return AccountLoadBalancerPool{}, err
+	}
+	var r AccountLoadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return AccountLoadBalancerPool{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}
+
+// ListAccountLoadBalancerPools lists load balancer pools connected to an account.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-list-pools
+func (api *API) ListAccountLoadBalancerPools(ctx context.Context, rc *ResourceContainer, monitor string) ([]AccountLoadBalancerPool, error) {
+	if rc.Identifier == "" {
+		return []AccountLoadBalancerPool{}, ErrMissingAccountID
+	}
+
+	uri := buildURI(fmt.Sprintf("/accounts/%s/load_balancers/pools", rc.Identifier), monitor)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var r ListAccountLoadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}
+
+// GetAccountLoadBalancerPool Fetch a single configured pool.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-pool-details
+func (api *API) GetAccountLoadBalancerPool(ctx context.Context, rc *ResourceContainer, poolID string) (AccountLoadBalancerPool, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerPool{}, ErrMissingAccountID
+	}
+	if poolID == "" {
+		return AccountLoadBalancerPool{}, ErrMissingAccountLoadBalancerPoolID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", rc.Identifier, poolID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return AccountLoadBalancerPool{}, err
+	}
+	var r GetAccountLoadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return AccountLoadBalancerPool{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}
+
+// GetAccountLoadBalancerPoolHeath Fetch the latest pool health status for a single pool.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-pool-health-details
+func (api *API) GetAccountLoadBalancerPoolHeath(ctx context.Context, rc *ResourceContainer, poolID string) (AccountLoadBalancerPoolHealth, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerPoolHealth{}, ErrMissingAccountID
+	}
+	if poolID == "" {
+		return AccountLoadBalancerPoolHealth{}, ErrMissingAccountLoadBalancerPoolID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools/%s/health", rc.Identifier, poolID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return AccountLoadBalancerPoolHealth{}, err
+	}
+	var r GetAccountLoadBalancerPoolHealthResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return AccountLoadBalancerPoolHealth{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}
+
+// UpdateAccountLoadBalancerPool modifies a configured load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-update-pool
+func (api *API) UpdateAccountLoadBalancerPool(ctx context.Context, rc *ResourceContainer, pool AccountLoadBalancerPool) (AccountLoadBalancerPool, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerPool{}, ErrMissingAccountID
+	}
+	if pool.ID == "" {
+		return AccountLoadBalancerPool{}, ErrMissingAccountLoadBalancerPoolID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", rc.Identifier, pool.ID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, pool)
+	if err != nil {
+		return AccountLoadBalancerPool{}, err
+	}
+
+	var r AccountLoadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return AccountLoadBalancerPool{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}
+
+// PatchAccountLoadBalancerPool Apply changes to an existing pool, overwriting the supplied properties.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-patch-pool
+func (api *API) PatchAccountLoadBalancerPool(ctx context.Context, rc *ResourceContainer, params AccountLoadBalancerPool) (AccountLoadBalancerPool, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerPool{}, ErrMissingAccountID
+	}
+
+	if params.ID == "" {
+		return AccountLoadBalancerPool{}, ErrMissingAccountLoadBalancerPoolID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", rc.Identifier, params.ID)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return AccountLoadBalancerPool{}, err
+	}
+
+	var result AccountLoadBalancerPoolResponse
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return AccountLoadBalancerPool{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// DeleteAccountLoadBalancerPool Delete a configured pool.
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-delete-pool
+func (api *API) DeleteAccountLoadBalancerPool(ctx context.Context, rc *ResourceContainer, poolID string) error {
+	if rc.Identifier == "" {
+		return ErrMissingAccountID
+	}
+	if poolID == "" {
+		return ErrMissingAccountLoadBalancerPoolID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", rc.Identifier, poolID)
+	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	return err
+}
+
+// PreviewAccountLoadBalancerPool Preview pool health using provided monitor details. The returned preview_id can be used in the preview endpoint to retrieve the results..
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-preview-pool
+func (api *API) PreviewAccountLoadBalancerPool(ctx context.Context, rc *ResourceContainer, params AccountLoadBalancerPoolPreviewParameters) (AccountLoadBalancerPoolPreview, error) {
+	if rc.Identifier == "" {
+		return AccountLoadBalancerPoolPreview{}, ErrMissingAccountID
+	}
+	if params.ID == "" {
+		return AccountLoadBalancerPoolPreview{}, ErrMissingAccountLoadBalancerPoolID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools/%s/preview", rc.Identifier, params.ID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
+	if err != nil {
+		return AccountLoadBalancerPoolPreview{}, err
+	}
+	var r PreviewAccountLoadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return AccountLoadBalancerPoolPreview{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}
+
+// ListAccountLoadBalancerPoolReferences Preview pool health using provided monitor details. The returned preview_id can be used in the preview endpoint to retrieve the results..
+//
+// API reference: https://api.cloudflare.com/#account-load-balancer-pools-list-pool-references
+func (api *API) ListAccountLoadBalancerPoolReferences(ctx context.Context, rc *ResourceContainer, poolID string) ([]AccountLoadBalancerPoolReferences, error) {
+	if rc.Identifier == "" {
+		return []AccountLoadBalancerPoolReferences{}, ErrMissingAccountID
+	}
+	if poolID == "" {
+		return []AccountLoadBalancerPoolReferences{}, ErrMissingAccountLoadBalancerPoolID
+	}
+
+	uri := fmt.Sprintf("/accounts/%s/load_balancers/pools/%s/references", rc.Identifier, poolID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, nil)
+	if err != nil {
+		return []AccountLoadBalancerPoolReferences{}, err
+	}
+	var r ListAccountLoadBalancerPoolReferencesResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return []AccountLoadBalancerPoolReferences{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}

--- a/account_load_balancer_pools_test.go
+++ b/account_load_balancer_pools_test.go
@@ -1,0 +1,1058 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const testAccountLoadBalancerPoolID = "17b5962d775c646f3f9725cbc7a53df4"
+
+func TestListAccountLoadBalancerPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": [{
+			"id": "17b5962d775c646f3f9725cbc7a53df4",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"description": "Primary data center - Provider XYZ",
+			"name": "primary-dc-1",
+			"enabled": false,
+			"load_shedding": {
+			  "default_percent": 0,
+			  "default_policy": "random",
+			  "session_percent": 0,
+			  "session_policy": "hash"
+			},
+			"minimum_origins": 2,
+			"monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"check_regions": [
+			  "WEU",
+			  "ENAM"
+			],
+			"origins": [
+			  {
+				"name": "app-server-1",
+				"address": "0.0.0.0",
+				"enabled": true,
+				"weight": 0.56,
+				"header": {
+				  "Host": [
+					"example.com"
+				  ]
+				}
+			  }
+			],
+			"origin_steering": {
+			  "policy": "random"
+			},
+			"notification_email": "someone@example.com,sometwo@example.com",
+			"notification_filter": {
+			  "origin": {
+				"disable": false,
+				"healthy": null
+			  },
+			  "pool": {
+				"disable": false,
+				"healthy": null
+			  }
+			}
+		  }]
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	//longitude := float32(01.23)
+	//latitude := float32(01.23)
+	want := []AccountLoadBalancerPool{
+		{
+			ID:          testAccountLoadBalancerPoolID,
+			CreatedOn:   &createdOn,
+			ModifiedOn:  &modifiedOn,
+			Description: "Primary data center - Provider XYZ",
+			Name:        "primary-dc-1",
+			Enabled:     false,
+			LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+				DefaultPercent: 0,
+				DefaultPolicy:  "random",
+				SessionPercent: 0,
+				SessionPolicy:  "hash",
+			},
+			MinimumOrigins: 2,
+			Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			CheckRegions:   []string{"WEU", "ENAM"},
+			Origins: []AccountLoadBalancerOrigin{
+				{
+					Name:    "app-server-1",
+					Address: "0.0.0.0",
+					Enabled: true,
+					Weight:  0.56,
+					Header: map[string][]string{
+						"Host": {"example.com"},
+					},
+				},
+			},
+			OriginSteering: &AccountLoadBalancerOriginSteering{
+				Policy: "random",
+			},
+			NotificationEmail: "someone@example.com,sometwo@example.com",
+			NotificationFilter: &AccountLoadBalancerNotificationFilter{
+				Origin: &AccountLoadBalancerNotificationResourceType{
+					Disable: false,
+					Healthy: nil,
+				},
+				Pool: &AccountLoadBalancerNotificationResourceType{
+					Disable: false,
+					Healthy: nil,
+				},
+			},
+			//Longitude: &longitude,
+			//Latitude:  &latitude,
+
+		},
+	}
+
+	_, err := client.ListAccountLoadBalancerPools(context.Background(), AccountIdentifier(""), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+
+	actual, err := client.ListAccountLoadBalancerPools(context.Background(), AccountIdentifier(testAccountID), "")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateAccountLoadBalancerPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools", testAccountID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		b, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		if assert.NoError(t, err) {
+			assert.JSONEq(t, `{
+			  "description": "Primary data center - Provider XYZ",
+			  "name": "primary-dc-1",
+			  "enabled": false,
+			  "load_shedding": {
+				"default_percent": 0,
+				"default_policy": "random",
+				"session_percent": 0,
+				"session_policy": "hash"
+			  },
+			  "minimum_origins": 2,
+			  "monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			  "check_regions": [
+			  	"WEU",
+			  	"ENAM"
+				],
+			  "origins": [
+				{
+				  "name": "app-server-1",
+				  "address": "0.0.0.0",
+				  "enabled": true,
+				  "weight": 0.56,
+				  "header": {
+					"Host": [
+					  "example.com"
+					]
+				  }
+				}
+			  ],
+			  "origin_steering": {
+				"policy": "random"
+			  },
+			  "notification_email": "someone@example.com,sometwo@example.com",
+			  "notification_filter": {
+				"origin": {
+				  "disable": false,
+				  "healthy": null
+				},
+				"pool": {
+				  "disable": false,
+				  "healthy": null
+				}
+			  }
+			}`, string(b))
+		}
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "17b5962d775c646f3f9725cbc7a53df4",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"description": "Primary data center - Provider XYZ",
+			"name": "primary-dc-1",
+			"enabled": false,
+			"load_shedding": {
+			  "default_percent": 0,
+			  "default_policy": "random",
+			  "session_percent": 0,
+			  "session_policy": "hash"
+			},
+			"minimum_origins": 2,
+			"monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"check_regions": [
+			  "WEU",
+			  "ENAM"
+			],
+			"origins": [
+			  {
+				"name": "app-server-1",
+				"address": "0.0.0.0",
+				"enabled": true,
+				"weight": 0.56,
+				"header": {
+				  "Host": [
+					"example.com"
+				  ]
+				}
+			  }
+			],
+			"origin_steering": {
+			  "policy": "random"
+			},
+			"notification_email": "someone@example.com,sometwo@example.com",
+			"notification_filter": {
+			  "origin": {
+				"disable": false,
+				"healthy": null
+			  },
+			  "pool": {
+				"disable": false,
+				"healthy": null
+			  }
+			}
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	//longitude := float32(01.23)
+	//latitude := float32(01.23)
+	want := AccountLoadBalancerPool{
+		ID:          testAccountLoadBalancerPoolID,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Description: "Primary data center - Provider XYZ",
+		Name:        "primary-dc-1",
+		Enabled:     false,
+		LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+			DefaultPercent: 0,
+			DefaultPolicy:  "random",
+			SessionPercent: 0,
+			SessionPolicy:  "hash",
+		},
+		MinimumOrigins: 2,
+		Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		CheckRegions:   []string{"WEU", "ENAM"},
+		Origins: []AccountLoadBalancerOrigin{
+			{
+				Name:    "app-server-1",
+				Address: "0.0.0.0",
+				Enabled: true,
+				Weight:  0.56,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
+			},
+		},
+		OriginSteering: &AccountLoadBalancerOriginSteering{
+			Policy: "random",
+		},
+		NotificationEmail: "someone@example.com,sometwo@example.com",
+		NotificationFilter: &AccountLoadBalancerNotificationFilter{
+			Origin: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+			Pool: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+		},
+		//Longitude: &longitude,
+		//Latitude:  &latitude,
+	}
+	request := AccountLoadBalancerPool{
+		Description: "Primary data center - Provider XYZ",
+		Name:        "primary-dc-1",
+		Enabled:     false,
+		LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+			DefaultPercent: 0,
+			DefaultPolicy:  "random",
+			SessionPercent: 0,
+			SessionPolicy:  "hash",
+		},
+		MinimumOrigins: 2,
+		Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		CheckRegions:   []string{"WEU", "ENAM"},
+		Origins: []AccountLoadBalancerOrigin{
+			{
+				Name:    "app-server-1",
+				Address: "0.0.0.0",
+				Enabled: true,
+				Weight:  0.56,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
+			},
+		},
+		OriginSteering: &AccountLoadBalancerOriginSteering{
+			Policy: "random",
+		},
+		NotificationEmail: "someone@example.com,sometwo@example.com",
+		NotificationFilter: &AccountLoadBalancerNotificationFilter{
+			Origin: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+			Pool: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+		},
+		//Longitude: &longitude,
+		//Latitude:  &latitude,
+	}
+
+	_, err := client.CreateAccountLoadBalancerPool(context.Background(), AccountIdentifier(""), AccountLoadBalancerPool{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+
+	actual, err := client.CreateAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), request)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetAccountLoadBalancerPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", testAccountID, testAccountLoadBalancerPoolID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "17b5962d775c646f3f9725cbc7a53df4",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"description": "Primary data center - Provider XYZ",
+			"name": "primary-dc-1",
+			"enabled": false,
+			"load_shedding": {
+			  "default_percent": 0,
+			  "default_policy": "random",
+			  "session_percent": 0,
+			  "session_policy": "hash"
+			},
+			"minimum_origins": 2,
+			"monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"check_regions": [
+			  "WEU",
+			  "ENAM"
+			],
+			"origins": [
+			  {
+				"name": "app-server-1",
+				"address": "0.0.0.0",
+				"enabled": true,
+				"weight": 0.56,
+				"header": {
+				  "Host": [
+					"example.com"
+				  ]
+				}
+			  }
+			],
+			"origin_steering": {
+			  "policy": "random"
+			},
+			"notification_email": "someone@example.com,sometwo@example.com",
+			"notification_filter": {
+			  "origin": {
+				"disable": false,
+				"healthy": null
+			  },
+			  "pool": {
+				"disable": false,
+				"healthy": null
+			  }
+			}
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	//longitude := float32(01.23)
+	//latitude := float32(01.23)
+	want := AccountLoadBalancerPool{
+		ID:          testAccountLoadBalancerPoolID,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Description: "Primary data center - Provider XYZ",
+		Name:        "primary-dc-1",
+		Enabled:     false,
+		LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+			DefaultPercent: 0,
+			DefaultPolicy:  "random",
+			SessionPercent: 0,
+			SessionPolicy:  "hash",
+		},
+		MinimumOrigins: 2,
+		Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		CheckRegions:   []string{"WEU", "ENAM"},
+		Origins: []AccountLoadBalancerOrigin{
+			{
+				Name:    "app-server-1",
+				Address: "0.0.0.0",
+				Enabled: true,
+				Weight:  0.56,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
+			},
+		},
+		OriginSteering: &AccountLoadBalancerOriginSteering{
+			Policy: "random",
+		},
+		NotificationEmail: "someone@example.com,sometwo@example.com",
+		NotificationFilter: &AccountLoadBalancerNotificationFilter{
+			Origin: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+			Pool: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+		},
+		//Longitude: &longitude,
+		//Latitude:  &latitude,
+	}
+
+	_, err := client.GetAccountLoadBalancerPool(context.Background(), AccountIdentifier(""), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	_, err = client.GetAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerPoolID, err)
+	}
+
+	_, err = client.GetAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), "invalid")
+	assert.Error(t, err)
+
+	actual, err := client.GetAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), testAccountLoadBalancerPoolID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetAccountLoadBalancerPoolHealth(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools/%s/health", testAccountID, testAccountLoadBalancerPoolID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"pool_id": "17b5962d775c646f3f9725cbc7a53df4",
+			"pop_health": {
+			  "Amsterdam, NL": {
+				"healthy": true,
+				"origins": [
+				  {
+					"2001:DB8::5": {
+					  "healthy": true,
+					  "rtt": "12.1ms",
+					  "failure_reason": "No failures",
+					  "response_code": 401
+					}
+				  }
+				]
+			  }
+			}
+		  }
+		}`)
+	})
+	rtt, _ := time.ParseDuration("12.1ms")
+	want := AccountLoadBalancerPoolHealth{
+		ID: testAccountLoadBalancerPoolID,
+		PopHealth: map[string]AccountLoadBalancerPoolPopHealth{
+			"Amsterdam, NL": {
+				Healthy: true,
+				Origins: []map[string]AccountLoadBalancerOriginHealth{
+					{
+						"2001:DB8::5": {
+							Healthy:       true,
+							RTT:           Duration{rtt},
+							FailureReason: "No failures",
+							ResponseCode:  401,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := client.GetAccountLoadBalancerPoolHeath(context.Background(), AccountIdentifier(""), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	_, err = client.GetAccountLoadBalancerPoolHeath(context.Background(), AccountIdentifier(testAccountID), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerPoolID, err)
+	}
+
+	_, err = client.GetAccountLoadBalancerPoolHeath(context.Background(), AccountIdentifier(testAccountID), "invalid")
+	assert.Error(t, err)
+
+	actual, err := client.GetAccountLoadBalancerPoolHeath(context.Background(), AccountIdentifier(testAccountID), testAccountLoadBalancerPoolID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateAccountLoadBalancerPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", testAccountID, testAccountLoadBalancerPoolID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "17b5962d775c646f3f9725cbc7a53df4",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"description": "Primary data center - Provider XYZ",
+			"name": "primary-dc-1",
+			"enabled": false,
+			"load_shedding": {
+			  "default_percent": 0,
+			  "default_policy": "random",
+			  "session_percent": 0,
+			  "session_policy": "hash"
+			},
+			"minimum_origins": 2,
+			"monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"check_regions": [
+			  "WEU",
+			  "ENAM"
+			],
+			"origins": [
+			  {
+				"name": "app-server-1",
+				"address": "0.0.0.0",
+				"enabled": true,
+				"weight": 0.56,
+				"header": {
+				  "Host": [
+					"example.com"
+				  ]
+				}
+			  }
+			],
+			"origin_steering": {
+			  "policy": "random"
+			},
+			"notification_email": "someone@example.com,sometwo@example.com",
+			"notification_filter": {
+			  "origin": {
+				"disable": false,
+				"healthy": null
+			  },
+			  "pool": {
+				"disable": false,
+				"healthy": null
+			  }
+			}
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	//longitude := float32(01.23)
+	//latitude := float32(01.23)
+	want := AccountLoadBalancerPool{
+		ID:          testAccountLoadBalancerPoolID,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Description: "Primary data center - Provider XYZ",
+		Name:        "primary-dc-1",
+		Enabled:     false,
+		LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+			DefaultPercent: 0,
+			DefaultPolicy:  "random",
+			SessionPercent: 0,
+			SessionPolicy:  "hash",
+		},
+		MinimumOrigins: 2,
+		Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		CheckRegions:   []string{"WEU", "ENAM"},
+		Origins: []AccountLoadBalancerOrigin{
+			{
+				Name:    "app-server-1",
+				Address: "0.0.0.0",
+				Enabled: true,
+				Weight:  0.56,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
+			},
+		},
+		OriginSteering: &AccountLoadBalancerOriginSteering{
+			Policy: "random",
+		},
+		NotificationEmail: "someone@example.com,sometwo@example.com",
+		NotificationFilter: &AccountLoadBalancerNotificationFilter{
+			Origin: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+			Pool: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+		},
+		//Longitude: &longitude,
+		//Latitude:  &latitude,
+	}
+	request := AccountLoadBalancerPool{
+		ID:          testAccountLoadBalancerPoolID,
+		Description: "Primary data center - Provider XYZ",
+		Name:        "primary-dc-1",
+		Enabled:     false,
+		LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+			DefaultPercent: 0,
+			DefaultPolicy:  "random",
+			SessionPercent: 0,
+			SessionPolicy:  "hash",
+		},
+		MinimumOrigins: 2,
+		Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		CheckRegions:   []string{"WEU", "ENAM"},
+		Origins: []AccountLoadBalancerOrigin{
+			{
+				Name:    "app-server-1",
+				Address: "0.0.0.0",
+				Enabled: true,
+				Weight:  0.56,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
+			},
+		},
+		OriginSteering: &AccountLoadBalancerOriginSteering{
+			Policy: "random",
+		},
+		NotificationEmail: "someone@example.com,sometwo@example.com",
+		NotificationFilter: &AccountLoadBalancerNotificationFilter{
+			Origin: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+			Pool: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+		},
+		//Longitude: &longitude,
+		//Latitude:  &latitude,
+	}
+
+	_, err := client.UpdateAccountLoadBalancerPool(context.Background(), AccountIdentifier(""), AccountLoadBalancerPool{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	_, err = client.UpdateAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerPool{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerPoolID, err)
+	}
+	_, err = client.UpdateAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerPool{ID: "invalid"})
+	assert.Error(t, err)
+
+	actual, err := client.UpdateAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), request)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestPatchAccountLoadBalancerPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", testAccountID, testAccountLoadBalancerPoolID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"id": "17b5962d775c646f3f9725cbc7a53df4",
+			"created_on": "2014-01-01T05:20:00.12345Z",
+			"modified_on": "2014-02-01T05:20:00.12345Z",
+			"description": "Primary data center - Provider XYZ",
+			"name": "primary-dc-1",
+			"enabled": false,
+			"load_shedding": {
+			  "default_percent": 0,
+			  "default_policy": "random",
+			  "session_percent": 0,
+			  "session_policy": "hash"
+			},
+			"minimum_origins": 2,
+			"monitor": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"check_regions": [
+			  "WEU",
+			  "ENAM"
+			],
+			"origins": [
+			  {
+				"name": "app-server-1",
+				"address": "0.0.0.0",
+				"enabled": true,
+				"weight": 0.56,
+				"header": {
+				  "Host": [
+					"example.com"
+				  ]
+				}
+			  }
+			],
+			"origin_steering": {
+			  "policy": "random"
+			},
+			"notification_email": "someone@example.com,sometwo@example.com",
+			"notification_filter": {
+			  "origin": {
+				"disable": false,
+				"healthy": null
+			  },
+			  "pool": {
+				"disable": false,
+				"healthy": null
+			  }
+			}
+		  }
+		}`)
+	})
+
+	createdOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2014-02-01T05:20:00.12345Z")
+	//longitude := float32(01.23)
+	//latitude := float32(01.23)
+	want := AccountLoadBalancerPool{
+		ID:          testAccountLoadBalancerPoolID,
+		CreatedOn:   &createdOn,
+		ModifiedOn:  &modifiedOn,
+		Description: "Primary data center - Provider XYZ",
+		Name:        "primary-dc-1",
+		Enabled:     false,
+		LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+			DefaultPercent: 0,
+			DefaultPolicy:  "random",
+			SessionPercent: 0,
+			SessionPolicy:  "hash",
+		},
+		MinimumOrigins: 2,
+		Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		CheckRegions:   []string{"WEU", "ENAM"},
+		Origins: []AccountLoadBalancerOrigin{
+			{
+				Name:    "app-server-1",
+				Address: "0.0.0.0",
+				Enabled: true,
+				Weight:  0.56,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
+			},
+		},
+		OriginSteering: &AccountLoadBalancerOriginSteering{
+			Policy: "random",
+		},
+		NotificationEmail: "someone@example.com,sometwo@example.com",
+		NotificationFilter: &AccountLoadBalancerNotificationFilter{
+			Origin: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+			Pool: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+		},
+		//Longitude: &longitude,
+		//Latitude:  &latitude,
+	}
+	request := AccountLoadBalancerPool{
+		ID:          testAccountLoadBalancerPoolID,
+		Description: "Primary data center - Provider XYZ",
+		Name:        "primary-dc-1",
+		Enabled:     false,
+		LoadShedding: &AccountLoadBalancerPoolLoadShedding{
+			DefaultPercent: 0,
+			DefaultPolicy:  "random",
+			SessionPercent: 0,
+			SessionPolicy:  "hash",
+		},
+		MinimumOrigins: 2,
+		Monitor:        "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		CheckRegions:   []string{"WEU", "ENAM"},
+		Origins: []AccountLoadBalancerOrigin{
+			{
+				Name:    "app-server-1",
+				Address: "0.0.0.0",
+				Enabled: true,
+				Weight:  0.56,
+				Header: map[string][]string{
+					"Host": {"example.com"},
+				},
+			},
+		},
+		OriginSteering: &AccountLoadBalancerOriginSteering{
+			Policy: "random",
+		},
+		NotificationEmail: "someone@example.com,sometwo@example.com",
+		NotificationFilter: &AccountLoadBalancerNotificationFilter{
+			Origin: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+			Pool: &AccountLoadBalancerNotificationResourceType{
+				Disable: false,
+				Healthy: nil,
+			},
+		},
+		//Longitude: &longitude,
+		//Latitude:  &latitude,
+	}
+
+	_, err := client.PatchAccountLoadBalancerPool(context.Background(), AccountIdentifier(""), AccountLoadBalancerPool{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	_, err = client.PatchAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerPool{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerPoolID, err)
+	}
+	_, err = client.PatchAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerPool{ID: "invalid"})
+	assert.Error(t, err)
+
+	actual, err := client.PatchAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), request)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+}
+
+func TestDeleteAccountLoadBalancerPool(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools/%s", testAccountID, testAccountLoadBalancerPoolID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+            "success": true,
+            "errors": [],
+            "messages": [],
+            "result": {
+              "id": "f1aba936b94213e5b8dca0c0dbf1f9cc"
+            }
+        }`)
+	})
+
+	err := client.DeleteAccountLoadBalancerPool(context.Background(), AccountIdentifier(""), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	err = client.DeleteAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerPoolID, err)
+	}
+
+	assert.NoError(t, client.DeleteAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), testAccountLoadBalancerPoolID))
+	assert.Error(t, client.DeleteAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), "invalid"))
+}
+
+func TestPreviewAccountLoadBalancerPool(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools/%s/preview", testAccountID, testAccountLoadBalancerPoolID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		b, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+		if assert.NoError(t, err) {
+			assert.JSONEq(t, `{
+			  "type": "https",
+			  "method": "GET",
+			  "path": "/health",
+			  "header": {
+				"Host": [
+				  "example.com"
+				],
+				"X-App-ID": [
+				  "abc123"
+				]
+			  },
+			  "port": 8080,
+			  "timeout": 3,
+			  "retries": 0,
+			  "expected_body": "alive",
+			  "expected_codes": "2xx",
+			  "follow_redirects": true,
+			  "allow_insecure": true,
+			  "probe_zone": "example.com"
+			}`, string(b))
+		}
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": {
+			"preview_id": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			"pools": {
+			  "abwlnp5jbqn45ecgxd03erbgtxtqai0d": "WNAM Datacenter",
+			  "ve8h9lrcip5n5bbga9yqmdws28ay5d0l": "EEU Datacenter"
+			}
+		}
+  		}`)
+	})
+
+	request := AccountLoadBalancerPoolPreviewParameters{
+		ID:     testAccountLoadBalancerPoolID,
+		Type:   "https",
+		Method: "GET",
+		Path:   "/health",
+		Header: map[string][]string{
+			"Host":     {"example.com"},
+			"X-App-ID": {"abc123"},
+		},
+		Port:            8080,
+		Timeout:         3,
+		Retries:         0,
+		ExpectedBody:    "alive",
+		ExpectedCodes:   "2xx",
+		FollowRedirects: true,
+		AllowInsecure:   true,
+		ProbeZone:       "example.com",
+	}
+	want := AccountLoadBalancerPoolPreview{
+		PreviewID: "f1aba936b94213e5b8dca0c0dbf1f9cc",
+		Pools: map[string]string{
+			"abwlnp5jbqn45ecgxd03erbgtxtqai0d": "WNAM Datacenter",
+			"ve8h9lrcip5n5bbga9yqmdws28ay5d0l": "EEU Datacenter",
+		},
+	}
+	_, err := client.PreviewAccountLoadBalancerPool(context.Background(), AccountIdentifier(""), AccountLoadBalancerPoolPreviewParameters{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	_, err = client.PreviewAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerPoolPreviewParameters{})
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerPoolID, err)
+	}
+	_, err = client.PreviewAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), AccountLoadBalancerPoolPreviewParameters{ID: "invalid"})
+	assert.Error(t, err)
+
+	actual, err := client.PreviewAccountLoadBalancerPool(context.Background(), AccountIdentifier(testAccountID), request)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestListAccountLoadBalancerPoolReferences(t *testing.T) {
+	setup()
+	defer teardown()
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/load_balancers/pools/%s/references", testAccountID, testAccountLoadBalancerPoolID), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+		  "success": true,
+		  "errors": [],
+		  "messages": [],
+		  "result": [
+			{
+			  "resource_id": "699d98642c564d2e855e9661899b7252",
+			  "resource_name": "www.example.com",
+			  "resource_type": "load_balancer",
+			  "reference_type": "referrer"
+			},
+			{
+			  "resource_id": "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			  "resource_name": "Login page monitor",
+			  "resource_type": "monitor",
+			  "reference_type": "referral"
+			}
+		  ]
+		}`)
+	})
+
+	want := []AccountLoadBalancerPoolReferences{
+		{
+			ResourceID:    "699d98642c564d2e855e9661899b7252",
+			ResourceName:  "www.example.com",
+			ResourceType:  "load_balancer",
+			ReferenceType: "referrer",
+		},
+		{
+			ResourceID:    "f1aba936b94213e5b8dca0c0dbf1f9cc",
+			ResourceName:  "Login page monitor",
+			ResourceType:  "monitor",
+			ReferenceType: "referral",
+		},
+	}
+	_, err := client.ListAccountLoadBalancerPoolReferences(context.Background(), AccountIdentifier(""), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountID, err)
+	}
+	_, err = client.ListAccountLoadBalancerPoolReferences(context.Background(), AccountIdentifier(testAccountID), "")
+	if assert.Error(t, err) {
+		assert.Equal(t, ErrMissingAccountLoadBalancerPoolID, err)
+	}
+	_, err = client.ListAccountLoadBalancerPoolReferences(context.Background(), AccountIdentifier(testAccountID), "invalid")
+	assert.Error(t, err)
+
+	actual, err := client.ListAccountLoadBalancerPoolReferences(context.Background(), AccountIdentifier(testAccountID), testAccountLoadBalancerPoolID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}

--- a/account_load_balancer_pools_test.go
+++ b/account_load_balancer_pools_test.go
@@ -879,7 +879,6 @@ func TestPatchAccountLoadBalancerPool(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}
-
 }
 
 func TestDeleteAccountLoadBalancerPool(t *testing.T) {

--- a/load_balancing.go
+++ b/load_balancing.go
@@ -105,7 +105,7 @@ type LoadBalancerLoadShedding struct {
 	SessionPolicy  string  `json:"session_policy,omitempty"`
 }
 
-// LoadBalancerRule represents a single rule entry for a Load Balancer. Each rules
+// LoadBalancerRule represents a single rule entry for a Load Balancer. Each rule
 // is run one after the other in priority order. Disabled rules are skipped.
 type LoadBalancerRule struct {
 	Overrides LoadBalancerRuleOverrides `json:"overrides"`

--- a/load_balancing.go
+++ b/load_balancing.go
@@ -64,6 +64,8 @@ type LoadBalancerMonitor struct {
 	FollowRedirects bool                `json:"follow_redirects"`
 	AllowInsecure   bool                `json:"allow_insecure"`
 	ProbeZone       string              `json:"probe_zone"`
+	ConsecutiveUp   int                 `json:"consecutive_up"`
+	ConsecutiveDown int                 `json:"consecutive_down"`
 }
 
 // LoadBalancer represents a load balancer's properties.

--- a/load_balancing.go
+++ b/load_balancing.go
@@ -64,8 +64,6 @@ type LoadBalancerMonitor struct {
 	FollowRedirects bool                `json:"follow_redirects"`
 	AllowInsecure   bool                `json:"allow_insecure"`
 	ProbeZone       string              `json:"probe_zone"`
-	ConsecutiveUp   int                 `json:"consecutive_up"`
-	ConsecutiveDown int                 `json:"consecutive_down"`
 }
 
 // LoadBalancer represents a load balancer's properties.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -512,7 +512,9 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
               "expected_codes": "2xx",
               "follow_redirects": true,
               "allow_insecure": true,
-              "probe_zone": ""
+              "probe_zone": "",
+			  "consecutive_up": 0,
+			  "consecutive_down": 0
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -542,7 +544,9 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
                 "expected_codes": "2xx",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": ""
+                "probe_zone": "",
+				"consecutive_up": 0,
+			  	"consecutive_down": 0
             }
         }`)
 	}
@@ -570,6 +574,8 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
+		ConsecutiveUp:   0,
+		ConsecutiveDown: 0,
 	}
 	request := LoadBalancerMonitor{
 		Type:        "https",
@@ -588,6 +594,8 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
+		ConsecutiveUp:   0,
+		ConsecutiveDown: 0,
 	}
 
 	actual, err := client.CreateLoadBalancerMonitor(context.Background(), request)
@@ -661,6 +669,9 @@ func TestListLoadBalancerMonitors(t *testing.T) {
 			Interval:      90,
 			ExpectedBody:  "alive",
 			ExpectedCodes: "2xx",
+
+			ConsecutiveUp:   0,
+			ConsecutiveDown: 0,
 		},
 	}
 
@@ -704,7 +715,9 @@ func TestLoadBalancerMonitorDetails(t *testing.T) {
                 "expected_codes": "2xx",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": ""
+                "probe_zone": "",
+				"consecutive_up": 3,
+				"consecutive_down": 2
             }
         }`)
 	}
@@ -732,6 +745,8 @@ func TestLoadBalancerMonitorDetails(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
+		ConsecutiveUp:   3,
+		ConsecutiveDown: 2,
 	}
 
 	actual, err := client.LoadBalancerMonitorDetails(context.Background(), "f1aba936b94213e5b8dca0c0dbf1f9cc")
@@ -796,7 +811,9 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "expected_codes": "200",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": ""
+                "probe_zone": "",
+				"consecutive_up": 2,
+				"consecutive_down": 3
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -826,7 +843,9 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "expected_codes": "200",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": ""
+                "probe_zone": "",
+				"consecutive_up": 2,
+				"consecutive_down": 3
             }
         }`)
 	}
@@ -854,6 +873,8 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
+		ConsecutiveUp:   2,
+		ConsecutiveDown: 3,
 	}
 	request := LoadBalancerMonitor{
 		ID:          "f1aba936b94213e5b8dca0c0dbf1f9cc",
@@ -873,6 +894,8 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
+		ConsecutiveUp:   2,
+		ConsecutiveDown: 3,
 	}
 
 	actual, err := client.ModifyLoadBalancerMonitor(context.Background(), request)

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -512,10 +512,8 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
               "expected_codes": "2xx",
               "follow_redirects": true,
               "allow_insecure": true,
-              "probe_zone": "",
-			  "consecutive_up": 0,
-			  "consecutive_down": 0
-						}`, string(b))
+              "probe_zone": ""
+		}`, string(b))
 		}
 		fmt.Fprint(w, `{
             "success": true,
@@ -544,9 +542,7 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
                 "expected_codes": "2xx",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": "",
-				"consecutive_up": 0,
-			  	"consecutive_down": 0
+                "probe_zone": ""
             }
         }`)
 	}
@@ -574,8 +570,6 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
-		ConsecutiveUp:   0,
-		ConsecutiveDown: 0,
 	}
 	request := LoadBalancerMonitor{
 		Type:        "https",
@@ -594,8 +588,6 @@ func TestCreateLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
-		ConsecutiveUp:   0,
-		ConsecutiveDown: 0,
 	}
 
 	actual, err := client.CreateLoadBalancerMonitor(context.Background(), request)
@@ -669,9 +661,6 @@ func TestListLoadBalancerMonitors(t *testing.T) {
 			Interval:      90,
 			ExpectedBody:  "alive",
 			ExpectedCodes: "2xx",
-
-			ConsecutiveUp:   0,
-			ConsecutiveDown: 0,
 		},
 	}
 
@@ -715,9 +704,7 @@ func TestLoadBalancerMonitorDetails(t *testing.T) {
                 "expected_codes": "2xx",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": "",
-				"consecutive_up": 3,
-				"consecutive_down": 2
+                "probe_zone": ""
             }
         }`)
 	}
@@ -745,8 +732,6 @@ func TestLoadBalancerMonitorDetails(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
-		ConsecutiveUp:   3,
-		ConsecutiveDown: 2,
 	}
 
 	actual, err := client.LoadBalancerMonitorDetails(context.Background(), "f1aba936b94213e5b8dca0c0dbf1f9cc")
@@ -811,9 +796,7 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "expected_codes": "200",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": "",
-				"consecutive_up": 2,
-				"consecutive_down": 3
+                "probe_zone": ""
 						}`, string(b))
 		}
 		fmt.Fprint(w, `{
@@ -843,9 +826,7 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
                 "expected_codes": "200",
                 "follow_redirects": true,
                 "allow_insecure": true,
-                "probe_zone": "",
-				"consecutive_up": 2,
-				"consecutive_down": 3
+                "probe_zone": ""
             }
         }`)
 	}
@@ -873,8 +854,6 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
-		ConsecutiveUp:   2,
-		ConsecutiveDown: 3,
 	}
 	request := LoadBalancerMonitor{
 		ID:          "f1aba936b94213e5b8dca0c0dbf1f9cc",
@@ -894,8 +873,6 @@ func TestModifyLoadBalancerMonitor(t *testing.T) {
 
 		FollowRedirects: true,
 		AllowInsecure:   true,
-		ConsecutiveUp:   2,
-		ConsecutiveDown: 3,
 	}
 
 	actual, err := client.ModifyLoadBalancerMonitor(context.Background(), request)


### PR DESCRIPTION
## Description

Adds support for Account Load Balancer [Monitors ](https://api.cloudflare.com/#account-load-balancer-monitors-list-monitors) and [Pools](https://api.cloudflare.com/#account-load-balancer-pools-properties).
Needed for https://github.com/cloudflare/terraform-provider-cloudflare/issues/1876

## Has your change been tested?
Updated unit tests and they pass

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
