### PR TITLE
Additional context deadline handling in makeRequestWithAuthTypeAndHeadersComplete

### DIFF
--- a/.changelog/1080.txt
+++ b/.changelog/1080.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cloudflare: exiting closer to the source on context timeouts to better defend from potential edge cases
+cloudflare: exiting closer to the source on context timeouts to improve error messaging and better defend from potential edge cases
 ```

--- a/.changelog/1080.txt
+++ b/.changelog/1080.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cloudflare: exiting closer to the source on context timeouts to better defend from potential edge cases
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -285,6 +285,8 @@ func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, m
 
 				api.logger.Printf("Request: %s %s got an error response %d: %s\n", method, uri, resp.StatusCode,
 					strings.Replace(strings.Replace(string(respBody), "\n", "", -1), "\t", "", -1))
+			} else if errors.Is(respErr, context.DeadlineExceeded) {
+				return nil, respErr
 			} else {
 				api.logger.Printf("Error performing request: %s %s : %s \n", method, uri, respErr.Error())
 			}

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -268,8 +268,7 @@ func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, m
 
 		resp, respErr = api.request(ctx, method, uri, reqBody, authType, headers)
 
-		// no reason to go through retry/backoff logic on context timeouts as it delays the return
-		// and makes it less clear if the request timed out on retry due to a previous error or on context timeout
+		// short circuit processing on context timeouts
 		if respErr != nil && errors.Is(respErr, context.DeadlineExceeded) {
 			return nil, respErr
 		}

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -286,6 +286,8 @@ func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, m
 				api.logger.Printf("Request: %s %s got an error response %d: %s\n", method, uri, resp.StatusCode,
 					strings.Replace(strings.Replace(string(respBody), "\n", "", -1), "\t", "", -1))
 			} else if errors.Is(respErr, context.DeadlineExceeded) {
+				// no reason to go through backoff logic on context timeouts as it delays the return
+				// and makes it less clear about what happened
 				return nil, respErr
 			} else {
 				api.logger.Printf("Error performing request: %s %s : %s \n", method, uri, respErr.Error())


### PR DESCRIPTION
Currently, the request retry / backoff logic is being applied to requests that reached context timeout. While it still works as we account for context deadline, it may be better to exit immediately. It also indirectly helps to safeguard from regressions like the ones introduced in v0.48.0 (fixed by https://github.com/cloudflare/cloudflare-go/pull/1072) as the response body is nil when go http client exits on context deadline (less processing/potentially less bugs).

Now, the error will just say that we reached the deadline for that specific request and doesn't imply we applied backoff logic or retried the request. It doesn't take away from the ability to surface more specific errors.

Also updating TestContextTimeout to:

1) better readability
2) making use of an actual http endpoint and increasing timeout values to make sure we get to api.request function and not timing out on rate limiter
3) ability to run the test individually

## Has your change been tested?

Ran a request with short context timeout to reproduce the issue, confirmed it the expected result on timeout is long enough for a request to finish

```
	ctx, cncl := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(50))
	defer cncl()

	// Getting existing A records from the zone
	_, err = api.DNSRecords(ctx, "<zone id>", cloudflare.DNSRecord{
		Type: "A",
		Name: "domain",
	})
```

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
