### PR TITLE
fix: make request with auth type

### DIFF
--- a/.changelog/1082.txt
+++ b/.changelog/1082.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+origin certificate: Fix API auth type used
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -193,7 +193,7 @@ type APIResponse struct {
 }
 
 func (api *API) makeRequestWithAuthTypeAndHeaders(ctx context.Context, method, uri string, params interface{}, authType int, headers http.Header) ([]byte, error) {
-	res, err := api.makeRequestWithAuthTypeAndHeadersComplete(ctx, method, uri, params, api.authType, headers)
+	res, err := api.makeRequestWithAuthTypeAndHeadersComplete(ctx, method, uri, params, authType, headers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Simple fix for regression introduced in https://github.com/cloudflare/cloudflare-go/commit/873a91b42be9d4efa192605043b91b8cb9666fb2

Currently all makeRequestWithAuthType calls (so all origin_ca.go calls) are failing cause it's using api.authType rather then overridden AuthUserService auth type in this case.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
