### PR TITLE
flarectl: support list,create,delete zone and account logpush jobs

### DIFF
--- a/.changelog/1083.txt
+++ b/.changelog/1083.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+flarectl: support list,create,delete zone and account logpush jobs
+```
+```release-note:enhancement
+logpush: add support for `max_upload_bytes` and `max_upload_records` parameters
+```

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -52,6 +52,166 @@ func main() {
 			},
 		},
 		{
+			Name:    "logpush",
+			Aliases: []string{"lp"},
+			Usage:   "Logpush",
+			Before:  initializeAPI,
+			Subcommands: []*cli.Command{
+				{
+					Name:    "list",
+					Aliases: []string{"l"},
+					Action:  zoneLogpushJobs,
+					Usage:   "List Logpush jobs for a zone",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+					},
+				},
+				{
+					Name:    "list-account",
+					Aliases: []string{"la"},
+					Action:  accountLogpushJobs,
+					Usage:   "List Logpush jobs for an account",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "account-id",
+							Usage: "account ID",
+						},
+					},
+				},
+				{
+					Name:    "create",
+					Aliases: []string{"c"},
+					Action:  zoneCreateLogpushJob,
+					Usage:   "Create a new Logpush job for a zone",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "dataset",
+							Usage: "dataset",
+						},
+						&cli.StringFlag{
+							Name:  "destination-conf",
+							Usage: "destination conf",
+						},
+						&cli.BoolFlag{
+							Name:  "enabled",
+							Usage: "enabled",
+						},
+						&cli.StringFlag{
+							Name:  "filter",
+							Usage: "filter",
+						},
+						&cli.StringFlag{
+							Name:  "kind",
+							Usage: "kind",
+						},
+						&cli.StringFlag{
+							Name:  "logpull-options",
+							Usage: "logpull options",
+						},
+						&cli.StringFlag{
+							Name:  "max-upload-bytes",
+							Usage: "max upload bytes",
+						},
+						&cli.StringFlag{
+							Name:  "max-upload-records",
+							Usage: "max upload records",
+						},
+						&cli.StringFlag{
+							Name:  "name",
+							Usage: "job name",
+						},
+						&cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+					},
+				},
+				{
+					Name:    "create-account",
+					Aliases: []string{"ca"},
+					Action:  accountCreateLogpushJob,
+					Usage:   "Create a new Logpush job for an account",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "account-id",
+							Usage: "account ID",
+						},
+						&cli.StringFlag{
+							Name:  "dataset",
+							Usage: "dataset",
+						},
+						&cli.StringFlag{
+							Name:  "destination-conf",
+							Usage: "destination conf",
+						},
+						&cli.BoolFlag{
+							Name:  "enabled",
+							Usage: "enabled",
+						},
+						&cli.StringFlag{
+							Name:  "filter",
+							Usage: "filter",
+						},
+						&cli.StringFlag{
+							Name:  "kind",
+							Usage: "kind",
+						},
+						&cli.StringFlag{
+							Name:  "logpull-options",
+							Usage: "logpull options",
+						},
+						&cli.StringFlag{
+							Name:  "max-upload-bytes",
+							Usage: "max upload bytes",
+						},
+						&cli.StringFlag{
+							Name:  "max-upload-records",
+							Usage: "max upload records",
+						},
+						&cli.StringFlag{
+							Name:  "name",
+							Usage: "job name",
+						},
+					},
+				},
+				{
+					Name:    "delete",
+					Aliases: []string{"d"},
+					Action:  zoneDeleteLogpushJob,
+					Usage:   "Delete a Logpush job for a zone",
+					Flags: []cli.Flag{
+						&cli.IntFlag{
+							Name:  "id",
+							Usage: "job id",
+						},
+						&cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+					},
+				},
+				{
+					Name:    "delete-account",
+					Aliases: []string{"da"},
+					Action:  accountDeleteLogpushJob,
+					Usage:   "Delete a Logpush job for an account",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "account-id",
+							Usage: "account ID",
+						},
+						&cli.IntFlag{
+							Name:  "id",
+							Usage: "job id",
+						},
+					},
+				},
+			},
+		},
+		{
 			Name:    "user",
 			Aliases: []string{"u"},
 			Usage:   "User information",

--- a/cmd/flarectl/logpush.go
+++ b/cmd/flarectl/logpush.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/urfave/cli/v2"
+)
+
+func accountLogpushJobs(c *cli.Context) error {
+	if err := checkFlags(c, "account-id"); err != nil {
+		return err
+	}
+	accountID := c.String("account-id")
+
+	jobs, err := api.ListAccountLogpushJobs(context.Background(), accountID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	output, cols, err := outputLogpushJobs(jobs)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	writeTable(c, output, cols...)
+	return nil
+}
+
+func accountCreateLogpushJob(c *cli.Context) error {
+	if err := checkFlags(c, "dataset", "destination-conf", "account-id"); err != nil {
+		cli.ShowSubcommandHelp(c) //nolint
+		return err
+	}
+	accountID := c.String("account-id")
+
+	job := cloudflare.LogpushJob{
+		Dataset:         c.String("dataset"),
+		DestinationConf: c.String("destination-conf"),
+		Enabled:         c.Bool("enabled"),
+	}
+
+	var filter cloudflare.LogpushJobFilters
+	if f := c.String("filter"); f != "" {
+		err := json.Unmarshal([]byte(f), &filter)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		job.Filter = &filter
+	}
+
+	if k := c.String("kind"); k != "" {
+		job.Kind = k
+	}
+
+	if l := c.String("logpull-options"); l != "" {
+		job.LogpullOptions = l
+	}
+
+	if m := c.Int("max-upload-bytes"); m > 0 {
+		job.MaxUploadBytes = m
+	}
+
+	if m := c.Int("max-upload-records"); m > 0 {
+		job.MaxUploadRecords = m
+	}
+
+	if n := c.String("name"); n != "" {
+		job.Name = n
+	}
+
+	returnedJob, err := api.CreateAccountLogpushJob(context.Background(), accountID, job)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	output, cols, err := outputLogpushJobs([]cloudflare.LogpushJob{*returnedJob})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	writeTable(c, output, cols...)
+	return nil
+}
+
+func accountDeleteLogpushJob(c *cli.Context) error {
+	if err := checkFlags(c, "account-id"); err != nil {
+		cli.ShowSubcommandHelp(c) //nolint
+		return err
+	}
+	accountID := c.String("account-id")
+
+	jobID := c.Int("id")
+	if jobID <= 0 {
+		err := fmt.Errorf("error: the required flag 'id' was invalid or not provided")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	err := api.DeleteAccountLogpushJob(context.Background(), accountID, jobID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	return nil
+}
+
+func zoneLogpushJobs(c *cli.Context) error {
+	if err := checkFlags(c, "zone"); err != nil {
+		cli.ShowSubcommandHelp(c) //nolint
+		return err
+	}
+
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	jobs, err := api.ListZoneLogpushJobs(context.Background(), zoneID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	output, cols, err := outputLogpushJobs(jobs)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	writeTable(c, output, cols...)
+	return nil
+}
+
+func zoneCreateLogpushJob(c *cli.Context) error {
+	if err := checkFlags(c, "dataset", "destination-conf", "zone"); err != nil {
+		cli.ShowSubcommandHelp(c) //nolint
+		return err
+	}
+
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	job := cloudflare.LogpushJob{
+		Dataset:         c.String("dataset"),
+		DestinationConf: c.String("destination-conf"),
+		Enabled:         c.Bool("enabled"),
+	}
+
+	var filter cloudflare.LogpushJobFilters
+	if f := c.String("filter"); f != "" {
+		err := json.Unmarshal([]byte(f), &filter)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		job.Filter = &filter
+	}
+
+	if k := c.String("kind"); k != "" {
+		job.Kind = k
+	}
+
+	if l := c.String("logpull-options"); l != "" {
+		job.LogpullOptions = l
+	}
+
+	if m := c.Int("max-upload-bytes"); m > 0 {
+		job.MaxUploadBytes = m
+	}
+
+	if m := c.Int("max-upload-records"); m > 0 {
+		job.MaxUploadRecords = m
+	}
+
+	if n := c.String("name"); n != "" {
+		job.Name = n
+	}
+
+	returnedJob, err := api.CreateZoneLogpushJob(context.Background(), zoneID, job)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	output, cols, err := outputLogpushJobs([]cloudflare.LogpushJob{*returnedJob})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	writeTable(c, output, cols...)
+	return nil
+}
+
+func zoneDeleteLogpushJob(c *cli.Context) error {
+	if err := checkFlags(c, "zone"); err != nil {
+		cli.ShowSubcommandHelp(c) //nolint
+		return err
+	}
+
+	jobID := c.Int("id")
+	if jobID <= 0 {
+		err := fmt.Errorf("error: the required flag 'id' was invalid or not provided")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	zoneID, err := api.ZoneIDByName(c.String("zone"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	err = api.DeleteZoneLogpushJob(context.Background(), zoneID, jobID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	return nil
+}
+
+func outputLogpushJobs(jobs []cloudflare.LogpushJob) (output [][]string, cols []string, err error) {
+	for _, job := range jobs {
+		filter, err := json.Marshal(job.Filter)
+		if err != nil {
+			return [][]string{}, []string{}, err
+		}
+		var lastComplete, lastError string
+		if job.LastComplete != nil {
+			lastComplete = job.LastComplete.String()
+		}
+		if job.LastError != nil {
+			lastError = job.LastError.String()
+		}
+		output = append(output, []string{
+			fmt.Sprintf("%d", job.ID),
+			job.Name,
+			job.Dataset,
+			job.Frequency,
+			string(filter),
+			job.Kind,
+			job.DestinationConf,
+			job.LogpullOptions,
+			strconv.FormatBool(job.Enabled),
+			lastComplete,
+			lastError,
+			job.ErrorMessage,
+		})
+	}
+	cols = []string{
+		"ID", "Name", "Dataset", "Frequency", "Filter", "Kind", "DestinationConf",
+		"LogpullOptions", "Enabled", "LastComplete", "LastError", "ErrorMessage",
+	}
+	return output, cols, nil
+}

--- a/logpush.go
+++ b/logpush.go
@@ -3,11 +3,10 @@ package cloudflare
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
-
-	"errors"
 )
 
 // LogpushJob describes a Logpush job.
@@ -20,6 +19,8 @@ type LogpushJob struct {
 	LogpullOptions     string             `json:"logpull_options"`
 	DestinationConf    string             `json:"destination_conf"`
 	OwnershipChallenge string             `json:"ownership_challenge,omitempty"`
+	MaxUploadBytes     int                `json:"max_upload_bytes,omitempty"`
+	MaxUploadRecords   int                `json:"max_upload_records,omitempty"`
 	LastComplete       *time.Time         `json:"last_complete,omitempty"`
 	LastError          *time.Time         `json:"last_error,omitempty"`
 	ErrorMessage       string             `json:"error_message,omitempty"`
@@ -136,7 +137,6 @@ func (f LogpushJob) MarshalJSON() ([]byte, error) {
 
 	if f.Filter != nil {
 		b, err := json.Marshal(f.Filter)
-
 		if err != nil {
 			return nil, err
 		}

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -25,6 +25,8 @@ const (
 	"name": "example.com",
 	"logpull_options": "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
 	"destination_conf": "s3://mybucket/logs?region=us-west-2",
+	"max_upload_bytes": 5000000,
+	"max_upload_records": 1000,
 	"last_complete": "%[2]s",
 	"last_error": "%[2]s",
 	"error_message": "test",
@@ -62,16 +64,18 @@ const (
 var (
 	testLogpushTimestamp     = time.Now().UTC()
 	expectedLogpushJobStruct = LogpushJob{
-		ID:              jobID,
-		Dataset:         "http_requests",
-		Enabled:         false,
-		Name:            "example.com",
-		LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
-		DestinationConf: "s3://mybucket/logs?region=us-west-2",
-		LastComplete:    &testLogpushTimestamp,
-		LastError:       &testLogpushTimestamp,
-		ErrorMessage:    "test",
-		Frequency:       "high",
+		ID:               jobID,
+		Dataset:          "http_requests",
+		Enabled:          false,
+		Name:             "example.com",
+		LogpullOptions:   "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
+		DestinationConf:  "s3://mybucket/logs?region=us-west-2",
+		MaxUploadBytes:   5000000,
+		MaxUploadRecords: 1000,
+		LastComplete:     &testLogpushTimestamp,
+		LastError:        &testLogpushTimestamp,
+		ErrorMessage:     "test",
+		Frequency:        "high",
 	}
 	expectedEdgeLogpushJobStruct = LogpushJob{
 		ID:              jobID,


### PR DESCRIPTION
## Description

Allow for flarectl to create and delete Logpush jobs for zones and accounts.
As part of this, two new fields were added to the Logpush struct to support the `max_upload_bytes` and `max_upload_records` parameters.

## Has your change been tested?

This has been tested in our account to create and delete several logpush jobs for both audit_logs and http datasets. I use http destinations however the API is simple enough that it should work for the other types without changes.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
