### PR TITLE
user-agent-blocking-rules: update validation for mode field

### DIFF
--- a/.changelog/1089.txt
+++ b/.changelog/1089.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+user-agent-blocking-rules: add missing managed_challenge validation and removed the deprecated whitelist one
+```

--- a/user_agent.go
+++ b/user_agent.go
@@ -45,10 +45,10 @@ type UserAgentRuleListResponse struct {
 // API reference: https://api.cloudflare.com/#user-agent-blocking-rules-create-a-useragent-rule
 func (api *API) CreateUserAgentRule(ctx context.Context, zoneID string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
 	switch ld.Mode {
-	case "block", "challenge", "js_challenge", "whitelist":
+	case "block", "challenge", "js_challenge", "managed_challenge":
 		break
 	default:
-		return nil, errors.New(`the User-Agent Block rule mode must be one of "block", "challenge", "js_challenge", "whitelist"`)
+		return nil, errors.New(`the User-Agent Block rule mode must be one of "block", "challenge", "js_challenge", "managed_challenge"`)
 	}
 
 	uri := fmt.Sprintf("/zones/%s/firewall/ua_rules", zoneID)


### PR DESCRIPTION
## Description

After following up with Firewall Team, we have agreed, that `whitelist` mode is the least popular, and we should rather validate against `block`, `challenge`, `js_challenge`, `managed_challenge`.

These values are also correlating with the public API: 
https://api.cloudflare.com/#user-agent-blocking-rules-create-a-user-agent-blocking-rule 

And the Terraform Provider: 
https://github.com/cloudflare/terraform-provider-cloudflare/blob/master/internal/provider/schema_cloudflare_user_agent_blocking_rules.go#L33

## Has your change been tested?

Swapped the library locally and tested new validations.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
