### PR TITLE
Add UI read-only field (Terraform/API only mode) to Access org

### DIFF
--- a/.changelog/1104.txt
+++ b/.changelog/1104.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access: add UI read-only field to organizations
+```

--- a/access_organization.go
+++ b/access_organization.go
@@ -10,11 +10,12 @@ import (
 
 // AccessOrganization represents an Access organization.
 type AccessOrganization struct {
-	CreatedAt   *time.Time                    `json:"created_at"`
-	UpdatedAt   *time.Time                    `json:"updated_at"`
-	Name        string                        `json:"name"`
-	AuthDomain  string                        `json:"auth_domain"`
-	LoginDesign AccessOrganizationLoginDesign `json:"login_design"`
+	CreatedAt    *time.Time                    `json:"created_at"`
+	UpdatedAt    *time.Time                    `json:"updated_at"`
+	Name         string                        `json:"name"`
+	AuthDomain   string                        `json:"auth_domain"`
+	LoginDesign  AccessOrganizationLoginDesign `json:"login_design"`
+	IsUIReadOnly *bool                         `json:"is_ui_read_only,omitempty"`
 }
 
 // AccessOrganizationLoginDesign represents the login design options.

--- a/access_organization_test.go
+++ b/access_organization_test.go
@@ -26,6 +26,7 @@ func TestAccessOrganization(t *testing.T) {
 				"updated_at": "2014-01-01T05:20:00.12345Z",
 				"name": "Widget Corps Internal Applications",
 				"auth_domain": "test.cloudflareaccess.com",
+				"is_ui_read_only": false,
 				"login_design": {
 					"background_color": "#c5ed1b",
 					"logo_path": "https://example.com/logo.png",
@@ -53,6 +54,7 @@ func TestAccessOrganization(t *testing.T) {
 			HeaderText:      "Widget Corp",
 			FooterText:      "© Widget Corp",
 		},
+		IsUIReadOnly: BoolPtr(false),
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/organizations", handler)
@@ -88,6 +90,7 @@ func TestCreateAccessOrganization(t *testing.T) {
 				"updated_at": "2014-01-01T05:20:00.12345Z",
 				"name": "Widget Corps Internal Applications",
 				"auth_domain": "test.cloudflareaccess.com",
+				"is_ui_read_only": true,
 				"login_design": {
 					"background_color": "#c5ed1b",
 					"logo_path": "https://example.com/logo.png",
@@ -115,6 +118,7 @@ func TestCreateAccessOrganization(t *testing.T) {
 			HeaderText:      "Widget Corp",
 			FooterText:      "© Widget Corp",
 		},
+		IsUIReadOnly: BoolPtr(true),
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/organizations", handler)
@@ -156,7 +160,8 @@ func TestUpdateAccessOrganization(t *testing.T) {
 					"text_color": "#c5ed1b",
 					"header_text": "Widget Corp",
 					"footer_text": "© Widget Corp"
-				}
+				},
+				"is_ui_read_only": false
 			}
 		}
 		`)
@@ -177,6 +182,7 @@ func TestUpdateAccessOrganization(t *testing.T) {
 			HeaderText:      "Widget Corp",
 			FooterText:      "© Widget Corp",
 		},
+		IsUIReadOnly: BoolPtr(false),
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/organizations", handler)


### PR DESCRIPTION
## Description

Adds the UI read-only mode field to the Access organization. This will lock the UI for non-super admin users and require changes to be made via API or Terraform.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
