### PR TITLE
Expose result info messages

### DIFF
--- a/.changelog/1106.txt
+++ b/.changelog/1106.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+cloudflare: expose `Messages` from the `Response` object
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,8 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"errors"
 
 	"golang.org/x/time/rate"
 )
@@ -347,6 +346,7 @@ func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, m
 			Errors:        errBody.Errors,
 			ErrorCodes:    errCodes,
 			ErrorMessages: errMsgs,
+			Messages:      errBody.Messages,
 		}
 
 		switch resp.StatusCode {


### PR DESCRIPTION
The messages field isn't really used broadly in the API as it was designed for
informational feedback as opposed to errors, however, the page rules endpoint
uses it to communicate validation failures. For these messages to be raised in
other tools, namely the Terraform provider, it needs a dedicated field on the
struct and to be included in the `Error()` method.

Closes https://github.com/cloudflare/terraform-provider-cloudflare/issues/1579