### PR TITLE
DLP-631 Add support for DLP Endpoints

### DIFF
--- a/.changelog/1111.txt
+++ b/.changelog/1111.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dlp: Adds support for DLP resources
+```

--- a/dlp_profile.go
+++ b/dlp_profile.go
@@ -24,7 +24,7 @@ type DLPEntry struct {
 	ID        string `json:"id,omitempty"`
 	Name      string `json:"name,omitempty"`
 	ProfileID string `json:"profile_id,omitempty"`
-	Enabled   bool   `json:"enabled,omitempty"`
+	Enabled   *bool  `json:"enabled,omitempty"`
 	Type      string `json:"type,omitempty"`
 
 	// The following fields are only present for custom entries.

--- a/dlp_profile.go
+++ b/dlp_profile.go
@@ -1,0 +1,194 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// DLPPattern represents a DLP Pattern that matches an entry.
+type DLPPattern struct {
+	Regex      string `json:"regex,omitempty"`
+	Validation string `json:"validation,omitempty"`
+}
+
+// DLPEntry represents a DLP Entry, which can be matched in HTTP bodies or files.
+type DLPEntry struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	ProfileID string `json:"profile_id,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty"`
+	Type      string `json:"type,omitempty"`
+
+	// The following fields are only present for custom entries.
+
+	Pattern   *DLPPattern `json:"pattern,omitempty"`
+	CreatedAt *time.Time  `json:"created_at,omitempty"`
+	UpdatedAt *time.Time  `json:"updated_at,omitempty"`
+}
+
+// DLPProfile represents a DLP Profile, which contains a set
+// of entries.
+type DLPProfile struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+
+	// The following fields are omitted for predefined DLP
+	// profiles
+	Entries   []DLPEntry `json:"entries,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+// DLPProfilesCreateRequest represents a request to create a
+// set of profiles.
+type DLPProfilesCreateRequest struct {
+	Profiles []DLPProfile `json:"profiles"`
+}
+
+// DLPProfileListResponse represents the response from the list
+// dlp profiles endpoint.
+type DLPProfileListResponse struct {
+	Result []DLPProfile `json:"result"`
+	Response
+}
+
+// DLPProfileResponse is the API response, containing a single
+// access application.
+type DLPProfileResponse struct {
+	Success  bool       `json:"success"`
+	Errors   []string   `json:"errors"`
+	Messages []string   `json:"messages"`
+	Result   DLPProfile `json:"result"`
+}
+
+// DLPProfiles returns all DLP profiles within an account.
+//
+// API reference: https://api.cloudflare.com/#dlp-profiles-list-all-profiles
+func (api *API) DLPProfiles(ctx context.Context, accountID string) ([]DLPProfile, error) {
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/profiles", AccountRouteRoot, accountID), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []DLPProfile{}, err
+	}
+
+	var dlpProfilesListResponse DLPProfileListResponse
+	err = json.Unmarshal(res, &dlpProfilesListResponse)
+	if err != nil {
+		return []DLPProfile{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return dlpProfilesListResponse.Result, nil
+}
+
+// DLPProfile returns a single DLP profile (custom or predefined) based on the
+// profile ID.
+//
+// API reference: https://api.cloudflare.com/#dlp-profiles-get-dlp-profile
+func (api *API) DLPProfile(ctx context.Context, accountID, profileID string) (DLPProfile, error) {
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/profiles/%s", AccountRouteRoot, accountID, profileID), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return DLPProfile{}, err
+	}
+
+	var dlpProfileResponse DLPProfileResponse
+	err = json.Unmarshal(res, &dlpProfileResponse)
+	if err != nil {
+		return DLPProfile{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return dlpProfileResponse.Result, nil
+}
+
+// CreateDLPCustomProfiles creates a set of custom DLP Profile.
+//
+// API reference: https://api.cloudflare.com/#dlp-profiles-create-custom-profiles
+func (api *API) CreateDLPCustomProfiles(ctx context.Context, accountID string, profiles []DLPProfile) ([]DLPProfile, error) {
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/profiles/custom", AccountRouteRoot, accountID), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, DLPProfilesCreateRequest{
+		Profiles: profiles,
+	})
+	if err != nil {
+		return []DLPProfile{}, err
+	}
+
+	var dLPCustomProfilesResponse DLPProfileListResponse
+	err = json.Unmarshal(res, &dLPCustomProfilesResponse)
+	if err != nil {
+		return []DLPProfile{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return dLPCustomProfilesResponse.Result, nil
+}
+
+// CreateDLPCustomProfile is a wrapper for CreateDLPCustomProfiles that creates a single custom DLP Profile.
+//
+// API reference: https://api.cloudflare.com/#dlp-profiles-create-custom-profiles
+func (api *API) CreateDLPCustomProfile(ctx context.Context, accountID string, profile DLPProfile) (DLPProfile, error) {
+	profiles, err := api.CreateDLPCustomProfiles(ctx, accountID, []DLPProfile{profile})
+	if err != nil {
+		return DLPProfile{}, err
+	}
+	if len(profiles) == 0 {
+		return DLPProfile{}, fmt.Errorf("%s: no profile found in the response", errUnmarshalError)
+	}
+	return profiles[0], nil
+}
+
+// DeleteDLPCustomProfile deletes a DLP custom profile.
+//
+// API reference: https://api.cloudflare.com/#dlp-profiles-delete-custom-profile
+func (api *API) DeleteDLPCustomProfile(ctx context.Context, accountID, profileID string) error {
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/profiles/custom/%s", AccountRouteRoot, accountID, profileID), nil)
+
+	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	return err
+}
+
+// UpdateDLPCustomProfile updates a DLP custom profile.
+//
+// API reference: https://api.cloudflare.com/#dlp-profiles-update-custom-profile
+func (api *API) UpdateDLPCustomProfile(ctx context.Context, accountID, profileID string, profile DLPProfile) (DLPProfile, error) {
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/profiles/custom/%s", AccountRouteRoot, accountID, profileID), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, profile)
+	if err != nil {
+		return DLPProfile{}, err
+	}
+
+	var dlpProfileResponse DLPProfileResponse
+	err = json.Unmarshal(res, &dlpProfileResponse)
+	if err != nil {
+		return DLPProfile{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return dlpProfileResponse.Result, nil
+}
+
+// UpdateDLPPredefinedProfile updates a DLP predefined profile.
+//
+// API reference: https://api.cloudflare.com/#dlp-profiles-update-predefined-profile
+func (api *API) UpdateDLPPredefinedProfile(ctx context.Context, accountID, profileID string, profile DLPProfile) (DLPProfile, error) {
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/profiles/predefined/%s", AccountRouteRoot, accountID, profileID), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, profile)
+	if err != nil {
+		return DLPProfile{}, err
+	}
+
+	var dlpProfileResponse DLPProfileResponse
+	err = json.Unmarshal(res, &dlpProfileResponse)
+	if err != nil {
+		return DLPProfile{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return dlpProfileResponse.Result, nil
+}

--- a/dlp_profile_test.go
+++ b/dlp_profile_test.go
@@ -88,13 +88,13 @@ func TestDLPProfiles(t *testing.T) {
 					Name:      "SSN Numeric Detection",
 					ProfileID: "d658f520-6ecb-4a34-a725-ba37243c2d28",
 					Type:      "predefined",
-					Enabled:   false,
+					Enabled:   BoolPtr(false),
 				},
 				{
 					ID:   "aec08712-ee49-4109-9d9f-3b229c5b3dcd",
 					Name: "SSN Text", ProfileID: "d658f520-6ecb-4a34-a725-ba37243c2d28",
 					Type:    "predefined",
-					Enabled: false,
+					Enabled: BoolPtr(false),
 				},
 			},
 		},
@@ -108,7 +108,7 @@ func TestDLPProfiles(t *testing.T) {
 					ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
 					Name:      "matches credit card regex",
 					ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
-					Enabled:   true,
+					Enabled:   BoolPtr(true),
 					Type:      "custom",
 					Pattern: &DLPPattern{
 						Regex:      "^4[0-9]$",
@@ -179,7 +179,7 @@ func TestGetDLPProfile(t *testing.T) {
 				ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
 				Name:      "matches credit card regex",
 				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
-				Enabled:   true,
+				Enabled:   BoolPtr(true),
 				Pattern: &DLPPattern{
 					Regex:      "^4[0-9]$",
 					Validation: "luhn",
@@ -231,7 +231,7 @@ func TestCreateDLPCustomProfiles(t *testing.T) {
 							"regex": "`+requestProfile.Entries[0].Pattern.Regex+`",
 							"validation": "`+requestProfile.Entries[0].Pattern.Validation+`"
 						},
-						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"enabled": `+fmt.Sprintf("%t", Bool(requestProfile.Entries[0].Enabled))+`,
 						"type": "custom"
 					}
 				],
@@ -257,7 +257,7 @@ func TestCreateDLPCustomProfiles(t *testing.T) {
 					ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
 					Name:      "matches credit card regex",
 					ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
-					Enabled:   true,
+					Enabled:   BoolPtr(true),
 					Type:      "custom",
 					Pattern: &DLPPattern{
 						Regex:      "^4[0-9]$",
@@ -282,7 +282,7 @@ func TestCreateDLPCustomProfiles(t *testing.T) {
 			Entries: []DLPEntry{
 				{
 					Name:    "matches credit card regex",
-					Enabled: true,
+					Enabled: BoolPtr(true),
 					Pattern: &DLPPattern{
 						Regex:      "^4[0-9]$",
 						Validation: "luhn",
@@ -327,7 +327,7 @@ func TestCreateDLPCustomProfile(t *testing.T) {
 							"regex": "`+requestProfile.Entries[0].Pattern.Regex+`",
 							"validation": "`+requestProfile.Entries[0].Pattern.Validation+`"
 						},
-						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"enabled": `+fmt.Sprintf("%t", Bool(requestProfile.Entries[0].Enabled))+`,
 						"type": "custom"
 					}
 				],
@@ -354,7 +354,7 @@ func TestCreateDLPCustomProfile(t *testing.T) {
 				Name:      "matches credit card regex",
 				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
 				Type:      "custom",
-				Enabled:   true,
+				Enabled:   BoolPtr(true),
 				Pattern: &DLPPattern{
 					Regex:      "^4[0-9]$",
 					Validation: "luhn",
@@ -375,7 +375,7 @@ func TestCreateDLPCustomProfile(t *testing.T) {
 		Entries: []DLPEntry{
 			{
 				Name:    "matches credit card regex",
-				Enabled: true,
+				Enabled: BoolPtr(true),
 				Pattern: &DLPPattern{
 					Regex:      "^4[0-9]$",
 					Validation: "luhn",
@@ -421,7 +421,7 @@ func TestUpdateDLPCustomProfile(t *testing.T) {
 							"regex": "`+requestProfile.Entries[0].Pattern.Regex+`",
 							"validation": "`+requestProfile.Entries[0].Pattern.Validation+`"
 						},
-						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"enabled": `+fmt.Sprintf("%t", Bool(requestProfile.Entries[0].Enabled))+`,
 						"type": "custom"
 					}
 				],
@@ -447,7 +447,7 @@ func TestUpdateDLPCustomProfile(t *testing.T) {
 				ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
 				Name:      "matches credit card regex",
 				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
-				Enabled:   true,
+				Enabled:   BoolPtr(true),
 				Type:      "custom",
 				Pattern: &DLPPattern{
 					Regex:      "^4[0-9]$",
@@ -469,7 +469,7 @@ func TestUpdateDLPCustomProfile(t *testing.T) {
 		Entries: []DLPEntry{
 			{
 				Name:    "matches credit card regex",
-				Enabled: true,
+				Enabled: BoolPtr(true),
 				Pattern: &DLPPattern{
 					Regex:      "^4[0-9]$",
 					Validation: "luhn",
@@ -510,7 +510,7 @@ func TestUpdateDLPPredefinedProfile(t *testing.T) {
 						"id": "ef79b054-12d4-4067-bb30-b85f6267b91c",
 						"name": "Example predefined entry",
 						"profile_id": "29678c26-a191-428d-9f63-6e20a4a636a4",
-						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"enabled": `+fmt.Sprintf("%t", Bool(requestProfile.Entries[0].Enabled))+`,
 						"type": "predefined"
 					}
 				],
@@ -531,7 +531,7 @@ func TestUpdateDLPPredefinedProfile(t *testing.T) {
 				Name:      "Example predefined entry",
 				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
 				Type:      "predefined",
-				Enabled:   true,
+				Enabled:   BoolPtr(true),
 			},
 		},
 	}
@@ -545,7 +545,7 @@ func TestUpdateDLPPredefinedProfile(t *testing.T) {
 			Entries: []DLPEntry{
 				{
 					ID:      "29678c26-a191-428d-9f63-6e20a4a636a4",
-					Enabled: true,
+					Enabled: BoolPtr(true),
 				},
 			},
 		}})

--- a/dlp_profile_test.go
+++ b/dlp_profile_test.go
@@ -1,0 +1,560 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestDLPProfiles(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"id": "d658f520-6ecb-4a34-a725-ba37243c2d28",
+					"name": "U.S. Social Security Numbers",
+					"entries": [
+						{
+							"id": "111b9d4b-a5c6-40f0-957d-9d53b25dd84a",
+							"name": "SSN Numeric Detection",
+							"profile_id": "d658f520-6ecb-4a34-a725-ba37243c2d28",
+							"enabled": false,
+							"type": "predefined"
+						},
+						{
+							"id": "aec08712-ee49-4109-9d9f-3b229c5b3dcd",
+							"name": "SSN Text",
+							"profile_id": "d658f520-6ecb-4a34-a725-ba37243c2d28",
+							"enabled": false,
+							"type": "predefined"
+						}
+					],
+					"type": "predefined"
+				},
+				{
+					"id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+					"name": "Example Custom Profile",
+					"entries": [
+						{
+							"id": "ef79b054-12d4-4067-bb30-b85f6267b91c",
+							"name": "matches credit card regex",
+							"profile_id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+							"created_at": "2022-10-18T08:00:56Z",
+							"updated_at": "2022-10-18T08:00:57Z",
+							"pattern": {
+								"regex": "^4[0-9]$",
+								"validation": "luhn"
+							},
+							"enabled": true,
+							"type": "custom"
+						}
+					],
+					"created_at": "2022-10-18T08:00:56Z",
+					"updated_at": "2022-10-18T08:00:57Z",
+					"type": "custom",
+					"description": "just a custom profile example"
+				}
+			]
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:56Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:57Z")
+
+	want := []DLPProfile{
+		{
+			ID:          "d658f520-6ecb-4a34-a725-ba37243c2d28",
+			Name:        "U.S. Social Security Numbers",
+			Type:        "predefined",
+			Description: "",
+			Entries: []DLPEntry{
+				{
+					ID:        "111b9d4b-a5c6-40f0-957d-9d53b25dd84a",
+					Name:      "SSN Numeric Detection",
+					ProfileID: "d658f520-6ecb-4a34-a725-ba37243c2d28",
+					Type:      "predefined",
+					Enabled:   false,
+				},
+				{
+					ID:   "aec08712-ee49-4109-9d9f-3b229c5b3dcd",
+					Name: "SSN Text", ProfileID: "d658f520-6ecb-4a34-a725-ba37243c2d28",
+					Type:    "predefined",
+					Enabled: false,
+				},
+			},
+		},
+		{
+			ID:          "29678c26-a191-428d-9f63-6e20a4a636a4",
+			Name:        "Example Custom Profile",
+			Type:        "custom",
+			Description: "just a custom profile example",
+			Entries: []DLPEntry{
+				{
+					ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
+					Name:      "matches credit card regex",
+					ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
+					Enabled:   true,
+					Type:      "custom",
+					Pattern: &DLPPattern{
+						Regex:      "^4[0-9]$",
+						Validation: "luhn",
+					},
+					CreatedAt: &createdAt,
+					UpdatedAt: &updatedAt,
+				},
+			},
+			CreatedAt: &createdAt,
+			UpdatedAt: &updatedAt,
+		}}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/profiles", handler)
+
+	actual, err := client.DLPProfiles(context.Background(), testAccountID)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestGetDLPProfile(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+				"name": "Example Custom Profile",
+				"entries": [
+					{
+						"id": "ef79b054-12d4-4067-bb30-b85f6267b91c",
+						"name": "matches credit card regex",
+						"profile_id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+						"created_at": "2022-10-18T08:00:56Z",
+						"updated_at": "2022-10-18T08:00:57Z",
+						"pattern": {
+							"regex": "^4[0-9]$",
+							"validation": "luhn"
+						},
+						"enabled": true,
+						"type": "custom"
+					}
+				],
+				"created_at": "2022-10-18T08:00:56Z",
+				"updated_at": "2022-10-18T08:00:57Z",
+				"type": "custom",
+				"description": "just a custom profile example"
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:56Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:57Z")
+
+	want := DLPProfile{
+		ID:          "29678c26-a191-428d-9f63-6e20a4a636a4",
+		Name:        "Example Custom Profile",
+		Type:        "custom",
+		Description: "just a custom profile example",
+		Entries: []DLPEntry{
+			{
+				ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
+				Name:      "matches credit card regex",
+				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
+				Enabled:   true,
+				Pattern: &DLPPattern{
+					Regex:      "^4[0-9]$",
+					Validation: "luhn",
+				},
+				Type:      "custom",
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+		},
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/profiles/29678c26-a191-428d-9f63-6e20a4a636a4", handler)
+
+	actual, err := client.DLPProfile(context.Background(), testAccountID, "29678c26-a191-428d-9f63-6e20a4a636a4")
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestCreateDLPCustomProfiles(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+
+		var reqBody DLPProfilesCreateRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.Nil(t, err)
+		requestProfile := reqBody.Profiles[0]
+
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [{
+				"id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+				"name": "`+requestProfile.Name+`",
+				"entries": [
+					{
+						"id": "ef79b054-12d4-4067-bb30-b85f6267b91c",
+						"name": "`+requestProfile.Entries[0].Name+`",
+						"profile_id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+						"created_at": "2022-10-18T08:00:56Z",
+						"updated_at": "2022-10-18T08:00:57Z",
+						"pattern": {
+							"regex": "`+requestProfile.Entries[0].Pattern.Regex+`",
+							"validation": "`+requestProfile.Entries[0].Pattern.Validation+`"
+						},
+						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"type": "custom"
+					}
+				],
+				"created_at": "2022-10-18T08:00:56Z",
+				"updated_at": "2022-10-18T08:00:57Z",
+				"type": "custom",
+				"description": "`+requestProfile.Description+`"
+			}]
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:56Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:57Z")
+
+	want := []DLPProfile{
+		{
+			ID:          "29678c26-a191-428d-9f63-6e20a4a636a4",
+			Name:        "Example Custom Profile",
+			Type:        "custom",
+			Description: "just a custom profile example",
+			Entries: []DLPEntry{
+				{
+					ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
+					Name:      "matches credit card regex",
+					ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
+					Enabled:   true,
+					Type:      "custom",
+					Pattern: &DLPPattern{
+						Regex:      "^4[0-9]$",
+						Validation: "luhn",
+					},
+					CreatedAt: &createdAt,
+					UpdatedAt: &updatedAt,
+				},
+			},
+			CreatedAt: &createdAt,
+			UpdatedAt: &updatedAt,
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/profiles/custom", handler)
+
+	actual, err := client.CreateDLPCustomProfiles(context.Background(), testAccountID, []DLPProfile{
+		{
+			Name:        "Example Custom Profile",
+			Description: "just a custom profile example",
+			Type:        "custom",
+			Entries: []DLPEntry{
+				{
+					Name:    "matches credit card regex",
+					Enabled: true,
+					Pattern: &DLPPattern{
+						Regex:      "^4[0-9]$",
+						Validation: "luhn",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestCreateDLPCustomProfile(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+
+		var reqBody DLPProfilesCreateRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.Nil(t, err)
+		requestProfile := reqBody.Profiles[0]
+
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [{
+				"id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+				"name": "`+requestProfile.Name+`",
+				"entries": [
+					{
+						"id": "ef79b054-12d4-4067-bb30-b85f6267b91c",
+						"name": "`+requestProfile.Entries[0].Name+`",
+						"profile_id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+						"created_at": "2022-10-18T08:00:56Z",
+						"updated_at": "2022-10-18T08:00:57Z",
+						"pattern": {
+							"regex": "`+requestProfile.Entries[0].Pattern.Regex+`",
+							"validation": "`+requestProfile.Entries[0].Pattern.Validation+`"
+						},
+						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"type": "custom"
+					}
+				],
+				"created_at": "2022-10-18T08:00:56Z",
+				"updated_at": "2022-10-18T08:00:57Z",
+				"type": "custom",
+				"description": "`+requestProfile.Description+`"
+			}]
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:56Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:57Z")
+
+	want := DLPProfile{
+
+		ID:          "29678c26-a191-428d-9f63-6e20a4a636a4",
+		Name:        "Example Custom Profile",
+		Type:        "custom",
+		Description: "just a custom profile example",
+		Entries: []DLPEntry{
+			{
+				ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
+				Name:      "matches credit card regex",
+				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
+				Type:      "custom",
+				Enabled:   true,
+				Pattern: &DLPPattern{
+					Regex:      "^4[0-9]$",
+					Validation: "luhn",
+				},
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+		},
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/profiles/custom", handler)
+
+	actual, err := client.CreateDLPCustomProfile(context.Background(), testAccountID, DLPProfile{
+		Name:        "Example Custom Profile",
+		Description: "just a custom profile example",
+		Entries: []DLPEntry{
+			{
+				Name:    "matches credit card regex",
+				Enabled: true,
+				Pattern: &DLPPattern{
+					Regex:      "^4[0-9]$",
+					Validation: "luhn",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestUpdateDLPCustomProfile(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+
+		var requestProfile DLPProfile
+		err := json.NewDecoder(r.Body).Decode(&requestProfile)
+		require.Nil(t, err)
+
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+				"name": "`+requestProfile.Name+`",
+				"entries": [
+					{
+						"id": "ef79b054-12d4-4067-bb30-b85f6267b91c",
+						"name": "`+requestProfile.Entries[0].Name+`",
+						"profile_id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+						"created_at": "2022-10-18T08:00:56Z",
+						"updated_at": "2022-10-18T08:00:57Z",
+						"pattern": {
+							"regex": "`+requestProfile.Entries[0].Pattern.Regex+`",
+							"validation": "`+requestProfile.Entries[0].Pattern.Validation+`"
+						},
+						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"type": "custom"
+					}
+				],
+				"created_at": "2022-10-18T08:00:56Z",
+				"updated_at": "2022-10-18T08:00:57Z",
+				"type": "custom",
+				"description": "`+requestProfile.Description+`"
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:56Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2022-10-18T08:00:57Z")
+
+	want := DLPProfile{
+
+		ID:          "29678c26-a191-428d-9f63-6e20a4a636a4",
+		Name:        "Example Custom Profile",
+		Type:        "custom",
+		Description: "just a custom profile example",
+		Entries: []DLPEntry{
+			{
+				ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
+				Name:      "matches credit card regex",
+				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
+				Enabled:   true,
+				Type:      "custom",
+				Pattern: &DLPPattern{
+					Regex:      "^4[0-9]$",
+					Validation: "luhn",
+				},
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+		},
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/profiles/custom/29678c26-a191-428d-9f63-6e20a4a636a4", handler)
+
+	actual, err := client.UpdateDLPCustomProfile(context.Background(), testAccountID, "29678c26-a191-428d-9f63-6e20a4a636a4", DLPProfile{
+		Name:        "Example Custom Profile",
+		Description: "just a custom profile example",
+		Entries: []DLPEntry{
+			{
+				Name:    "matches credit card regex",
+				Enabled: true,
+				Pattern: &DLPPattern{
+					Regex:      "^4[0-9]$",
+					Validation: "luhn",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestUpdateDLPPredefinedProfile(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+
+		var requestProfile DLPProfile
+		err := json.NewDecoder(r.Body).Decode(&requestProfile)
+		require.Nil(t, err)
+
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+				"name": "Example predefined profile",
+				"entries": [
+					{
+						"id": "ef79b054-12d4-4067-bb30-b85f6267b91c",
+						"name": "Example predefined entry",
+						"profile_id": "29678c26-a191-428d-9f63-6e20a4a636a4",
+						"enabled": `+fmt.Sprintf("%t", requestProfile.Entries[0].Enabled)+`,
+						"type": "predefined"
+					}
+				],
+				"type": "predefined",
+				"description": "example predefined profile"
+			}
+		}`)
+	}
+
+	want := DLPProfile{
+		ID:          "29678c26-a191-428d-9f63-6e20a4a636a4",
+		Name:        "Example predefined profile",
+		Type:        "predefined",
+		Description: "example predefined profile",
+		Entries: []DLPEntry{
+			{
+				ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
+				Name:      "Example predefined entry",
+				ProfileID: "29678c26-a191-428d-9f63-6e20a4a636a4",
+				Type:      "predefined",
+				Enabled:   true,
+			},
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/profiles/predefined/29678c26-a191-428d-9f63-6e20a4a636a4", handler)
+
+	actual, err := client.UpdateDLPPredefinedProfile(context.Background(), testAccountID, "29678c26-a191-428d-9f63-6e20a4a636a4", DLPProfile{
+		Entries: []DLPEntry{
+			{
+				ID:      "29678c26-a191-428d-9f63-6e20a4a636a4",
+				Enabled: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestDeleteDLPCustomProfile(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DEL', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/profiles/custom/29678c26-a191-428d-9f63-6e20a4a636a4", handler)
+
+	err := client.DeleteDLPCustomProfile(context.Background(), testAccountID, "29678c26-a191-428d-9f63-6e20a4a636a4")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Adds support for Zero Trust DLP endpoints

## Description

We are adding DLP endpoints support to cloudflare-go and terraform, as we prepare to go live in production.

## Has your change been tested?

Manually, through a simple program running DLP endpoint calls against my account.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ X ] My code follows the code style of this project.
- [ X ] My change requires a change to the documentation.
- [ X  ] I have updated the documentation accordingly.
- [ X ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
- [ X ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.  --> **PENDING RELEASE**

[1]: https://help.github.com/articles/closing-issues-using-keywords/
