### PR TITLE
AUTH-4694 Support Access service token rotation

### DIFF
--- a/.changelog/1120.txt
+++ b/.changelog/1120.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access: add support for service token rotation
+```

--- a/access_service_tokens_test.go
+++ b/access_service_tokens_test.go
@@ -208,6 +208,49 @@ func TestRefreshAccessServiceToken(t *testing.T) {
 	}
 }
 
+func TestRotateAccessServiceToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z",
+				"expires_at": "2015-01-01T05:20:00.12345Z",
+				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+				"name": "CI/CD token",
+				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com",
+				"client_secret": "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5"
+			}
+		}
+		`)
+	}
+
+	expected := AccessServiceTokenRotateResponse{
+		CreatedAt:    &createdAt,
+		UpdatedAt:    &updatedAt,
+		ExpiresAt:    &expiresAt,
+		ID:           "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
+		Name:         "CI/CD token",
+		ClientID:     "88bf3b6d86161464f6509f7219099e57.access.example.com",
+		ClientSecret: "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5",
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/rotate", handler)
+
+	actual, err := client.RotateAccessServiceToken(context.Background(), AccountIdentifier(testAccountID), "f174e90a-fafe-4643-bbbc-4a0ed4fc8415")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, actual)
+	}
+}
+
 func TestDeleteAccessServiceToken(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description

Adds the `RotateAccessServiceToken` function, which is a wrapper for https://api.cloudflare.com/#access-service-tokens-rotate-a-service-token

## Has your change been tested?

Automated tests + I tried using it to rotate my own service tokens

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
