### PR TITLE
add Ignore option to cache rules query string struct

### DIFF
--- a/.changelog/1140.txt
+++ b/.changelog/1140.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+cache_rules: add ignore option to query string struct
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -330,6 +330,7 @@ type RulesetRuleActionParametersCustomKeyFields struct {
 type RulesetRuleActionParametersCustomKeyQuery struct {
 	Include *RulesetRuleActionParametersCustomKeyList `json:"include,omitempty"`
 	Exclude *RulesetRuleActionParametersCustomKeyList `json:"exclude,omitempty"`
+	Ignore  *bool                                     `json:"ignore,omitempty"`
 }
 
 type RulesetRuleActionParametersCustomKeyList struct {


### PR DESCRIPTION
Add "Ignored" option to cache rules query string struct

