### PR TITLE
add support for "Always Use HTTPS" zone settings

### DIFF
--- a/.changelog/1144.txt
+++ b/.changelog/1144.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+zone_settings: add support for "Always Use HTTPS" setting
+```

--- a/always_use_https.go
+++ b/always_use_https.go
@@ -1,0 +1,62 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type AlwaysUseHTTPS struct {
+	ID         string    `json:"id,omitempty"`
+	Value      string    `json:"value,omitempty"`
+	Editable   bool      `json:"editable,omitempty"`
+	ModifiedOn time.Time `json:"modified_on,omitempty"`
+}
+
+type AlwaysUseHTTPSResponse struct {
+	Response
+	Result AlwaysUseHTTPS `json:"result"`
+}
+
+// GetAlwaysUseHTTPS Get Always Use HTTPS Settings for a Zone.
+//
+// API Reference: https://api.cloudflare.com/#zone-settings-get-always-use-https-setting
+func (api *API) GetAlwaysUseHTTPS(ctx context.Context, zoneID string) (AlwaysUseHTTPS, error) {
+	uri := fmt.Sprintf("/zones/%s/settings/always_use_https", zoneID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return AlwaysUseHTTPS{}, err
+	}
+
+	var r AlwaysUseHTTPSResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return AlwaysUseHTTPS{}, err
+	}
+	return r.Result, nil
+}
+
+// SetAlwaysUseHTTPS Set Always Use HTTPS Settings for a Zone.
+//
+// API Reference: https://api.cloudflare.com/#zone-settings-change-always-use-https-setting
+func (api *API) SetAlwaysUseHTTPS(ctx context.Context, zoneID string, enabled bool) (AlwaysUseHTTPS, error) {
+	params := AlwaysUseHTTPS{Value: "off"}
+	if enabled {
+		params.Value = "on"
+	}
+
+	uri := fmt.Sprintf("/zones/%s/settings/always_use_https", zoneID)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return AlwaysUseHTTPS{}, err
+	}
+
+	var r AlwaysUseHTTPSResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return AlwaysUseHTTPS{}, err
+	}
+	return r.Result, nil
+}

--- a/always_use_https_test.go
+++ b/always_use_https_test.go
@@ -1,0 +1,114 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAlwaysUseHTTPS(t *testing.T) {
+    setup()
+    defer teardown()
+
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("content-type", "application/json")
+        fmt.Fprintf(w, `{
+          "success": true,
+          "errors": [],
+          "messages": [],
+          "result": {
+            "id": "always_use_https",
+            "value": "on",
+            "editable": true,
+            "modified_on": "2022-12-11T03:20:00.12345Z"
+          }
+        }`)
+    }
+    mux.HandleFunc("/zones/4e2d6095be5f10bbec901abc5136415d/settings/always_use_https", handler)
+
+    modifiedOn, _ := time.Parse(time.RFC3339, "2022-12-11T03:20:00.12345Z")
+    want := AlwaysUseHTTPS{
+        ID: "always_use_https",
+        Value: "on",
+        Editable: true,
+        ModifiedOn: modifiedOn,
+    }
+
+    actual, err := client.GetAlwaysUseHTTPS(context.TODO(), "4e2d6095be5f10bbec901abc5136415d")
+    if assert.NoError(t, err) {
+        assert.Equal(t, want, actual)
+    }
+}
+
+func TestSetAlwaysUseHTTPSEnabled(t *testing.T) {
+    setup()
+    defer teardown()
+
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("content-type", "application/json")
+        fmt.Fprintf(w, `{
+          "success": true,
+          "errors": [],
+          "messages": [],
+          "result": {
+            "id": "always_use_https",
+            "value": "on",
+            "editable": true,
+            "modified_on": "2022-12-11T03:20:00.12345Z"
+          }
+        }`)
+    }
+    mux.HandleFunc("/zones/4e2d6095be5f10bbec901abc5136415d/settings/always_use_https", handler)
+
+    modifiedOn, _ := time.Parse(time.RFC3339, "2022-12-11T03:20:00.12345Z")
+    want := AlwaysUseHTTPS{
+        ID: "always_use_https",
+        Value: "on",
+        Editable: true,
+        ModifiedOn: modifiedOn,
+    }
+
+    actual, err := client.SetAlwaysUseHTTPS(context.TODO(), "4e2d6095be5f10bbec901abc5136415d", true)
+    if assert.NoError(t, err) {
+        assert.Equal(t, want, actual)
+    }
+}
+
+func TestSetAlwaysUseHTTPSDisabled(t *testing.T) {
+    setup()
+    defer teardown()
+
+    handler := func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("content-type", "application/json")
+        fmt.Fprintf(w, `{
+          "success": true,
+          "errors": [],
+          "messages": [],
+          "result": {
+            "id": "always_use_https",
+            "value": "off",
+            "editable": true,
+            "modified_on": "2022-12-11T03:20:00.12345Z"
+          }
+        }`)
+    }
+    mux.HandleFunc("/zones/4e2d6095be5f10bbec901abc5136415d/settings/always_use_https", handler)
+
+    modifiedOn, _ := time.Parse(time.RFC3339, "2022-12-11T03:20:00.12345Z")
+    want := AlwaysUseHTTPS{
+        ID: "always_use_https",
+        Value: "off",
+        Editable: true,
+        ModifiedOn: modifiedOn,
+    }
+
+    actual, err := client.SetAlwaysUseHTTPS(context.TODO(), "4e2d6095be5f10bbec901abc5136415d", false)
+    if assert.NoError(t, err) {
+        assert.Equal(t, want, actual)
+    }
+}
+


### PR DESCRIPTION
## Description

Adds support for getting and setting "Always Use HTTPS" zone setting with new methods:
- GetAlwaysUseHTTPS
- SetAlwaysUseHTTPS

I'm trying to fully automate my zone provisioning process, this was a part that I had to do manually.

I tried to follow the style of [authenticated_origin_pulls.go](https://github.com/cloudflare/cloudflare-go/blob/master/authenticated_origin_pulls.go) (another simple on/off zone setting) as much as possible.

Open to file+struct naming suggestions of course -- this one is a doozy lol. 

## Has your change been tested?

I've already used this code for provisioning a new domain with "Always Use HTTPS" enabled.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
