### PR TITLE
Update api shield to allow empty payload

### DIFF
--- a/.changelog/1147.txt
+++ b/.changelog/1147.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+api_shield: allow for empty auth_id_characteristics
+```

--- a/api_shield.go
+++ b/api_shield.go
@@ -74,7 +74,9 @@ func (api *API) UpdateAPIShieldConfiguration(ctx context.Context, rc *ResourceCo
 func validateAPIShieldConfigurationUpdateParams(params UpdateAPIShieldParams) UpdateAPIShieldParams {
 	// edge case for when we get an empty auth_id_characteristics. We want to send `{auth_id_characteristics: []}` to the API.
 	if len(params.AuthIdCharacteristics) <= 1 {
-		if params.AuthIdCharacteristics[0].Name == "" && params.AuthIdCharacteristics[0].Type == "" {
+		if len(params.AuthIdCharacteristics) == 0 {
+			params.AuthIdCharacteristics = make([]AuthIdCharacteristics, 0)
+		} else if params.AuthIdCharacteristics[0].Name == "" && params.AuthIdCharacteristics[0].Type == "" {
 			params.AuthIdCharacteristics = make([]AuthIdCharacteristics, 0)
 		}
 	}

--- a/api_shield.go
+++ b/api_shield.go
@@ -56,6 +56,8 @@ func (api *API) GetAPIShieldConfiguration(ctx context.Context, rc *ResourceConta
 func (api *API) UpdateAPIShieldConfiguration(ctx context.Context, rc *ResourceContainer, params UpdateAPIShieldParams) (Response, error) {
 	uri := fmt.Sprintf("/zones/%s/api_gateway/configuration", rc.Identifier)
 
+	params = validateAPIShieldConfigurationUpdateParams(params)
+
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
 		return Response{}, err
@@ -67,4 +69,14 @@ func (api *API) UpdateAPIShieldConfiguration(ctx context.Context, rc *ResourceCo
 	}
 
 	return asResponse, nil
+}
+
+func validateAPIShieldConfigurationUpdateParams(params UpdateAPIShieldParams) UpdateAPIShieldParams {
+	// edge case for when we get an empty auth_id_characteristics. We want to send `{auth_id_characteristics: []}` to the API.
+	if len(params.AuthIdCharacteristics) <= 1 {
+		if params.AuthIdCharacteristics[0].Name == "" && params.AuthIdCharacteristics[0].Type == "" {
+			params.AuthIdCharacteristics = make([]AuthIdCharacteristics, 0)
+		}
+	}
+	return params
 }

--- a/api_shield_test.go
+++ b/api_shield_test.go
@@ -82,3 +82,33 @@ func TestPutAPIShield(t *testing.T) {
 		assert.Equal(t, want, actual)
 	}
 }
+
+func TestPutAPIShieldNoAuthIDCharacteristics(t *testing.T) {
+	setup()
+	defer teardown()
+
+	// now lets do a PUT
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+	"success" : true,
+	"errors": [],
+	"messages": [],
+	"result": []
+}
+		`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/api_gateway/configuration", handler)
+
+	apiShieldData := UpdateAPIShieldParams{AuthIdCharacteristics: nil}
+
+	want := Response{Success: true, Errors: []ResponseInfo{}, Messages: []ResponseInfo{}}
+
+	actual, err := client.UpdateAPIShieldConfiguration(context.Background(), ZoneIdentifier(testZoneID), apiShieldData)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
## Description

It has recently come to our attention that `auth_id_characteristics` can be empty when sent to the API. This change will fix the payload that goes to the API to send `{ "auth_id_characteristics" : [] }` when the payload is empty. 

## Has your change been tested?

I added an additional test case for sending an empty auth_id_characteristics payload.


## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

