### PR TITLE
remove unnecessary time.Duration(...)

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -65,8 +65,8 @@ func newClient(opts ...Option) (*API, error) {
 		rateLimiter: rate.NewLimiter(rate.Limit(4), 1), // 4rps equates to default api limit (1200 req/5 min)
 		retryPolicy: RetryPolicy{
 			MaxRetries:    3,
-			MinRetryDelay: time.Duration(1) * time.Second,
-			MaxRetryDelay: time.Duration(30) * time.Second,
+			MinRetryDelay: 1 * time.Second,
+			MaxRetryDelay: 30 * time.Second,
 		},
 		logger: silentLogger,
 	}

--- a/cloudflare_experimental.go
+++ b/cloudflare_experimental.go
@@ -98,13 +98,13 @@ func NewExperimental(config *ClientParams) (*Client, error) {
 		if c.RetryPolicy.MinRetryDelay > 0 {
 			retryClient.RetryWaitMin = c.RetryPolicy.MinRetryDelay
 		} else {
-			retryClient.RetryWaitMin = time.Duration(1) * time.Second
+			retryClient.RetryWaitMin = 1 * time.Second
 		}
 
 		if c.RetryPolicy.MaxRetryDelay > 0 {
 			retryClient.RetryWaitMax = c.RetryPolicy.MaxRetryDelay
 		} else {
-			retryClient.RetryWaitMax = time.Duration(30) * time.Second
+			retryClient.RetryWaitMax = 30 * time.Second
 		}
 
 		retryClient.Logger = silentRetryLogger

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -495,18 +495,18 @@ func TestContextTimeout(t *testing.T) {
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(time.Second * time.Duration(3))
+		time.Sleep(3 * time.Second)
 	}
 
 	mux.HandleFunc("/timeout", handler)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(1))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	start := time.Now()
 	_, err := client.makeRequestContext(ctx, http.MethodHead, "/timeout", nil)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.WithinDuration(t, start, time.Now(), time.Second*2,
+	assert.WithinDuration(t, start, time.Now(), 2*time.Second,
 		"makeRequestContext took too much time with an expiring context")
 }
 


### PR DESCRIPTION
This is a minor clean-up of unnecessary (and arguably confusing) type conversion to `time.Duration`.

## Description

Untyped constants in Go will automatically match the type of the other operand of `*`, and thus `time.Duration(30) * time.Second` is the same as `30 * time.Second`. Arguably, the latter is cleaner.

## Has your change been tested?

The changes should be covered by the existing test cases.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This is just a minor style clean-up.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
