### PR TITLE
workers: default body to provided payload

### DIFF
--- a/.changelog/1155.txt
+++ b/.changelog/1155.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+workers: correctly set `body` value for non-ES module uploads
+```

--- a/workers.go
+++ b/workers.go
@@ -214,10 +214,10 @@ func (api *API) UploadWorker(ctx context.Context, rc *ResourceContainer, params 
 		return WorkerScriptResponse{}, ErrMissingAccountID
 	}
 
+	body := []byte(params.Script)
 	var (
 		contentType = "application/javascript"
 		err         error
-		body        []byte
 	)
 
 	if params.Module || len(params.Bindings) > 0 {


### PR DESCRIPTION
This was previously incorrectly always using `body` (an uninitialised slice of bytes) for the script payload when the configuration was not for an ES module upload. Fixes the upload so that both types are covered.
