### PR TITLE
firewall_rules/filter: reset fResponse on each loop to avoid residual data

### DIFF
--- a/.changelog/1156.txt
+++ b/.changelog/1156.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+firewall_rules: use empty reponse struct on each page call
+```
+```release-note:bug
+filter: use empty reponse struct on each page call
+```

--- a/.changelog/1156.txt
+++ b/.changelog/1156.txt
@@ -1,6 +1,31 @@
 ```release-note:bug
 firewall_rules: use empty reponse struct on each page call
 ```
+
 ```release-note:bug
 filter: use empty reponse struct on each page call
+```
+
+```release-note:bug
+email_routing_destination: use empty reponse struct on each page call
+```
+
+```release-note:bug
+email_routing_rules: use empty reponse struct on each page call
+```
+
+```release-note:bug
+lockdown: use empty reponse struct on each page call
+```
+
+```release-note:bug
+queue: use empty reponse struct on each page call
+```
+
+```release-note:bug
+teams_list: use empty reponse struct on each page call
+```
+
+```release-note:bug
+workers_kv: use empty reponse struct on each page call
 ```

--- a/email_routing_destination.go
+++ b/email_routing_destination.go
@@ -61,6 +61,7 @@ func (api *API) ListEmailRoutingDestinationAddresses(ctx context.Context, rc *Re
 	var addresses []EmailRoutingDestinationAddress
 	var eResponse ListEmailRoutingAddressResponse
 	for {
+		eResponse = ListEmailRoutingAddressResponse{}
 		uri := buildURI(fmt.Sprintf("/accounts/%s/email/routing/addresses", rc.Identifier), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)

--- a/email_routing_rules.go
+++ b/email_routing_rules.go
@@ -103,6 +103,7 @@ func (api *API) ListEmailRoutingRules(ctx context.Context, rc *ResourceContainer
 	var rules []EmailRoutingRule
 	var rResponse ListEmailRoutingRuleResponse
 	for {
+		rResponse = ListEmailRoutingRuleResponse{}
 		uri := buildURI(fmt.Sprintf("/zones/%s/email/routing/rules", rc.Identifier), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)

--- a/filter.go
+++ b/filter.go
@@ -124,6 +124,7 @@ func (api *API) Filters(ctx context.Context, rc *ResourceContainer, params Filte
 	var filters []Filter
 	var fResponse FiltersDetailResponse
 	for {
+		fResponse = FiltersDetailResponse{}
 		uri := buildURI(fmt.Sprintf("/zones/%s/filters", rc.Identifier), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -90,6 +90,7 @@ func (api *API) FirewallRules(ctx context.Context, rc *ResourceContainer, params
 	var firewallRules []FirewallRule
 	var fResponse FirewallRulesDetailResponse
 	for {
+		fResponse = FirewallRulesDetailResponse{}
 		uri := buildURI(fmt.Sprintf("/zones/%s/firewall/rules", rc.Identifier), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)

--- a/lockdown.go
+++ b/lockdown.go
@@ -166,6 +166,7 @@ func (api *API) ListZoneLockdowns(ctx context.Context, rc *ResourceContainer, pa
 	var zoneLockdowns []ZoneLockdown
 	var zResponse ZoneLockdownListResponse
 	for {
+		zResponse = ZoneLockdownListResponse{}
 		uri := buildURI(fmt.Sprintf("/zones/%s/firewall/lockdowns", rc.Identifier), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)

--- a/queue.go
+++ b/queue.go
@@ -129,6 +129,7 @@ func (api *API) ListQueues(ctx context.Context, rc *ResourceContainer, params Li
 	var queues []Queue
 	var qResponse QueueListResponse
 	for {
+		qResponse = QueueListResponse{}
 		uri := buildURI(fmt.Sprintf("/accounts/%s/workers/queues", rc.Identifier), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
@@ -276,6 +277,7 @@ func (api *API) ListQueueConsumers(ctx context.Context, rc *ResourceContainer, p
 	var queuesConsumers []QueueConsumer
 	var qResponse ListQueueConsumersResponse
 	for {
+		qResponse = ListQueueConsumersResponse{}
 		uri := buildURI(fmt.Sprintf("/accounts/%s/workers/queues/%s/consumers", rc.Identifier, params.QueueName), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)

--- a/teams_list.go
+++ b/teams_list.go
@@ -172,6 +172,7 @@ func (api *API) ListTeamsListItems(ctx context.Context, rc *ResourceContainer, p
 	var teamListItems []TeamsListItem
 	var lResponse TeamsListItemsListResponse
 	for {
+		lResponse = TeamsListItemsListResponse{}
 		uri := buildURI(
 			fmt.Sprintf("/%s/%s/gateway/lists/%s/items", rc.Level, rc.Identifier, params.ListID),
 			params,

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -153,6 +153,7 @@ func (api *API) ListWorkersKVNamespaces(ctx context.Context, rc *ResourceContain
 	var namespaces []WorkersKVNamespace
 	var nsResponse ListWorkersKVNamespacesResponse
 	for {
+		nsResponse = ListWorkersKVNamespacesResponse{}
 		uri := buildURI(fmt.Sprintf("/accounts/%s/storage/kv/namespaces", rc.Identifier), params)
 
 		res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)


### PR DESCRIPTION

## Description
We found an issue were data from the previous page could populate into the current page because we were not reseting the struct on each loop.

## Has your change been tested?

This is something i'd love to have a conversation about. We need / should look into how to properly test our paginated APIs

## Types of changes
bugfix
What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
