### PR TITLE
feat(workers): allow enabling logpush on worker uploads

### DIFF
--- a/.changelog/1160.txt
+++ b/.changelog/1160.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers-upload: Add support for workers logpush enablement on script upload
+```

--- a/.changelog/1160.txt
+++ b/.changelog/1160.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-workers-upload: Add support for workers logpush enablement on script upload
+workers: Add support for workers logpush enablement on script upload
 ```

--- a/workers.go
+++ b/workers.go
@@ -28,6 +28,10 @@ type CreateWorkerParams struct {
 	// ES Module syntax script.
 	Module bool
 
+	// Logpush opts the worker into Workers Logpush logging. A nil value leaves the current setting unchanged.
+	//  https://developers.cloudflare.com/workers/platform/logpush/
+	Logpush *bool
+
 	// Bindings should be a map where the keys are the binding name, and the
 	// values are the binding content
 	Bindings map[string]WorkerBinding
@@ -220,7 +224,7 @@ func (api *API) UploadWorker(ctx context.Context, rc *ResourceContainer, params 
 		err         error
 	)
 
-	if params.Module || len(params.Bindings) > 0 {
+	if params.Module || params.Logpush != nil || len(params.Bindings) > 0 {
 		contentType, body, err = formatMultipartBody(params)
 		if err != nil {
 			return WorkerScriptResponse{}, err
@@ -257,8 +261,10 @@ func formatMultipartBody(params CreateWorkerParams) (string, []byte, error) {
 		BodyPart   string              `json:"body_part,omitempty"`
 		MainModule string              `json:"main_module,omitempty"`
 		Bindings   []workerBindingMeta `json:"bindings"`
+		Logpush    *bool               `json:"logpush,omitempty"`
 	}{
 		Bindings: make([]workerBindingMeta, 0, len(params.Bindings)),
+		Logpush:  params.Logpush,
 	}
 
 	if params.Module {


### PR DESCRIPTION
This allows cloudflare-go users to turn on/off [logpush support for Cloudflare Workers](https://developers.cloudflare.com/workers/platform/logpush/).
The analogous functionality in Wrangler can be found here: https://github.com/cloudflare/wrangler2/blob/7169142171b1c9b4ff2f19b8b46871932ef7d10a/packages/wrangler/src/create-worker-upload-form.ts#L294

## Description

This adds a new option to `CreateWorkerParams` that allows control over the logpush setting. Note its a nullable bool: the 3 states are true - on / false - off / nil - unchanged. Again, this is analogous to wrangler with its `boolean | undefined` type.

## Has your change been tested?

A new test was created to test this. 

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
