### PR TITLE
origin_ca: remove the restriction of using API service keys

### DIFF
--- a/.changelog/1161.txt
+++ b/.changelog/1161.txt
@@ -1,0 +1,23 @@
+```release-note:enhancement
+origin_ca: add support for using API keys, API tokens or API User service keys for interacting with Origin CA endpoints
+```
+
+```release-note:breaking-change
+origin_ca: renamed to `CreateOriginCertificate` to `CreateOriginCACertificate`
+```
+
+```release-note:breaking-change
+origin_ca: renamed to `OriginCertificates` to `ListOriginCACertificates`
+```
+
+```release-note:breaking-change
+origin_ca: renamed to `OriginCertificate` to `GetOriginCACertificate`
+```
+
+```release-note:breaking-change
+origin_ca: renamed to `RevokeOriginCertificate` to `RevokeOriginCACertificate`
+```
+
+```release-note:breaking-change
+origin_ca: renamed to `OriginCARootCertificate` to `GetOriginCARootCertificate`
+```

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -203,7 +203,7 @@ func pageRules(c *cli.Context) error {
 }
 
 func originCARootCertificate(c *cli.Context) error {
-	cert, err := cloudflare.OriginCARootCertificate(c.String("algorithm"))
+	cert, err := cloudflare.GetOriginCARootCertificate(c.String("algorithm"))
 	if err != nil {
 		return err
 	}

--- a/origin_ca.go
+++ b/origin_ca.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"time"
 )
 
@@ -15,6 +14,17 @@ import (
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ca
 type OriginCACertificate struct {
+	ID              string    `json:"id"`
+	Certificate     string    `json:"certificate"`
+	Hostnames       []string  `json:"hostnames"`
+	ExpiresOn       time.Time `json:"expires_on"`
+	RequestType     string    `json:"request_type"`
+	RequestValidity int       `json:"requested_validity"`
+	RevokedAt       time.Time `json:"revoked_at,omitempty"`
+	CSR             string    `json:"csr"`
+}
+
+type CreateOriginCertificateParams struct {
 	ID              string    `json:"id"`
 	Certificate     string    `json:"certificate"`
 	Hostnames       []string  `json:"hostnames"`
@@ -57,9 +67,10 @@ func (c *OriginCACertificate) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// OriginCACertificateListOptions represents the parameters used to list Cloudflare-issued certificates.
-type OriginCACertificateListOptions struct {
-	ZoneID string
+// ListOriginCertificatesParams represents the parameters used to list
+// Cloudflare-issued certificates.
+type ListOriginCertificatesParams struct {
+	ZoneID string `url:"zone_id,omitempty"`
 }
 
 // OriginCACertificateID represents the ID of the revoked certificate from the Revoke Certificate endpoint.
@@ -86,17 +97,13 @@ type originCACertificateResponseRevoke struct {
 	Result OriginCACertificateID `json:"result"`
 }
 
-// CreateOriginCertificate creates a Cloudflare-signed certificate.
-//
-// This function requires api.APIUserServiceKey be set to your Certificates API key.
+// CreateOriginCACertificate creates a Cloudflare-signed certificate.
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ca-create-certificate
-func (api *API) CreateOriginCertificate(ctx context.Context, certificate OriginCACertificate) (*OriginCACertificate, error) {
-	uri := "/certificates"
-	res, err := api.makeRequestWithAuthType(ctx, http.MethodPost, uri, certificate, AuthUserService)
-
+func (api *API) CreateOriginCACertificate(ctx context.Context, params CreateOriginCertificateParams) (*OriginCACertificate, error) {
+	res, err := api.makeRequestContext(ctx, http.MethodPost, "/certificates", params)
 	if err != nil {
-		return nil, err
+		return &OriginCACertificate{}, err
 	}
 
 	var originResponse *originCACertificateResponse
@@ -114,18 +121,12 @@ func (api *API) CreateOriginCertificate(ctx context.Context, certificate OriginC
 	return &originResponse.Result, nil
 }
 
-// OriginCertificates lists all Cloudflare-issued certificates.
-//
-// This function requires api.APIUserServiceKey be set to your Certificates API key.
+// ListOriginCACertificates lists all Cloudflare-issued certificates.
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ca-list-certificates
-func (api *API) OriginCertificates(ctx context.Context, options OriginCACertificateListOptions) ([]OriginCACertificate, error) {
-	v := url.Values{}
-	if options.ZoneID != "" {
-		v.Set("zone_id", options.ZoneID)
-	}
-	uri := fmt.Sprintf("/certificates?%s", v.Encode())
-	res, err := api.makeRequestWithAuthType(ctx, http.MethodGet, uri, nil, AuthUserService)
+func (api *API) ListOriginCACertificates(ctx context.Context, params ListOriginCertificatesParams) ([]OriginCACertificate, error) {
+	uri := buildURI("/certificates", params)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 
 	if err != nil {
 		return nil, err
@@ -146,14 +147,13 @@ func (api *API) OriginCertificates(ctx context.Context, options OriginCACertific
 	return originResponse.Result, nil
 }
 
-// OriginCertificate returns the details for a Cloudflare-issued certificate.
-//
-// This function requires api.APIUserServiceKey be set to your Certificates API key.
+// GetOriginCACertificate returns the details for a Cloudflare-issued
+// certificate.
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ca-certificate-details
-func (api *API) OriginCertificate(ctx context.Context, certificateID string) (*OriginCACertificate, error) {
+func (api *API) GetOriginCACertificate(ctx context.Context, certificateID string) (*OriginCACertificate, error) {
 	uri := fmt.Sprintf("/certificates/%s", certificateID)
-	res, err := api.makeRequestWithAuthType(ctx, http.MethodGet, uri, nil, AuthUserService)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 
 	if err != nil {
 		return nil, err
@@ -174,14 +174,12 @@ func (api *API) OriginCertificate(ctx context.Context, certificateID string) (*O
 	return &originResponse.Result, nil
 }
 
-// RevokeOriginCertificate revokes a created certificate for a zone.
-//
-// This function requires api.APIUserServiceKey be set to your Certificates API key.
+// RevokeOriginCACertificate revokes a created certificate for a zone.
 //
 // API reference: https://api.cloudflare.com/#cloudflare-ca-revoke-certificate
-func (api *API) RevokeOriginCertificate(ctx context.Context, certificateID string) (*OriginCACertificateID, error) {
+func (api *API) RevokeOriginCACertificate(ctx context.Context, certificateID string) (*OriginCACertificateID, error) {
 	uri := fmt.Sprintf("/certificates/%s", certificateID)
-	res, err := api.makeRequestWithAuthType(ctx, http.MethodDelete, uri, nil, AuthUserService)
+	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 
 	if err != nil {
 		return nil, err
@@ -204,7 +202,7 @@ func (api *API) RevokeOriginCertificate(ctx context.Context, certificateID strin
 
 // Gets the Cloudflare Origin CA Root Certificate for a given algorithm in PEM format.
 // Algorithm must be one of ['ecc', 'rsa'].
-func OriginCARootCertificate(algorithm string) ([]byte, error) {
+func GetOriginCARootCertificate(algorithm string) ([]byte, error) {
 	var url string
 	switch algorithm {
 	case "ecc":

--- a/origin_ca_test.go
+++ b/origin_ca_test.go
@@ -74,7 +74,7 @@ func TestOriginCA_CreateOriginCertificate(t *testing.T) {
 
 	expiresOn, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
-	testCertificate := OriginCACertificate{
+	testCertificate := CreateOriginCertificateParams{
 		ID:              "0x47530d8f561faa08",
 		Certificate:     "-----BEGIN CERTIFICATE-----MIICvDCCAaQCAQAwdzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFV0YWgxDzANBgNVBAcMBkxpbmRvbjEWMBQGA1UECgwNRGlnaUNlcnQgSW5jLjERMA8GA1UECwwIRGlnaUNlcnQxHTAbBgNVBAMMFGV4YW1wbGUuZGlnaWNlcnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8+To7d+2kPWeBv/orU3LVbJwDrSQbeKamCmowp5bqDxIwV20zqRb7APUOKYoVEFFOEQs6T6gImnIolhbiH6m4zgZ/CPvWBOkZc+c1Po2EmvBz+AD5sBdT5kzGQA6NbWyZGldxRthNLOs1efOhdnWFuhI162qmcflgpiIWDuwq4C9f+YkeJhNn9dF5+owm8cOQmDrV8NNdiTqin8q3qYAHHJRW28glJUCZkTZwIaSR6crBQ8TbYNE0dc+Caa3DOIkz1EOsHWzTx+n0zKfqcbgXi4DJx+C1bjptYPRBPZL8DAeWuA8ebudVT44yEp82G96/Ggcf7F33xMxe0yc+Xa6owIDAQABoAAwDQYJKoZIhvcNAQEFBQADggEBAB0kcrFccSmFDmxox0Ne01UIqSsDqHgL+XmHTXJwre6DhJSZwbvEtOK0G3+dr4Fs11WuUNt5qcLsx5a8uk4G6AKHMzuhLsJ7XZjgmQXGECpYQ4mC3yT3ZoCGpIXbw+iP3lmEEXgaQL0Tx5LFl/okKbKYwIqNiyKWOMj7ZR/wxWg/ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn29XI1PpVUNCPQGn9p/eX6Qo7vpDaPybRtA2R7XLKjQaF9oXWeCUqy1hvJac9QFO297Ob1alpHPoZ7mWiEuJwjBPii6a9M9G30nUo39lBi1w=-----END CERTIFICATE-----",
 		Hostnames:       []string{"example.com", "*.another.com"},
@@ -84,10 +84,18 @@ func TestOriginCA_CreateOriginCertificate(t *testing.T) {
 		CSR:             "-----BEGIN CERTIFICATE REQUEST-----MIICvDCCAaQCAQAwdzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFV0YWgxDzANBgNVBAcMBkxpbmRvbjEWMBQGA1UECgwNRGlnaUNlcnQgSW5jLjERMA8GA1UECwwIRGlnaUNlcnQxHTAbBgNVBAMMFGV4YW1wbGUuZGlnaWNlcnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8+To7d+2kPWeBv/orU3LVbJwDrSQbeKamCmowp5bqDxIwV20zqRb7APUOKYoVEFFOEQs6T6gImnIolhbiH6m4zgZ/CPvWBOkZc+c1Po2EmvBz+AD5sBdT5kzGQA6NbWyZGldxRthNLOs1efOhdnWFuhI162qmcflgpiIWDuwq4C9f+YkeJhNn9dF5+owm8cOQmDrV8NNdiTqin8q3qYAHHJRW28glJUCZkTZwIaSR6crBQ8TbYNE0dc+Caa3DOIkz1EOsHWzTx+n0zKfqcbgXi4DJx+C1bjptYPRBPZL8DAeWuA8ebudVT44yEp82G96/Ggcf7F33xMxe0yc+Xa6owIDAQABoAAwDQYJKoZIhvcNAQEFBQADggEBAB0kcrFccSmFDmxox0Ne01UIqSsDqHgL+XmHTXJwre6DhJSZwbvEtOK0G3+dr4Fs11WuUNt5qcLsx5a8uk4G6AKHMzuhLsJ7XZjgmQXGECpYQ4mC3yT3ZoCGpIXbw+iP3lmEEXgaQL0Tx5LFl/okKbKYwIqNiyKWOMj7ZR/wxWg/ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn29XI1PpVUNCPQGn9p/eX6Qo7vpDaPybRtA2R7XLKjQaF9oXWeCUqy1hvJac9QFO297Ob1alpHPoZ7mWiEuJwjBPii6a9M9G30nUo39lBi1w=-----END CERTIFICATE REQUEST-----",
 	}
 
-	createdCertificate, err := client.CreateOriginCertificate(context.Background(), testCertificate)
+	createdCertificate, err := client.CreateOriginCACertificate(context.Background(), testCertificate)
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, createdCertificate, &testCertificate)
+		assert.Equal(t, &OriginCACertificate{
+			ID:              "0x47530d8f561faa08",
+			Certificate:     "-----BEGIN CERTIFICATE-----MIICvDCCAaQCAQAwdzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFV0YWgxDzANBgNVBAcMBkxpbmRvbjEWMBQGA1UECgwNRGlnaUNlcnQgSW5jLjERMA8GA1UECwwIRGlnaUNlcnQxHTAbBgNVBAMMFGV4YW1wbGUuZGlnaWNlcnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8+To7d+2kPWeBv/orU3LVbJwDrSQbeKamCmowp5bqDxIwV20zqRb7APUOKYoVEFFOEQs6T6gImnIolhbiH6m4zgZ/CPvWBOkZc+c1Po2EmvBz+AD5sBdT5kzGQA6NbWyZGldxRthNLOs1efOhdnWFuhI162qmcflgpiIWDuwq4C9f+YkeJhNn9dF5+owm8cOQmDrV8NNdiTqin8q3qYAHHJRW28glJUCZkTZwIaSR6crBQ8TbYNE0dc+Caa3DOIkz1EOsHWzTx+n0zKfqcbgXi4DJx+C1bjptYPRBPZL8DAeWuA8ebudVT44yEp82G96/Ggcf7F33xMxe0yc+Xa6owIDAQABoAAwDQYJKoZIhvcNAQEFBQADggEBAB0kcrFccSmFDmxox0Ne01UIqSsDqHgL+XmHTXJwre6DhJSZwbvEtOK0G3+dr4Fs11WuUNt5qcLsx5a8uk4G6AKHMzuhLsJ7XZjgmQXGECpYQ4mC3yT3ZoCGpIXbw+iP3lmEEXgaQL0Tx5LFl/okKbKYwIqNiyKWOMj7ZR/wxWg/ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn29XI1PpVUNCPQGn9p/eX6Qo7vpDaPybRtA2R7XLKjQaF9oXWeCUqy1hvJac9QFO297Ob1alpHPoZ7mWiEuJwjBPii6a9M9G30nUo39lBi1w=-----END CERTIFICATE-----",
+			Hostnames:       []string{"example.com", "*.another.com"},
+			ExpiresOn:       expiresOn,
+			RequestType:     "origin-rsa",
+			RequestValidity: 5475,
+			CSR:             "-----BEGIN CERTIFICATE REQUEST-----MIICvDCCAaQCAQAwdzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFV0YWgxDzANBgNVBAcMBkxpbmRvbjEWMBQGA1UECgwNRGlnaUNlcnQgSW5jLjERMA8GA1UECwwIRGlnaUNlcnQxHTAbBgNVBAMMFGV4YW1wbGUuZGlnaWNlcnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8+To7d+2kPWeBv/orU3LVbJwDrSQbeKamCmowp5bqDxIwV20zqRb7APUOKYoVEFFOEQs6T6gImnIolhbiH6m4zgZ/CPvWBOkZc+c1Po2EmvBz+AD5sBdT5kzGQA6NbWyZGldxRthNLOs1efOhdnWFuhI162qmcflgpiIWDuwq4C9f+YkeJhNn9dF5+owm8cOQmDrV8NNdiTqin8q3qYAHHJRW28glJUCZkTZwIaSR6crBQ8TbYNE0dc+Caa3DOIkz1EOsHWzTx+n0zKfqcbgXi4DJx+C1bjptYPRBPZL8DAeWuA8ebudVT44yEp82G96/Ggcf7F33xMxe0yc+Xa6owIDAQABoAAwDQYJKoZIhvcNAQEFBQADggEBAB0kcrFccSmFDmxox0Ne01UIqSsDqHgL+XmHTXJwre6DhJSZwbvEtOK0G3+dr4Fs11WuUNt5qcLsx5a8uk4G6AKHMzuhLsJ7XZjgmQXGECpYQ4mC3yT3ZoCGpIXbw+iP3lmEEXgaQL0Tx5LFl/okKbKYwIqNiyKWOMj7ZR/wxWg/ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn29XI1PpVUNCPQGn9p/eX6Qo7vpDaPybRtA2R7XLKjQaF9oXWeCUqy1hvJac9QFO297Ob1alpHPoZ7mWiEuJwjBPii6a9M9G30nUo39lBi1w=-----END CERTIFICATE REQUEST-----",
+		}, createdCertificate)
 	}
 }
 
@@ -138,7 +146,7 @@ func TestOriginCA_OriginCertificates(t *testing.T) {
 		CSR:             "-----BEGIN CERTIFICATE REQUEST-----MIICvDCCAaQCAQAwdzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFV0YWgxDzANBgNVBAcMBkxpbmRvbjEWMBQGA1UECgwNRGlnaUNlcnQgSW5jLjERMA8GA1UECwwIRGlnaUNlcnQxHTAbBgNVBAMMFGV4YW1wbGUuZGlnaWNlcnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8+To7d+2kPWeBv/orU3LVbJwDrSQbeKamCmowp5bqDxIwV20zqRb7APUOKYoVEFFOEQs6T6gImnIolhbiH6m4zgZ/CPvWBOkZc+c1Po2EmvBz+AD5sBdT5kzGQA6NbWyZGldxRthNLOs1efOhdnWFuhI162qmcflgpiIWDuwq4C9f+YkeJhNn9dF5+owm8cOQmDrV8NNdiTqin8q3qYAHHJRW28glJUCZkTZwIaSR6crBQ8TbYNE0dc+Caa3DOIkz1EOsHWzTx+n0zKfqcbgXi4DJx+C1bjptYPRBPZL8DAeWuA8ebudVT44yEp82G96/Ggcf7F33xMxe0yc+Xa6owIDAQABoAAwDQYJKoZIhvcNAQEFBQADggEBAB0kcrFccSmFDmxox0Ne01UIqSsDqHgL+XmHTXJwre6DhJSZwbvEtOK0G3+dr4Fs11WuUNt5qcLsx5a8uk4G6AKHMzuhLsJ7XZjgmQXGECpYQ4mC3yT3ZoCGpIXbw+iP3lmEEXgaQL0Tx5LFl/okKbKYwIqNiyKWOMj7ZR/wxWg/ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn29XI1PpVUNCPQGn9p/eX6Qo7vpDaPybRtA2R7XLKjQaF9oXWeCUqy1hvJac9QFO297Ob1alpHPoZ7mWiEuJwjBPii6a9M9G30nUo39lBi1w=-----END CERTIFICATE REQUEST-----",
 	}
 
-	certs, err := client.OriginCertificates(context.Background(), OriginCACertificateListOptions{ZoneID: testZoneID})
+	certs, err := client.ListOriginCACertificates(context.Background(), ListOriginCertificatesParams{ZoneID: testZoneID})
 
 	if assert.NoError(t, err) {
 		assert.IsType(t, []OriginCACertificate{}, certs, "Expected type []OriginCACertificate and got %v", certs)
@@ -187,7 +195,7 @@ func TestOriginCA_OriginCertificate(t *testing.T) {
 		CSR:             "-----BEGIN CERTIFICATE REQUEST-----MIICvDCCAaQCAQAwdzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFV0YWgxDzANBgNVBAcMBkxpbmRvbjEWMBQGA1UECgwNRGlnaUNlcnQgSW5jLjERMA8GA1UECwwIRGlnaUNlcnQxHTAbBgNVBAMMFGV4YW1wbGUuZGlnaWNlcnQuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA8+To7d+2kPWeBv/orU3LVbJwDrSQbeKamCmowp5bqDxIwV20zqRb7APUOKYoVEFFOEQs6T6gImnIolhbiH6m4zgZ/CPvWBOkZc+c1Po2EmvBz+AD5sBdT5kzGQA6NbWyZGldxRthNLOs1efOhdnWFuhI162qmcflgpiIWDuwq4C9f+YkeJhNn9dF5+owm8cOQmDrV8NNdiTqin8q3qYAHHJRW28glJUCZkTZwIaSR6crBQ8TbYNE0dc+Caa3DOIkz1EOsHWzTx+n0zKfqcbgXi4DJx+C1bjptYPRBPZL8DAeWuA8ebudVT44yEp82G96/Ggcf7F33xMxe0yc+Xa6owIDAQABoAAwDQYJKoZIhvcNAQEFBQADggEBAB0kcrFccSmFDmxox0Ne01UIqSsDqHgL+XmHTXJwre6DhJSZwbvEtOK0G3+dr4Fs11WuUNt5qcLsx5a8uk4G6AKHMzuhLsJ7XZjgmQXGECpYQ4mC3yT3ZoCGpIXbw+iP3lmEEXgaQL0Tx5LFl/okKbKYwIqNiyKWOMj7ZR/wxWg/ZDGRs55xuoeLDJ/ZRFf9bI+IaCUd1YrfYcHIl3G87Av+r49YVwqRDT0VDV7uLgqn29XI1PpVUNCPQGn9p/eX6Qo7vpDaPybRtA2R7XLKjQaF9oXWeCUqy1hvJac9QFO297Ob1alpHPoZ7mWiEuJwjBPii6a9M9G30nUo39lBi1w=-----END CERTIFICATE REQUEST-----",
 	}
 
-	cert, err := client.OriginCertificate(context.Background(), testCertificate.ID)
+	cert, err := client.GetOriginCACertificate(context.Background(), testCertificate.ID)
 
 	if assert.NoError(t, err) {
 		assert.IsType(t, &OriginCACertificate{}, cert, "Expected type &OriginCACertificate and got %v", cert)
@@ -216,7 +224,7 @@ func TestOriginCA_RevokeCertificate(t *testing.T) {
 		ID: "0x47530d8f561faa08",
 	}
 
-	cert, err := client.RevokeOriginCertificate(context.Background(), testCertificate.ID)
+	cert, err := client.RevokeOriginCACertificate(context.Background(), testCertificate.ID)
 
 	if assert.NoError(t, err) {
 		assert.IsType(t, &OriginCACertificateID{}, cert, "Expected type &OriginCACertificateID and got %v", cert)
@@ -237,7 +245,7 @@ func TestOriginCA_OriginCARootCertificate(t *testing.T) {
 
 	for _, algorithm := range algorithms {
 		t.Logf("get origin CA root certificate for algorithm %s", algorithm)
-		rootCACert, err := OriginCARootCertificate(algorithm)
+		rootCACert, err := GetOriginCARootCertificate(algorithm)
 
 		if assert.NoError(t, err) {
 			assert.NotNil(t, rootCACert)


### PR DESCRIPTION
The team has made strides in removing the restriction of only using the API user service keys for origin CA requests so we can now pass in any auth scheme the end user requires.

Method updates:

- renamed to `CreateOriginCertificate` to `CreateOriginCACertificate`
- renamed to `OriginCertificates` to `ListOriginCACertificates`
- renamed to `OriginCertificate` to `GetOriginCACertificate`
- renamed to `RevokeOriginCertificate` to `RevokeOriginCACertificate`
- renamed to `OriginCARootCertificate` to `GetOriginCARootCertificate`