### PR TITLE
dns: allow filtering `ListDNSRecord` calls by `priority`

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -57,6 +57,7 @@ type ListDNSRecordsParams struct {
 	Order      string        `url:"order,omitempty"`
 	Direction  ListDirection `url:"direction,omitempty"`
 	Match      string        `url:"match,omitempty"`
+	Priority   *uint16       `json:"priority,omitempty"`
 
 	ResultInfo
 }


### PR DESCRIPTION
Even though this doesn't make it to the API, we still use it internally for filtering.
