### PR TITLE
dns: don't send unsupported "priority" field for list operations

### DIFF
--- a/.changelog/1167.txt
+++ b/.changelog/1167.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dns: don't send "priority" for list operations as it isn't supported and is only used for internal filtering
+```

--- a/dns.go
+++ b/dns.go
@@ -57,7 +57,7 @@ type ListDNSRecordsParams struct {
 	Order      string        `url:"order,omitempty"`
 	Direction  ListDirection `url:"direction,omitempty"`
 	Match      string        `url:"match,omitempty"`
-	Priority   *uint16       `json:"priority,omitempty"`
+	Priority   *uint16       `url:"-"`
 
 	ResultInfo
 }


### PR DESCRIPTION
Noticed at https://github.com/cloudflare/cloudflare-go/commit/a7b8640f01d3f4c54eb9c929d7596b0540a9841e#r95124059 but isn't actually used by the API.