### PR TITLE
fix: omit 'Priority=' in the query URL

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -57,7 +57,7 @@ type ListDNSRecordsParams struct {
 	Order      string        `url:"order,omitempty"`
 	Direction  ListDirection `url:"direction,omitempty"`
 	Match      string        `url:"match,omitempty"`
-	Priority   *uint16       `json:"priority,omitempty"`
+	Priority   *uint16       `url:"-" json:"priority,omitempty"`
 
 	ResultInfo
 }


### PR DESCRIPTION
## Description

Current, `ListDNSRecords` will generate an URL with `Priority=`. While it is mostly harmless, I prefer not to adjust my testing framework because of this, and here we are. The change follows the comment at https://github.com/cloudflare/cloudflare-go/commit/a7b8640f01d3f4c54eb9c929d7596b0540a9841e#r95126277.

## Has your change been tested?

Yes, but using my own testing framework.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.