### PR TITLE
Allow for autopagination with custom page size

### DIFF
--- a/.changelog/1169.txt
+++ b/.changelog/1169.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+dns: auto-pagination with custom per_page value and no page
+```

--- a/dns.go
+++ b/dns.go
@@ -165,7 +165,7 @@ func (api *API) ListDNSRecords(ctx context.Context, rc *ResourceContainer, param
 	}
 
 	autoPaginate := true
-	if params.PerPage >= 1 || params.Page >= 1 {
+	if params.Page >= 1 {
 		autoPaginate = false
 	}
 

--- a/dns_test.go
+++ b/dns_test.go
@@ -153,7 +153,7 @@ func TestCreateDNSRecord(t *testing.T) {
 	assert.Equal(t, want, actual)
 }
 
-func TestDNSRecords(t *testing.T) {
+func TestListDNSRecords(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -242,7 +242,7 @@ func TestDNSRecords(t *testing.T) {
 	assert.Equal(t, want, actual)
 }
 
-func TestDNSRecordsSearch(t *testing.T) {
+func TestListDNSRecordsSearch(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -339,6 +339,40 @@ func TestDNSRecordsSearch(t *testing.T) {
 	assert.Equal(t, 2000, resultInfo.Total)
 
 	assert.Equal(t, want, actual)
+}
+
+func TestListDNSRecordsPagination(t *testing.T) {
+	setup()
+	defer teardown()
+
+	var page1Called, page2Called bool
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		w.Header().Set("content-type", "application/json")
+
+		var response string
+		switch page {
+		case "1":
+			response = loadFixture("dns", "list_page_1")
+			page1Called = true
+		case "2":
+			response = loadFixture("dns", "list_page_2")
+			page2Called = true
+		}
+		fmt.Fprint(w, response)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/dns_records", handler)
+
+	actual, _, err := client.ListDNSRecords(context.Background(), ZoneIdentifier(testZoneID), ListDNSRecordsParams{
+		ResultInfo: ResultInfo{
+			PerPage: 1,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, page1Called)
+	assert.True(t, page2Called)
+	assert.Len(t, actual, 2)
 }
 
 func TestDNSRecord(t *testing.T) {

--- a/testdata/fixtures/dns/list_page_1.json
+++ b/testdata/fixtures/dns/list_page_1.json
@@ -1,0 +1,37 @@
+{
+    "success": true,
+    "errors": [],
+    "messages": [],
+    "result": [
+        {
+            "id": "372e67954025e0ba6aaa6d586b9e0b59",
+            "type": "A",
+            "name": "example.com",
+            "content": "198.51.100.4",
+            "proxiable": true,
+            "proxied": true,
+            "ttl": 120,
+            "locked": false,
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6",
+            "zone_name": "example.com",
+            "created_on": "2014-01-01T05:20:00Z",
+            "modified_on": "2014-01-01T05:20:00Z",
+            "data": {},
+            "meta": {
+                "auto_added": true,
+                "source": "primary"
+            },
+            "tags": [
+                "tag1",
+                "tag2extended"
+            ]
+        }
+    ],
+    "result_info": {
+        "count": 1,
+        "page": 1,
+        "per_page": 1,
+        "total_count": 2,
+        "total_pages": 2
+    }
+}

--- a/testdata/fixtures/dns/list_page_2.json
+++ b/testdata/fixtures/dns/list_page_2.json
@@ -1,0 +1,37 @@
+{
+    "success": true,
+    "errors": [],
+    "messages": [],
+    "result": [
+        {
+            "id": "372e67954025e0ba6aaa6d586b9e0b59",
+            "type": "A",
+            "name": "www.example.com",
+            "content": "198.51.100.4",
+            "proxiable": true,
+            "proxied": true,
+            "ttl": 120,
+            "locked": false,
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6",
+            "zone_name": "example.com",
+            "created_on": "2014-01-01T05:20:00Z",
+            "modified_on": "2014-01-01T05:20:00Z",
+            "data": {},
+            "meta": {
+                "auto_added": true,
+                "source": "primary"
+            },
+            "tags": [
+                "tag1",
+                "tag2extended"
+            ]
+        }
+    ],
+    "result_info": {
+        "count": 1,
+        "page": 2,
+        "per_page": 1,
+        "total_count": 2,
+        "total_pages": 2
+    }
+}


### PR DESCRIPTION
Signed-off-by: Artur Rodrigues <artur.rodrigues@lacework.net>

On https://github.com/cloudflare/cloudflare-go/pull/1151, `ListDNSRecordsParams` was introduced, which allows for users of the library to "search" for a specific page. What is not possible, however, is to have auto-pagination (i.e.: fetch all results) with a customer page size.

This level of flexibility is interesting for those seeking to reduce the number of API calls made to Cloudflare if they're facing rate limits.

## Description

On https://github.com/cloudflare/cloudflare-go/pull/1151, `ListDNSRecordsParams` was introduced, which embeds the [`ResultInfo`](https://github.com/cloudflare/cloudflare-go/blob/63d7aa85c4216e423033ce2f3315a672b657afd6/cloudflare.go#L473-L482) struct.

This bring the library to the same level of flexibility as the [API itself](https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records). However, users opting for the auto-pagination feature are restricted to the default `PerPage` [value of 50](https://github.com/cloudflare/cloudflare-go/blob/master/dns.go#L173).

If users decide to pass in a custom `PerPage` value, auto-pagination is silently turned off, with just the first page being returned.

This PR simply changes the logic in ListDNSRecords to turn off `autopaginate` only if `Page` is passed in. With the current auto-pagination logic, a larger `PerPage` can be used with no side-effects. This seems sensible, as auto-pagination is an added feature of the library on top of the API.

Imho, adding some documentation to the behaviour (current and new) is probably a good idea.

## Has your change been tested?

Added new unit test for the pagination behaviour with a custom `PerPage` value.
I've also validated it manually using `flarectl`.

## Screenshots (if appropriate):

N/A

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
