### PR TITLE
dns: update ListDNSRecords default `per_page` attribute to 100 records

### DIFF
--- a/.changelog/1171.txt
+++ b/.changelog/1171.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dns: Match ListDNSRecords per_page value to the API's (100)
+```

--- a/.changelog/1171.txt
+++ b/.changelog/1171.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-dns: Match ListDNSRecords per_page value to the API's (100)
+dns: update default `per_page` attribute to 100 records
 ```

--- a/dns.go
+++ b/dns.go
@@ -89,6 +89,9 @@ type DNSListResponse struct {
 	ResultInfo `json:"result_info"`
 }
 
+// listDNSRecordsDefaultPageSize represents the default per_page size of the API.
+var listDNSRecordsDefaultPageSize int = 100
+
 // nontransitionalLookup implements the nontransitional processing as specified in
 // Unicode Technical Standard 46 with almost all checkings off to maximize user freedom.
 var nontransitionalLookup = idna.New(
@@ -152,7 +155,10 @@ func (api *API) CreateDNSRecord(ctx context.Context, rc *ResourceContainer, para
 	return recordResp, nil
 }
 
-// ListDNSRecords returns a slice of DNS records for the given zone identifier.
+// ListDNSRecords returns a slice of DNS records for the given zone
+// identifier. If params doesn't include any pagination (ResultInfo)
+// options, auto pagination is performed with the default page size
+// of 100 records per request.
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
 func (api *API) ListDNSRecords(ctx context.Context, rc *ResourceContainer, params ListDNSRecordsParams) ([]DNSRecord, *ResultInfo, error) {
@@ -170,7 +176,7 @@ func (api *API) ListDNSRecords(ctx context.Context, rc *ResourceContainer, param
 	}
 
 	if params.PerPage < 1 {
-		params.PerPage = 50
+		params.PerPage = listDNSRecordsDefaultPageSize
 	}
 
 	if params.Page < 1 {

--- a/dns.go
+++ b/dns.go
@@ -156,7 +156,7 @@ func (api *API) CreateDNSRecord(ctx context.Context, rc *ResourceContainer, para
 }
 
 // ListDNSRecords returns a slice of DNS records for the given zone
-// identifier. 
+// identifier.
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
 func (api *API) ListDNSRecords(ctx context.Context, rc *ResourceContainer, params ListDNSRecordsParams) ([]DNSRecord, *ResultInfo, error) {

--- a/dns.go
+++ b/dns.go
@@ -155,8 +155,7 @@ func (api *API) CreateDNSRecord(ctx context.Context, rc *ResourceContainer, para
 	return recordResp, nil
 }
 
-// ListDNSRecords returns a slice of DNS records for the given zone
-// identifier.
+// ListDNSRecords returns a slice of DNS records for the given zone identifier.
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
 func (api *API) ListDNSRecords(ctx context.Context, rc *ResourceContainer, params ListDNSRecordsParams) ([]DNSRecord, *ResultInfo, error) {

--- a/dns.go
+++ b/dns.go
@@ -156,9 +156,7 @@ func (api *API) CreateDNSRecord(ctx context.Context, rc *ResourceContainer, para
 }
 
 // ListDNSRecords returns a slice of DNS records for the given zone
-// identifier. If params doesn't include any pagination (ResultInfo)
-// options, auto pagination is performed with the default page size
-// of 100 records per request.
+// identifier. 
 //
 // API reference: https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
 func (api *API) ListDNSRecords(ctx context.Context, rc *ResourceContainer, params ListDNSRecordsParams) ([]DNSRecord, *ResultInfo, error) {

--- a/dns_test.go
+++ b/dns_test.go
@@ -361,6 +361,9 @@ func TestListDNSRecordsPagination(t *testing.T) {
 		case "2":
 			response = loadFixture("dns", "list_page_2")
 			page2Called = true
+		default:
+			assert.Failf(t, "Unexpeted page requested: %s", page)
+			return
 		}
 		fmt.Fprint(w, response)
 	}

--- a/testdata/fixtures/dns/list_page_1.json
+++ b/testdata/fixtures/dns/list_page_1.json
@@ -1,0 +1,37 @@
+{
+    "success": true,
+    "errors": [],
+    "messages": [],
+    "result": [
+        {
+            "id": "372e67954025e0ba6aaa6d586b9e0b59",
+            "type": "A",
+            "name": "example.com",
+            "content": "198.51.100.4",
+            "proxiable": true,
+            "proxied": true,
+            "ttl": 120,
+            "locked": false,
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6",
+            "zone_name": "example.com",
+            "created_on": "2014-01-01T05:20:00Z",
+            "modified_on": "2014-01-01T05:20:00Z",
+            "data": {},
+            "meta": {
+                "auto_added": true,
+                "source": "primary"
+            },
+            "tags": [
+                "tag1",
+                "tag2extended"
+            ]
+        }
+    ],
+    "result_info": {
+        "count": 1,
+        "page": 1,
+        "per_page": 1,
+        "total_count": 2,
+        "total_pages": 2
+    }
+}

--- a/testdata/fixtures/dns/list_page_2.json
+++ b/testdata/fixtures/dns/list_page_2.json
@@ -1,0 +1,37 @@
+{
+    "success": true,
+    "errors": [],
+    "messages": [],
+    "result": [
+        {
+            "id": "372e67954025e0ba6aaa6d586b9e0b59",
+            "type": "A",
+            "name": "www.example.com",
+            "content": "198.51.100.4",
+            "proxiable": true,
+            "proxied": true,
+            "ttl": 120,
+            "locked": false,
+            "zone_id": "d56084adb405e0b7e32c52321bf07be6",
+            "zone_name": "example.com",
+            "created_on": "2014-01-01T05:20:00Z",
+            "modified_on": "2014-01-01T05:20:00Z",
+            "data": {},
+            "meta": {
+                "auto_added": true,
+                "source": "primary"
+            },
+            "tags": [
+                "tag1",
+                "tag2extended"
+            ]
+        }
+    ],
+    "result_info": {
+        "count": 1,
+        "page": 2,
+        "per_page": 1,
+        "total_count": 2,
+        "total_pages": 2
+    }
+}


### PR DESCRIPTION
Bump the `PerPage` value used when auto-pagination is performed on `ListDNSRecords` to 100, matching that of the API: https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records

## Description

As outlined in https://github.com/cloudflare/cloudflare-go/pull/1169, when no pagination options are passed in to `ListDNSRecords`, auto- pagination is performed. However, the current `per_page` value doesn't match that of the official API (50 vs 100). This commit makes both values match. 

## Has your change been tested?

A new test was implemented that more explicitly tests the auto pagination behaviour.

## Screenshots (if appropriate):

N/A

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of the above. I'd classify this as an enhancement, per the discussion on https://github.com/cloudflare/cloudflare-go/pull/1169

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
