### PR TITLE
dns: clean up ListDNSRecordsParams and actually support tags for searching

### DIFF
--- a/.changelog/1173.txt
+++ b/.changelog/1173.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+dns: the field `Tags` in `ListDNSRecordsParams` was not correctly serialized into URL queries
+```
+
+```release-note:enhancement
+dns: the URL parameter `tag-match` for listing DNS records is now supported as the field `TagMatch` in `ListDNSRecordsParams`
+```
+
+```release-note:breaking-change
+dns: the fields `CreatedOn` and `ModifiedOn` are removed from `ListDNSRecordsParams`
+```

--- a/dns.go
+++ b/dns.go
@@ -47,18 +47,17 @@ const (
 )
 
 type ListDNSRecordsParams struct {
-	CreatedOn  time.Time     `json:"created_on,omitempty" url:"created_on,omitempty"`
-	ModifiedOn time.Time     `json:"modified_on,omitempty" url:"modified_on,omitempty"`
-	Type       string        `json:"type,omitempty" url:"type,omitempty"`
-	Name       string        `json:"name,omitempty" url:"name,omitempty"`
-	Content    string        `json:"content,omitempty" url:"content,omitempty"`
-	Proxied    *bool         `json:"proxied,omitempty" url:"proxied,omitempty"`
-	Comment    string        `json:"comment,omitempty" url:"comment,omitempty"`
-	Tags       []string      `json:"tags,omitempty"`
-	Order      string        `url:"order,omitempty"`
-	Direction  ListDirection `url:"direction,omitempty"`
-	Match      string        `url:"match,omitempty"`
-	Priority   *uint16       `url:"-"`
+	Type      string        `url:"type,omitempty"`
+	Name      string        `url:"name,omitempty"`
+	Content   string        `url:"content,omitempty"`
+	Proxied   *bool         `url:"proxied,omitempty"`
+	Comment   string        `url:"comment,omitempty"`
+	Tags      []string      `url:"tag,omitempty"` // potentially multiple `tag=`
+	TagMatch  string        `url:"tag-match,omitempty"`
+	Order     string        `url:"order,omitempty"`
+	Direction ListDirection `url:"direction,omitempty"`
+	Match     string        `url:"match,omitempty"`
+	Priority  *uint16       `url:"-"`
 
 	ResultInfo
 }
@@ -157,9 +156,7 @@ func (api *API) ListDNSRecords(ctx context.Context, rc *ResourceContainer, param
 		return nil, nil, ErrMissingZoneID
 	}
 
-	if params.Name != "" {
-		params.Name = toUTS46ASCII(params.Name)
-	}
+	params.Name = toUTS46ASCII(params.Name)
 
 	autoPaginate := true
 	if params.PerPage >= 1 || params.Page >= 1 {

--- a/dns_test.go
+++ b/dns_test.go
@@ -261,6 +261,8 @@ func TestListDNSRecordsSearch(t *testing.T) {
 		assert.Equal(t, "1", r.URL.Query().Get("page"))
 		assert.Equal(t, "type", r.URL.Query().Get("order"))
 		assert.Equal(t, "asc", r.URL.Query().Get("direction"))
+		assert.Equal(t, "any", r.URL.Query().Get("tag-match"))
+		assert.ElementsMatch(t, []string{"tag1", "tag2"}, r.URL.Query()["tag"])
 
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprint(w, `{
@@ -334,6 +336,8 @@ func TestListDNSRecordsSearch(t *testing.T) {
 		Name:      "example.com",
 		Type:      "A",
 		Content:   "198.51.100.4",
+		TagMatch:  "any",
+		Tags:      []string{"tag1", "tag2"},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 2000, resultInfo.Total)


### PR DESCRIPTION
## Description

This is the sequel to #1170 to clean up `ListDNSRecordsParams`.

## Has your change been tested?

My (free) Cloudflare plan cannot test the new features `tag-match` and `tag` enabled by this PR. Otherwise, this PR passes the minimum test case, which barely tests the tags beyond mocking.

@jacobbednarz @janik-cloudflare **Help is needed to confirm the "real" behavior of tags.**

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)\
  Previously, `tags` was listed as a parameter but the URL parameter name was `tags`, which should have been `tag`.
- [x] New feature (non-breaking change which adds functionality)\
  The parameter `tag-match` is added.
- [x] Breaking change (fix or feature that would cause existing functionality to change)\
  All the fields not documented in the public API are removed except `Priority`.

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.