### PR TITLE
dns: test empty DNS record IDs

### DIFF
--- a/.changelog/1174.txt
+++ b/.changelog/1174.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dns: `GetDNSRecord`, `UpdateDNSRecord` and `DeleteDNSRecord` now return the new, dedicated error `ErrMissingDNSRecordID` when an empty DNS record ID is given.
+```

--- a/dns.go
+++ b/dns.go
@@ -259,6 +259,10 @@ func (api *API) DeleteDNSRecord(ctx context.Context, rc *ResourceContainer, reco
 	if rc.Identifier == "" {
 		return ErrMissingZoneID
 	}
+	if recordID == "" {
+		return ErrMissingDNSRecordID
+	}
+
 	uri := fmt.Sprintf("/zones/%s/dns_records/%s", rc.Identifier, recordID)
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 	if err != nil {

--- a/dns_test.go
+++ b/dns_test.go
@@ -139,7 +139,7 @@ func TestCreateDNSRecord(t *testing.T) {
 	}
 
 	_, err := client.CreateDNSRecord(context.Background(), ZoneIdentifier(""), CreateDNSRecordParams{})
-	assert.Equal(t, ErrMissingZoneID, err)
+	assert.ErrorIs(t, err, ErrMissingZoneID)
 
 	actual, err := client.CreateDNSRecord(context.Background(), ZoneIdentifier(testZoneID), CreateDNSRecordParams{
 		Type:     "A",
@@ -230,7 +230,7 @@ func TestListDNSRecords(t *testing.T) {
 	}}
 
 	_, _, err := client.ListDNSRecords(context.Background(), ZoneIdentifier(""), ListDNSRecordsParams{})
-	assert.Equal(t, ErrMissingZoneID, err)
+	assert.ErrorIs(t, err, ErrMissingZoneID)
 
 	actual, _, err := client.ListDNSRecords(context.Background(), ZoneIdentifier(testZoneID), ListDNSRecordsParams{
 		Name:    "😺.example.com",
@@ -377,7 +377,7 @@ func TestListDNSRecordsPagination(t *testing.T) {
 	assert.Len(t, actual, 2)
 }
 
-func TestDNSRecord(t *testing.T) {
+func TestGetDNSRecord(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -442,7 +442,10 @@ func TestDNSRecord(t *testing.T) {
 	}
 
 	_, err := client.GetDNSRecord(context.Background(), ZoneIdentifier(""), dnsRecordID)
-	assert.Equal(t, ErrMissingZoneID, err)
+	assert.ErrorIs(t, err, ErrMissingZoneID)
+
+	_, err = client.GetDNSRecord(context.Background(), ZoneIdentifier(testZoneID), "")
+	assert.ErrorIs(t, err, ErrMissingDNSRecordID)
 
 	actual, err := client.GetDNSRecord(context.Background(), ZoneIdentifier(testZoneID), dnsRecordID)
 	require.NoError(t, err)
@@ -504,8 +507,11 @@ func TestUpdateDNSRecord(t *testing.T) {
 
 	mux.HandleFunc("/zones/"+testZoneID+"/dns_records/"+dnsRecordID, handler)
 
-	err := client.UpdateDNSRecord(context.Background(), ZoneIdentifier(""), UpdateDNSRecordParams{})
-	assert.Equal(t, ErrMissingZoneID, err)
+	err := client.UpdateDNSRecord(context.Background(), ZoneIdentifier(""), UpdateDNSRecordParams{ID: dnsRecordID})
+	assert.ErrorIs(t, err, ErrMissingZoneID)
+
+	err = client.UpdateDNSRecord(context.Background(), ZoneIdentifier(testZoneID), UpdateDNSRecordParams{})
+	assert.ErrorIs(t, err, ErrMissingDNSRecordID)
 
 	err = client.UpdateDNSRecord(context.Background(), ZoneIdentifier(testZoneID), UpdateDNSRecordParams{
 		ID:      dnsRecordID,
@@ -541,7 +547,10 @@ func TestDeleteDNSRecord(t *testing.T) {
 	mux.HandleFunc("/zones/"+testZoneID+"/dns_records/"+dnsRecordID, handler)
 
 	err := client.DeleteDNSRecord(context.Background(), ZoneIdentifier(""), dnsRecordID)
-	assert.Equal(t, ErrMissingZoneID, err)
+	assert.ErrorIs(t, err, ErrMissingZoneID)
+
+	err = client.DeleteDNSRecord(context.Background(), ZoneIdentifier(testZoneID), "")
+	assert.ErrorIs(t, err, ErrMissingDNSRecordID)
 
 	err = client.DeleteDNSRecord(context.Background(), ZoneIdentifier(testZoneID), dnsRecordID)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

1. Check whether DNS record IDs are empty in `DeleteDNSRecord` (my oversight in #1170)
2. Add test cases for empty DNS record IDs for `GetDNSRecord`, `UpdateDNSRecord`, and `DeleteDNSRecord`
3. Use `assert/require.ErrorIs` to compare errors during testing

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.