### PR TITLE
Add queue binding type for workers scripts

### DIFF
--- a/.changelog/1176.txt
+++ b/.changelog/1176.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers: script upload now supports Queues bindings
+```


### PR DESCRIPTION
## Description

Adds the Queue binding type. Workers scripts use this binding to write messages to a Queue.

## Has your change been tested?

* Added new unit test
* Manually tested alongside terraform provider changes here: https://github.com/cloudflare/terraform-provider-cloudflare/pull/2134

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
