### PR TITLE
Add support for compatibility date and flags

### DIFF
--- a/.changelog/1177.txt
+++ b/.changelog/1177.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers: Add support for compatibility_date and compatibility_flags when upoading a worker script
+```

--- a/workers.go
+++ b/workers.go
@@ -36,7 +36,14 @@ type CreateWorkerParams struct {
 	// values are the binding content
 	Bindings map[string]WorkerBinding
 
-	// CompatibilityFlags are the names of features from upcoming features of the Workers runtime.
+	// CompatibilityDate is a date in the form yyyy-mm-dd,
+	// which will be used to determine which version of the Workers runtime is used.
+	//  https://developers.cloudflare.com/workers/platform/compatibility-dates/
+	CompatibilityDate string
+
+	// CompatibilityFlags are the names of features of the Workers runtime to be enabled or disabled,
+	// usually used together with CompatibilityDate.
+	//  https://developers.cloudflare.com/workers/platform/compatibility-dates/#compatibility-flags
 	CompatibilityFlags []string
 }
 
@@ -227,7 +234,7 @@ func (api *API) UploadWorker(ctx context.Context, rc *ResourceContainer, params 
 		err         error
 	)
 
-	if params.Module || params.Logpush != nil || len(params.Bindings) > 0 || len(params.CompatibilityFlags) > 0 {
+	if params.Module || params.Logpush != nil || len(params.Bindings) > 0 || params.CompatibilityDate != "" || len(params.CompatibilityFlags) > 0 {
 		contentType, body, err = formatMultipartBody(params)
 		if err != nil {
 			return WorkerScriptResponse{}, err
@@ -265,10 +272,12 @@ func formatMultipartBody(params CreateWorkerParams) (string, []byte, error) {
 		MainModule         string              `json:"main_module,omitempty"`
 		Bindings           []workerBindingMeta `json:"bindings"`
 		Logpush            *bool               `json:"logpush,omitempty"`
+		CompatibilityDate  string              `json:"compatibility_date,omitempty"`
 		CompatibilityFlags []string            `json:"compatibility_flags,omitempty"`
 	}{
 		Bindings:           make([]workerBindingMeta, 0, len(params.Bindings)),
 		Logpush:            params.Logpush,
+		CompatibilityDate:  params.CompatibilityDate,
 		CompatibilityFlags: params.CompatibilityFlags,
 	}
 

--- a/workers.go
+++ b/workers.go
@@ -35,6 +35,9 @@ type CreateWorkerParams struct {
 	// Bindings should be a map where the keys are the binding name, and the
 	// values are the binding content
 	Bindings map[string]WorkerBinding
+
+	// CompatibilityFlags are the names of features from upcoming features of the Workers runtime.
+	CompatibilityFlags []string
 }
 
 // WorkerScriptParams provides a worker script and the associated bindings.
@@ -224,7 +227,7 @@ func (api *API) UploadWorker(ctx context.Context, rc *ResourceContainer, params 
 		err         error
 	)
 
-	if params.Module || params.Logpush != nil || len(params.Bindings) > 0 {
+	if params.Module || params.Logpush != nil || len(params.Bindings) > 0 || len(params.CompatibilityFlags) > 0 {
 		contentType, body, err = formatMultipartBody(params)
 		if err != nil {
 			return WorkerScriptResponse{}, err
@@ -258,13 +261,15 @@ func formatMultipartBody(params CreateWorkerParams) (string, []byte, error) {
 	// Write metadata part
 	var scriptPartName string
 	meta := struct {
-		BodyPart   string              `json:"body_part,omitempty"`
-		MainModule string              `json:"main_module,omitempty"`
-		Bindings   []workerBindingMeta `json:"bindings"`
-		Logpush    *bool               `json:"logpush,omitempty"`
+		BodyPart           string              `json:"body_part,omitempty"`
+		MainModule         string              `json:"main_module,omitempty"`
+		Bindings           []workerBindingMeta `json:"bindings"`
+		Logpush            *bool               `json:"logpush,omitempty"`
+		CompatibilityFlags []string            `json:"compatibility_flags,omitempty"`
 	}{
-		Bindings: make([]workerBindingMeta, 0, len(params.Bindings)),
-		Logpush:  params.Logpush,
+		Bindings:           make([]workerBindingMeta, 0, len(params.Bindings)),
+		Logpush:            params.Logpush,
+		CompatibilityFlags: params.CompatibilityFlags,
 	}
 
 	if params.Module {

--- a/workers_test.go
+++ b/workers_test.go
@@ -884,7 +884,7 @@ func TestUploadWorker_WithCompatibilityFlags(t *testing.T) {
 		assert.Equal(t, compatibilityFlags, mpUpload.CompatibilityFlags)
 
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprintf(w, uploadWorkerResponseData)
+		fmt.Fprint(w, uploadWorkerResponseData)
 	}
 	mux.HandleFunc("/accounts/"+testAccountID+"/workers/scripts/bar", handler)
 


### PR DESCRIPTION
## Description

This PR adds support for the compatibility_date and compatibility_flags options when uploading a worker script.
https://developers.cloudflare.com/workers/platform/compatibility-dates/

## Has your change been tested?

* test included

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

/fyi @GustavoCaso - attempting to get https://github.com/Shopify/cloudflare-go/pull/13 upstreamed