### PR TITLE
Add support for score_per_period in RulesetRuleRateLimit

### DIFF
--- a/.changelog/1183.txt
+++ b/.changelog/1183.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+rulesets: add support for `score_per_period` and `score_response_header_name`
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ DEPENDENCIES:
 
 * deps: bumps github.com/urfave/cli/v2 from 2.23.7 to 2.24.1 ([#1180](https://github.com/cloudflare/cloudflare-go/issues/1180))
 
+ENHANCEMENTS:
+
+* rulesets: add support for `score_per_period` and `score_response_header_name` ([#1182](https://github.com/cloudflare/cloudflare-go/issues/1182))
+
 ## 0.59.0 (January 18th, 2023)
 
 BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ DEPENDENCIES:
 
 * deps: bumps github.com/urfave/cli/v2 from 2.23.7 to 2.24.1 ([#1180](https://github.com/cloudflare/cloudflare-go/issues/1180))
 
-ENHANCEMENTS:
-
-* rulesets: add support for `score_per_period` and `score_response_header_name` ([#1182](https://github.com/cloudflare/cloudflare-go/issues/1182))
-
 ## 0.59.0 (January 18th, 2023)
 
 BREAKING CHANGES:

--- a/rulesets.go
+++ b/rulesets.go
@@ -645,7 +645,7 @@ type RulesetRule struct {
 type RulesetRuleRateLimit struct {
 	Characteristics         []string `json:"characteristics,omitempty"`
 	RequestsPerPeriod       int      `json:"requests_per_period,omitempty"`
-	ScorePerPeriod	        int      `json:"score_per_period,omitempty"`
+	ScorePerPeriod          int      `json:"score_per_period,omitempty"`
 	ScoreResponseHeaderName string   `json:"score_response_header_name,omitempty"`
 	Period                  int      `json:"period,omitempty"`
 	MitigationTimeout       int      `json:"mitigation_timeout,omitempty"`

--- a/rulesets.go
+++ b/rulesets.go
@@ -643,12 +643,14 @@ type RulesetRule struct {
 
 // RulesetRuleRateLimit contains the structure of a HTTP rate limit Ruleset Rule.
 type RulesetRuleRateLimit struct {
-	Characteristics    []string `json:"characteristics,omitempty"`
-	RequestsPerPeriod  int      `json:"requests_per_period,omitempty"`
-	Period             int      `json:"period,omitempty"`
-	MitigationTimeout  int      `json:"mitigation_timeout,omitempty"`
-	CountingExpression string   `json:"counting_expression,omitempty"`
-	RequestsToOrigin   bool     `json:"requests_to_origin,omitempty"`
+	Characteristics         []string `json:"characteristics,omitempty"`
+	RequestsPerPeriod       int      `json:"requests_per_period,omitempty"`
+	ScorePerPeriod	        int      `json:"score_per_period,omitempty"`
+	ScoreResponseHeaderName string   `json:"score_response_header_name,omitempty"`
+	Period                  int      `json:"period,omitempty"`
+	MitigationTimeout       int      `json:"mitigation_timeout,omitempty"`
+	CountingExpression      string   `json:"counting_expression,omitempty"`
+	RequestsToOrigin        bool     `json:"requests_to_origin,omitempty"`
 }
 
 // RulesetRuleExposedCredentialCheck contains the structure of an exposed


### PR DESCRIPTION
closes #1182 

## Description
Adds support for score_per_period and score_response_header_name for Advanced Rate limiting so it is usable by the the Cloudflare Terraform Provider.


What sort of change does your code introduce/modify?

- [ X ] New feature (non-breaking change which adds functionality)
