### PR TITLE
Make Customer Endpoint optional in IPSEC tunnel config

### DIFF
--- a/.changelog/1185.txt
+++ b/.changelog/1185.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+magic_transit_ipsec_tunnel: makes customer endpoint an optional field for ipsec tunnel creation
+```

--- a/magic_transit_ipsec_tunnel.go
+++ b/magic_transit_ipsec_tunnel.go
@@ -32,7 +32,7 @@ type MagicTransitIPsecTunnel struct {
 	CreatedOn          *time.Time                          `json:"created_on,omitempty"`
 	ModifiedOn         *time.Time                          `json:"modified_on,omitempty"`
 	Name               string                              `json:"name"`
-	CustomerEndpoint   string                              `json:"customer_endpoint"`
+	CustomerEndpoint   string                              `json:"customer_endpoint,omitempty"`
 	CloudflareEndpoint string                              `json:"cloudflare_endpoint"`
 	InterfaceAddress   string                              `json:"interface_address"`
 	Description        string                              `json:"description,omitempty"`


### PR DESCRIPTION
Verified tunnel setup without specifying Customer endpoint IP in local setup

## Description
In Magic Transit IPSEC Tunnel config API, the customer endpoint IP parameter is optional.


## Has your change been tested?
Tested this with a private image. And verified that the tunnel setup is successful without specifying an IP address

## Types of changes

What sort of change does your code introduce/modify?
-  Enhancement : which provides flexibility during tunnel creation.