### PR TITLE
feat(workers): add logpush to workers response metadata

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -83,6 +83,7 @@ type WorkerMetaData struct {
 	ID         string    `json:"id,omitempty"`
 	ETAG       string    `json:"etag,omitempty"`
 	Size       int       `json:"size,omitempty"`
+	Logpush    bool      `json:"logpush"`
 	CreatedOn  time.Time `json:"created_on,omitempty"`
 	ModifiedOn time.Time `json:"modified_on,omitempty"`
 }


### PR DESCRIPTION
## Description

This updates the Worker script response format to include the logpush field in the script metadata. This is present in all API responses that include the script metadata.

## Has your change been tested?

Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.

## Screenshots (if appropriate):

This demonstrates the api's updated return format
```
❯ curl -H "Authorization: Bearer <REDACTED>" -H "Content-Type: multipart/form-data" "https://api.cloudflare.com/client/v4/accounts/<REDACTED>/workers/scripts" -X GET -s | head -15
{
  "result": [
    {
      "created_on": "2020-02-17T10:20:51.78846Z",
      "modified_on": "2020-02-17T10:20:52.924158Z",
      "id": "test-script-id",
      "tag": "some-random-tag",
      "tags": null,
      "deployment_id": "",
      "logpush": false,
      "etag": "a-redacted-etag",
      "handlers": [
        "fetch"
      ],
      "last_deployed_from": "",
...
```
Aside: you can see there are a few fields here that have been added that don't exist in the the worker metadata construct here. Have spoken to other members of the team to make sure those are kept in sync.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
