### PR TITLE
UpdateQueue function now matches API docs and allows a Queue's name t…

### DIFF
--- a/.changelog/1188.txt
+++ b/.changelog/1188.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+queues: UpdateQueue has been updated to match the API and now correctly updates a Queue's name
+```

--- a/queue.go
+++ b/queue.go
@@ -78,7 +78,8 @@ type QueueConsumerResponse struct {
 }
 
 type UpdateQueueParams struct {
-	Name string `json:"queue_name,omitempty"`
+	Name        string `json:"-"`
+	UpdatedName string `json:"queue_name,omitempty"`
 }
 
 type ListQueueConsumersParams struct {
@@ -221,16 +222,16 @@ func (api *API) GetQueue(ctx context.Context, rc *ResourceContainer, queueName s
 // UpdateQueue updates a queue.
 //
 // API reference: https://api.cloudflare.com/#queue-update-queue
-func (api *API) UpdateQueue(ctx context.Context, rc *ResourceContainer, queueName string, params UpdateQueueParams) (Queue, error) {
+func (api *API) UpdateQueue(ctx context.Context, rc *ResourceContainer, params UpdateQueueParams) (Queue, error) {
 	if rc.Identifier == "" {
 		return Queue{}, ErrMissingAccountID
 	}
 
-	if params.Name == "" {
+	if params.Name == "" || params.UpdatedName == "" {
 		return Queue{}, ErrMissingQueueName
 	}
 
-	uri := fmt.Sprintf("/accounts/%s/workers/queues/%s", rc.Identifier, queueName)
+	uri := fmt.Sprintf("/accounts/%s/workers/queues/%s", rc.Identifier, params.Name)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
 		return Queue{}, fmt.Errorf("%s: %w", errMakeRequestError, err)

--- a/queue.go
+++ b/queue.go
@@ -78,14 +78,7 @@ type QueueConsumerResponse struct {
 }
 
 type UpdateQueueParams struct {
-	ID                  string          `json:"queue_id,omitempty"`
-	Name                string          `json:"queue_name,omitempty"`
-	CreatedOn           *time.Time      `json:"created_on,omitempty"`
-	ModifiedOn          *time.Time      `json:"modified_on,omitempty"`
-	ProducersTotalCount int             `json:"producers_total_count,omitempty"`
-	Producers           []QueueProducer `json:"producers,omitempty"`
-	ConsumersTotalCount int             `json:"consumers_total_count,omitempty"`
-	Consumers           []QueueConsumer `json:"consumers,omitempty"`
+	Name string `json:"queue_name,omitempty"`
 }
 
 type ListQueueConsumersParams struct {
@@ -228,7 +221,7 @@ func (api *API) GetQueue(ctx context.Context, rc *ResourceContainer, queueName s
 // UpdateQueue updates a queue.
 //
 // API reference: https://api.cloudflare.com/#queue-update-queue
-func (api *API) UpdateQueue(ctx context.Context, rc *ResourceContainer, params UpdateQueueParams) (Queue, error) {
+func (api *API) UpdateQueue(ctx context.Context, rc *ResourceContainer, queueName string, params UpdateQueueParams) (Queue, error) {
 	if rc.Identifier == "" {
 		return Queue{}, ErrMissingAccountID
 	}
@@ -237,8 +230,8 @@ func (api *API) UpdateQueue(ctx context.Context, rc *ResourceContainer, params U
 		return Queue{}, ErrMissingQueueName
 	}
 
-	uri := fmt.Sprintf("/accounts/%s/workers/queues/%s", rc.Identifier, params.Name)
-	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, nil)
+	uri := fmt.Sprintf("/accounts/%s/workers/queues/%s", rc.Identifier, queueName)
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
 		return Queue{}, fmt.Errorf("%s: %w", errMakeRequestError, err)
 	}

--- a/queue_test.go
+++ b/queue_test.go
@@ -272,17 +272,17 @@ func TestQueue_Update(t *testing.T) {
 		}
 	}`)
 	})
-	_, err := client.UpdateQueue(context.Background(), AccountIdentifier(""), testQueueName, UpdateQueueParams{})
+	_, err := client.UpdateQueue(context.Background(), AccountIdentifier(""), UpdateQueueParams{Name: testQueueName})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrMissingAccountID, err)
 	}
 
-	_, err = client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), testQueueName, UpdateQueueParams{})
+	_, err = client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), UpdateQueueParams{Name: testQueueName})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrMissingQueueName, err)
 	}
 
-	results, err := client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), testQueueName, UpdateQueueParams{Name: "renamed-example-queue"})
+	results, err := client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), UpdateQueueParams{Name: testQueueName, UpdatedName: "renamed-example-queue"})
 	if assert.NoError(t, err) {
 		CreatedOn, _ := time.Parse(time.RFC3339, "2023-01-01T00:00:00Z")
 		ModifiedOn, _ := time.Parse(time.RFC3339, "2023-01-01T00:00:00Z")

--- a/queue_test.go
+++ b/queue_test.go
@@ -272,17 +272,17 @@ func TestQueue_Update(t *testing.T) {
 		}
 	}`)
 	})
-	_, err := client.UpdateQueue(context.Background(), AccountIdentifier(""), UpdateQueueParams{})
+	_, err := client.UpdateQueue(context.Background(), AccountIdentifier(""), testQueueName, UpdateQueueParams{})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrMissingAccountID, err)
 	}
 
-	_, err = client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), UpdateQueueParams{})
+	_, err = client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), testQueueName, UpdateQueueParams{})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrMissingQueueName, err)
 	}
 
-	results, err := client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), UpdateQueueParams{Name: "example-queue"})
+	results, err := client.UpdateQueue(context.Background(), AccountIdentifier(testAccountID), testQueueName, UpdateQueueParams{Name: "renamed-example-queue"})
 	if assert.NoError(t, err) {
 		CreatedOn, _ := time.Parse(time.RFC3339, "2023-01-01T00:00:00Z")
 		ModifiedOn, _ := time.Parse(time.RFC3339, "2023-01-01T00:00:00Z")


### PR DESCRIPTION
## Description

The existing UpdateQueue implementation was not quite correct. The API endpoint only allows for updating a Queue's name. The existing name is passed in the URL, while the new name is passed as a parameter in the body. This PR updates the function to match the API expectations.

## Has your change been tested?

* Updated unit test
* Tested manually with local terraform provider changes to update a Queue's name

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
