### PR TITLE
ci: remove mac + windows jobs

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -3,16 +3,13 @@ on: [pull_request_target]
 
 jobs:
   changelog-check:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version-file: 'internal/tools/go.mod'
       - run: go generate -tags tools internal/tools/tools.go
       - run: go run cmd/changelog-check/main.go ${{ github.event.pull_request.number }}
         working-directory: ./internal/tools

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,11 +4,11 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
       - name: Checkout code
         uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
       - uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -8,12 +8,12 @@ jobs:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'internal/tools/go.mod'
       - run: go generate -tags tools internal/tools/tools.go
       - run: ./scripts/generate-changelog.sh
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.17
+          go-version-file: 'go.mod'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4.1.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.17, 1.18, 1.19]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
We added MacOS and Windows runners after we had a dependency library incompatible upgrade occur. We haven't seen anything like this recently so let's remove it for now given our tight budget on GitHub Action runners.
