### PR TITLE
Change DLP Profile allowed_match_count to int

### DIFF
--- a/.changelog/1200.txt
+++ b/.changelog/1200.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dlp_profile: Use int rather than uint for allowed_match_count field
+```

--- a/dlp_profile.go
+++ b/dlp_profile.go
@@ -41,7 +41,7 @@ type DLPProfile struct {
 	Name              string `json:"name,omitempty"`
 	Type              string `json:"type,omitempty"`
 	Description       string `json:"description,omitempty"`
-	AllowedMatchCount uint   `json:"allowed_match_count"`
+	AllowedMatchCount int    `json:"allowed_match_count"`
 
 	// The following fields are omitted for predefined DLP
 	// profiles


### PR DESCRIPTION
## Description

the uint type does not play well with the terraform provider, and given the bounds of this field are 0-1000, an int is sufficient.

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
