### PR TITLE
Add support for Pagination in Tunnels API

### DIFF
--- a/.changelog/1206.txt
+++ b/.changelog/1206.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+tunnels: Added Pagination (through `WithPagination`) support to `Tunnels` API.
+```

--- a/.changelog/1206.txt
+++ b/.changelog/1206.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-tunnels: Added Pagination (through `WithPagination`) support to `Tunnels` API.
+tunnels: automatically paginate `ListTunnels`
 ```

--- a/testdata/fixtures/tunnel/multiple_full.json
+++ b/testdata/fixtures/tunnel/multiple_full.json
@@ -20,5 +20,11 @@
         }
       ]
     }
-  ]
+  ],
+  "result_info": {
+    "count": 1,
+    "page": 1,
+    "per_page": 20,
+    "total_count": 1
+  }
 }

--- a/tunnel.go
+++ b/tunnel.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/google/go-querystring/query"
 	"net/http"
-	"strconv"
 	"time"
 )
 
@@ -192,17 +191,8 @@ func (api *API) Tunnels(ctx context.Context, rc *ResourceContainer, params Tunne
 		of(&opt)
 	}
 
-	if opt.params.Get("page") != "" || opt.params.Get("per_page") != "" {
-		return []Tunnel{}, errors.New(errManualPagination)
-	}
-
-	opt.params.Add("per_page", strconv.Itoa(listZonesPerPage))
-
-	paramsStr := opt.params.Encode()
-	fmt.Printf("Issuing a cfd_tunnel query with params [%v]", paramsStr)
-
 	res, err := api.makeRequestContext(ctx, http.MethodGet,
-		fmt.Sprintf("/accounts/%s/cfd_tunnel?%s", rc.Identifier, paramsStr), nil)
+		fmt.Sprintf("/accounts/%s/cfd_tunnel?%s", rc.Identifier, opt.params.Encode()), nil)
 	if err != nil {
 		return []Tunnel{}, err
 	}

--- a/tunnel.go
+++ b/tunnel.go
@@ -198,8 +198,11 @@ func (api *API) Tunnels(ctx context.Context, rc *ResourceContainer, params Tunne
 
 	opt.params.Add("per_page", strconv.Itoa(listZonesPerPage))
 
+	paramsStr := opt.params.Encode()
+	fmt.Printf("Issuing a cfd_tunnel query with params [%v]", paramsStr)
+
 	res, err := api.makeRequestContext(ctx, http.MethodGet,
-		fmt.Sprintf("/accounts/%s/cfd_tunnel?%s", rc.Identifier, opt.params.Encode()), nil)
+		fmt.Sprintf("/accounts/%s/cfd_tunnel?%s", rc.Identifier, paramsStr), nil)
 	if err != nil {
 		return []Tunnel{}, err
 	}

--- a/tunnel.go
+++ b/tunnel.go
@@ -51,7 +51,7 @@ type TunnelConnection struct {
 type TunnelsDetailResponse struct {
 	Result []Tunnel `json:"result"`
 	Response
-	ResultInfo
+	ResultInfo `json:"result_info"`
 }
 
 // listTunnelsDefaultPageSize represents the default per_page size of the API.

--- a/tunnel.go
+++ b/tunnel.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
 	"time"
+
+	"github.com/google/go-querystring/query"
 )
 
 // ErrMissingTunnelID is for when a required tunnel ID is missing from the

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -41,7 +41,7 @@ func TestTunnels(t *testing.T) {
 		}},
 	}}
 
-	actual, err := client.Tunnels(context.Background(), AccountIdentifier(testAccountID), TunnelListParams{UUID: "f174e90a-fafe-4643-bbbc-4a0ed4fc8415"})
+	actual, _, err := client.Tunnels(context.Background(), AccountIdentifier(testAccountID), TunnelListParams{UUID: "f174e90a-fafe-4643-bbbc-4a0ed4fc8415"})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -84,10 +84,14 @@ func TestTunnelsPagination(t *testing.T) {
 		},
 	}
 
-	actual, err := client.Tunnels(context.Background(), AccountIdentifier(testAccountID),
+	actual, _, err := client.Tunnels(context.Background(), AccountIdentifier(testAccountID),
 		TunnelListParams{
 			Name: "blog",
-		}, WithPagination(PaginationOptions{PerPage: 1, Page: 2}))
+			ResultInfo: ResultInfo{
+				Page:    2,
+				PerPage: 1,
+			},
+		})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

## Description

[GET Tunnels API](https://api.cloudflare.com/#cloudflare-tunnel-list-cloudflare-tunnels) supports pagination but the cloudflare-go client doesn't. I copied the way it's done from Zone Contexts into this API. Generally speaking I think all APIs that support pagination should ideally support `ReqOption`s

## Example:
```golang
actual, err := client.Tunnels(context.Background(), AccountIdentifier(testAccountID),
		TunnelListParams{}, WithPagination(PaginationOptions{PerPage: 1, Page: 2}))
```
 
## Has your change been tested?

Using the fork, we have deployed a service that syncs the status of the channels to a local DB and now is able to iterate through all tunnels we've (100+ in total)

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/