### PR TITLE
cloudflare: make it clearer when we hit a server error and to retry later

### DIFF
--- a/.changelog/1207.txt
+++ b/.changelog/1207.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+cloudflare: make it clearer when we hit a server error and to retry later
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -266,18 +266,8 @@ func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, m
 				respErr = errors.New("exceeded available rate limit retries")
 			}
 
-			// if we got a valid http response, try to read body so we can reuse the connection
-			// see https://golang.org/pkg/net/http/#Client.Do
 			if respErr == nil {
-				respBody, err = io.ReadAll(resp.Body)
-				resp.Body.Close()
-
-				respErr = fmt.Errorf("could not read response body: %w", err)
-
-				api.logger.Printf("Request: %s %s got an error response %d: %s\n", method, uri, resp.StatusCode,
-					strings.Replace(strings.Replace(string(respBody), "\n", "", -1), "\t", "", -1))
-			} else {
-				api.logger.Printf("Error performing request: %s %s : %s \n", method, uri, respErr.Error())
+				respErr = fmt.Errorf("received %s response (HTTP %d), please try again later", strings.ToLower(http.StatusText(resp.StatusCode)), resp.StatusCode)
 			}
 			continue
 		} else {
@@ -286,6 +276,7 @@ func (api *API) makeRequestWithAuthTypeAndHeadersComplete(ctx context.Context, m
 			if err != nil {
 				return nil, fmt.Errorf("could not read response body: %w", err)
 			}
+
 			break
 		}
 	}


### PR DESCRIPTION
Occasionally, folks will hit an API endpoint that returns a 5xx for whatever reason. Instead of sending a vague and incorrect `could not read response body: %!w()` response, note that we hit the exception with the HTTP status code and to retry later in case it is a transient issue.
