### PR TITLE
DLP-809: Add support for DLP payload logging rule/account settings

### DIFF
--- a/.changelog/1212.txt
+++ b/.changelog/1212.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+dlp: Adds support for partial payload logging
+```

--- a/dlp_payload_log.go
+++ b/dlp_payload_log.go
@@ -1,0 +1,71 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type DLPPayloadLogSettings struct {
+	PublicKey string `json:"public_key,omitempty"`
+
+	// Only present in responses
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type GetDLPPayloadLogSettingsParams struct{}
+
+type DLPPayloadLogSettingsResponse struct {
+	Response
+	Result DLPPayloadLogSettings `json:"result"`
+}
+
+// GetDLPPayloadLogSettings gets the current DLP payload logging settings.
+//
+// API reference: https://api.cloudflare.com/#dlp-payload-log-settings-get-settings
+func (api *API) GetDLPPayloadLogSettings(ctx context.Context, rc *ResourceContainer, params GetDLPPayloadLogSettingsParams) (DLPPayloadLogSettings, error) {
+	if rc.Identifier == "" {
+		return DLPPayloadLogSettings{}, ErrMissingResourceIdentifier
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/payload_log", rc.Level, rc.Identifier), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return DLPPayloadLogSettings{}, err
+	}
+
+	var dlpPayloadLogSettingsResponse DLPPayloadLogSettingsResponse
+	err = json.Unmarshal(res, &dlpPayloadLogSettingsResponse)
+	if err != nil {
+		return DLPPayloadLogSettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return dlpPayloadLogSettingsResponse.Result, nil
+}
+
+// UpdateDLPPayloadLogSettings sets the current DLP payload logging settings to new values.
+//
+// API reference: https://api.cloudflare.com/#dlp-payload-log-settings-update-settings
+func (api *API) UpdateDLPPayloadLogSettings(ctx context.Context, rc *ResourceContainer, settings DLPPayloadLogSettings) (DLPPayloadLogSettings, error) {
+	if rc.Identifier == "" {
+		return DLPPayloadLogSettings{}, ErrMissingResourceIdentifier
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/dlp/payload_log", rc.Level, rc.Identifier), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, settings)
+	if err != nil {
+		return DLPPayloadLogSettings{}, err
+	}
+
+	var dlpPayloadLogSettingsResponse DLPPayloadLogSettingsResponse
+	err = json.Unmarshal(res, &dlpPayloadLogSettingsResponse)
+	if err != nil {
+		return DLPPayloadLogSettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return dlpPayloadLogSettingsResponse.Result, nil
+}

--- a/dlp_payload_log_test.go
+++ b/dlp_payload_log_test.go
@@ -1,0 +1,84 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDLPPayloadLogSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"public_key": "3NP5MGKjzBLLceVxNZrF+LyithbWX+AVFBMRAA0Xl2A=",
+				"updated_at": "2022-12-22T21:02:39Z"
+			}
+		}`)
+	}
+
+	updatedAt, _ := time.Parse(time.RFC3339, "2022-12-22T21:02:39Z")
+
+	want := DLPPayloadLogSettings{
+		PublicKey: "3NP5MGKjzBLLceVxNZrF+LyithbWX+AVFBMRAA0Xl2A=",
+		UpdatedAt: &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/payload_log", handler)
+
+	actual, err := client.GetDLPPayloadLogSettings(context.Background(), AccountIdentifier(testAccountID), GetDLPPayloadLogSettingsParams{})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestPutDLPPayloadLogSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+
+		var requestSettings DLPPayloadLogSettings
+		err := json.NewDecoder(r.Body).Decode(&requestSettings)
+		require.Nil(t, err)
+
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"public_key": "`+requestSettings.PublicKey+`",
+				"updated_at": "2022-12-22T21:02:39Z"
+			}
+		}`)
+	}
+
+	updatedAt, _ := time.Parse(time.RFC3339, "2022-12-22T21:02:39Z")
+
+	want := DLPPayloadLogSettings{
+		PublicKey: "3NP5MGKjzBLLceVxNZrF+LyithbWX+AVFBMRAA0Xl2A=",
+		UpdatedAt: &updatedAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/dlp/payload_log", handler)
+
+	actual, err := client.UpdateDLPPayloadLogSettings(context.Background(), AccountIdentifier(testAccountID), DLPPayloadLogSettings{
+		PublicKey: "3NP5MGKjzBLLceVxNZrF+LyithbWX+AVFBMRAA0Xl2A=",
+	})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}

--- a/teams_rules.go
+++ b/teams_rules.go
@@ -37,6 +37,9 @@ type TeamsRuleSettings struct {
 	InsecureDisableDNSSECValidation bool `json:"insecure_disable_dnssec_validation"`
 
 	EgressSettings *EgressSettings `json:"egress"`
+
+	// DLP payload logging configuration
+	PayloadLog *TeamsDlpPayloadLogSettings `json:"payload_log"`
 }
 
 type EgressSettings struct {
@@ -62,6 +65,10 @@ type TeamsBISOAdminControlSettings struct {
 type TeamsCheckSessionSettings struct {
 	Enforce  bool     `json:"enforce"`
 	Duration Duration `json:"duration"`
+}
+
+type TeamsDlpPayloadLogSettings struct {
+	Enabled bool `json:"enabled"`
 }
 
 type TeamsFilterType string


### PR DESCRIPTION
## Description

DLP recently added support for partial payload logging, which will log a portion region of matching requests and encrypt it using a user-provided public key. This PR adds support for setting that public key and enabling payload logging for individual rules.

## Has your change been tested?

The change includes unit tests to cover the new functions. These tests match the actual responses given/URLs used by the public API.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
