### PR TITLE
rulesets: update to support migration to plugin framework

### DIFF
--- a/rulesets.go
+++ b/rulesets.go
@@ -40,6 +40,7 @@ const (
 	RulesetPhaseSuperBotFightMode                   RulesetPhase = "http_request_sbfm"
 	RulesetPhaseHTTPConfigSettings                  RulesetPhase = "http_config_settings"
 
+	RulesetRuleActionAllow                RulesetRuleAction = "allow"
 	RulesetRuleActionBlock                RulesetRuleAction = "block"
 	RulesetRuleActionChallenge            RulesetRuleAction = "challenge"
 	RulesetRuleActionDDoSDynamic          RulesetRuleAction = "ddos_dynamic"
@@ -115,6 +116,7 @@ func RulesetPhaseValues() []string {
 // as a slice of strings.
 func RulesetRuleActionValues() []string {
 	return []string{
+		string(RulesetRuleActionAllow),
 		string(RulesetRuleActionBlock),
 		string(RulesetRuleActionChallenge),
 		string(RulesetRuleActionDDoSDynamic),
@@ -185,7 +187,7 @@ type Ruleset struct {
 	Name                     string        `json:"name,omitempty"`
 	Description              string        `json:"description,omitempty"`
 	Kind                     string        `json:"kind,omitempty"`
-	Version                  string        `json:"version,omitempty"`
+	Version                  *string       `json:"version,omitempty"`
 	LastUpdated              *time.Time    `json:"last_updated,omitempty"`
 	Phase                    string        `json:"phase,omitempty"`
 	Rules                    []RulesetRule `json:"rules"`
@@ -212,7 +214,7 @@ type RulesetRuleActionParameters struct {
 	Phases                  []string                                         `json:"phases,omitempty"`
 	Overrides               *RulesetRuleActionParametersOverrides            `json:"overrides,omitempty"`
 	MatchedData             *RulesetRuleActionParametersMatchedData          `json:"matched_data,omitempty"`
-	Version                 string                                           `json:"version,omitempty"`
+	Version                 *string                                          `json:"version,omitempty"`
 	Response                *RulesetRuleActionParametersBlockResponse        `json:"response,omitempty"`
 	HostHeader              string                                           `json:"host_header,omitempty"`
 	Origin                  *RulesetRuleActionParametersOrigin               `json:"origin,omitempty"`
@@ -381,7 +383,7 @@ type RulesetRuleActionParametersBlockResponse struct {
 type RulesetRuleActionParametersURI struct {
 	Path   *RulesetRuleActionParametersURIPath  `json:"path,omitempty"`
 	Query  *RulesetRuleActionParametersURIQuery `json:"query,omitempty"`
-	Origin bool                                 `json:"origin,omitempty"`
+	Origin *bool                                `json:"origin,omitempty"`
 }
 
 // RulesetRuleActionParametersURIPath holds the path specific portion of a URI
@@ -394,8 +396,8 @@ type RulesetRuleActionParametersURIPath struct {
 // RulesetRuleActionParametersURIQuery holds the query specific portion of a URI
 // action parameter.
 type RulesetRuleActionParametersURIQuery struct {
-	Value      string `json:"value,omitempty"`
-	Expression string `json:"expression,omitempty"`
+	Value      *string `json:"value,omitempty"`
+	Expression string  `json:"expression,omitempty"`
 }
 
 // RulesetRuleActionParametersHTTPHeader is the definition for define action
@@ -627,14 +629,14 @@ func (p SSL) IntoRef() *SSL {
 // RulesetRule contains information about a single Ruleset Rule.
 type RulesetRule struct {
 	ID                     string                             `json:"id,omitempty"`
-	Version                string                             `json:"version,omitempty"`
+	Version                *string                            `json:"version,omitempty"`
 	Action                 string                             `json:"action"`
 	ActionParameters       *RulesetRuleActionParameters       `json:"action_parameters,omitempty"`
 	Expression             string                             `json:"expression"`
-	Description            string                             `json:"description"`
+	Description            string                             `json:"description,omitempty"`
 	LastUpdated            *time.Time                         `json:"last_updated,omitempty"`
 	Ref                    string                             `json:"ref,omitempty"`
-	Enabled                bool                               `json:"enabled"`
+	Enabled                *bool                              `json:"enabled,omitempty"`
 	ScoreThreshold         int                                `json:"score_threshold,omitempty"`
 	RateLimit              *RulesetRuleRateLimit              `json:"ratelimit,omitempty"`
 	ExposedCredentialCheck *RulesetRuleExposedCredentialCheck `json:"exposed_credential_check,omitempty"`

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -46,7 +46,7 @@ func TestListRulesets(t *testing.T) {
 			Name:        "my example ruleset",
 			Description: "Test magic transit ruleset",
 			Kind:        "root",
-			Version:     "1",
+			Version:     StringPtr("1"),
 			LastUpdated: &lastUpdated,
 			Phase:       string(RulesetPhaseMagicTransit),
 		},
@@ -96,7 +96,7 @@ func TestGetRuleset_MagicTransit(t *testing.T) {
 		Name:        "my example ruleset",
 		Description: "Test magic transit ruleset",
 		Kind:        "root",
-		Version:     "1",
+		Version:     StringPtr("1"),
 		LastUpdated: &lastUpdated,
 		Phase:       string(RulesetPhaseMagicTransit),
 	}
@@ -161,20 +161,20 @@ func TestGetRuleset_WAF(t *testing.T) {
 
 	rules := []RulesetRule{{
 		ID:      "78723a9e0c7c4c6dbec5684cb766231d",
-		Version: "1",
+		Version: StringPtr("1"),
 		Action:  string(RulesetRuleActionRewrite),
 		ActionParameters: &RulesetRuleActionParameters{
 			URI: &RulesetRuleActionParametersURI{
 				Path: &RulesetRuleActionParametersURIPath{
 					Expression: "normalize_url_path(raw.http.request.uri.path)",
 				},
-				Origin: false,
+				Origin: BoolPtr(false),
 			},
 		},
 		Description: "Normalization on the URL path, without propagating it to the origin",
 		LastUpdated: &lastUpdated,
 		Ref:         "272936dc447b41fe976255ff6b768ec0",
-		Enabled:     true,
+		Enabled:     BoolPtr(true),
 	}}
 
 	want := Ruleset{
@@ -182,7 +182,7 @@ func TestGetRuleset_WAF(t *testing.T) {
 		Name:        "Cloudflare Normalization Ruleset",
 		Description: "Created by the Cloudflare security team, this ruleset provides normalization on the URL path",
 		Kind:        string(RulesetKindManaged),
-		Version:     "1",
+		Version:     StringPtr("1"),
 		LastUpdated: &lastUpdated,
 		Phase:       string(RulesetPhaseHTTPRequestSanitize),
 		Rules:       rules,
@@ -265,7 +265,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 
 	rules := []RulesetRule{{
 		ID:      "78723a9e0c7c4c6dbec5684cb766231d",
-		Version: "1",
+		Version: StringPtr("1"),
 		Action:  string(RulesetRuleActionSetCacheSettings),
 		ActionParameters: &RulesetRuleActionParameters{
 			Cache: BoolPtr(true),
@@ -329,7 +329,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 		Description: "Set all available cache settings in one rule",
 		LastUpdated: &lastUpdated,
 		Ref:         "272936dc447b41fe976255ff6b768ec0",
-		Enabled:     true,
+		Enabled:     BoolPtr(true),
 	}}
 
 	want := Ruleset{
@@ -337,7 +337,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 		Name:        "Cloudflare Cache Rules Ruleset",
 		Description: "This ruleset provides cache settings modifications",
 		Kind:        string(RulesetKindZone),
-		Version:     "1",
+		Version:     StringPtr("1"),
 		LastUpdated: &lastUpdated,
 		Phase:       string(RulesetPhaseHTTPRequestCacheSettings),
 		Rules:       rules,
@@ -413,7 +413,7 @@ func TestGetRuleset_SetConfig(t *testing.T) {
 
 	rules := []RulesetRule{{
 		ID:      "78723a9e0c7c4c6dbec5684cb766231d",
-		Version: "1",
+		Version: StringPtr("1"),
 		Action:  string(RulesetRuleActionSetConfig),
 		ActionParameters: &RulesetRuleActionParameters{
 			AutomaticHTTPSRewrites: BoolPtr(true),
@@ -440,7 +440,7 @@ func TestGetRuleset_SetConfig(t *testing.T) {
 		Description: "Set all available config rules in one rule",
 		LastUpdated: &lastUpdated,
 		Ref:         "272936dc447b41fe976255ff6b768ec0",
-		Enabled:     true,
+		Enabled:     BoolPtr(true),
 	}}
 
 	want := Ruleset{
@@ -448,7 +448,7 @@ func TestGetRuleset_SetConfig(t *testing.T) {
 		Name:        "Cloudflare Config Rules Ruleset",
 		Description: "This ruleset provides config rules modifications",
 		Kind:        string(RulesetKindZone),
-		Version:     "1",
+		Version:     StringPtr("1"),
 		LastUpdated: &lastUpdated,
 		Phase:       string(RulesetPhaseHTTPConfigSettings),
 		Rules:       rules,
@@ -515,7 +515,7 @@ func TestGetRuleset_RedirectFromValue(t *testing.T) {
 
 	rules := []RulesetRule{{
 		ID:      "78723a9e0c7c4c6dbec5684cb766231d",
-		Version: "1",
+		Version: StringPtr("1"),
 		Action:  string(RulesetRuleActionRedirect),
 		ActionParameters: &RulesetRuleActionParameters{
 			FromValue: &RulesetRuleActionParametersFromValue{
@@ -529,7 +529,7 @@ func TestGetRuleset_RedirectFromValue(t *testing.T) {
 		Description: "Set dynamic redirect from value",
 		LastUpdated: &lastUpdated,
 		Ref:         "272936dc447b41fe976255ff6b768ec0",
-		Enabled:     true,
+		Enabled:     BoolPtr(true),
 	}}
 
 	want := Ruleset{
@@ -537,7 +537,7 @@ func TestGetRuleset_RedirectFromValue(t *testing.T) {
 		Name:        "Cloudflare Redirect Rules Ruleset",
 		Description: "This ruleset provides redirect from value",
 		Kind:        string(RulesetKindZone),
-		Version:     "1",
+		Version:     StringPtr("1"),
 		LastUpdated: &lastUpdated,
 		Phase:       string(RulesetPhaseHTTPRequestDynamicRedirect),
 		Rules:       rules,
@@ -599,7 +599,7 @@ func TestCreateRuleset(t *testing.T) {
 
 	rules := []RulesetRule{{
 		ID:      "62449e2e0de149619edb35e59c10d801",
-		Version: "1",
+		Version: StringPtr("1"),
 		Action:  string(RulesetRuleActionSkip),
 		ActionParameters: &RulesetRuleActionParameters{
 			Ruleset: "current",
@@ -608,7 +608,7 @@ func TestCreateRuleset(t *testing.T) {
 		Description: "Allow TCP Ephemeral Ports",
 		LastUpdated: &lastUpdated,
 		Ref:         "72449e2e0de149619edb35e59c10d801",
-		Enabled:     true,
+		Enabled:     BoolPtr(true),
 	}}
 
 	newRuleset := Ruleset{
@@ -624,7 +624,7 @@ func TestCreateRuleset(t *testing.T) {
 		Name:        "my example ruleset",
 		Description: "Test magic transit ruleset",
 		Kind:        "root",
-		Version:     "1",
+		Version:     StringPtr("1"),
 		LastUpdated: &lastUpdated,
 		Phase:       string(RulesetPhaseMagicTransit),
 		Rules:       rules,
@@ -719,7 +719,7 @@ func TestUpdateRuleset(t *testing.T) {
 
 	rules := []RulesetRule{{
 		ID:      "62449e2e0de149619edb35e59c10d801",
-		Version: "1",
+		Version: StringPtr("1"),
 		Action:  string(RulesetRuleActionSkip),
 		ActionParameters: &RulesetRuleActionParameters{
 			Ruleset: "current",
@@ -728,10 +728,10 @@ func TestUpdateRuleset(t *testing.T) {
 		Description: "Allow TCP Ephemeral Ports",
 		LastUpdated: &lastUpdated,
 		Ref:         "72449e2e0de149619edb35e59c10d801",
-		Enabled:     true,
+		Enabled:     BoolPtr(true),
 	}, {
 		ID:      "62449e2e0de149619edb35e59c10d802",
-		Version: "1",
+		Version: StringPtr("1"),
 		Action:  string(RulesetRuleActionSkip),
 		ActionParameters: &RulesetRuleActionParameters{
 			Ruleset: "current",
@@ -740,7 +740,7 @@ func TestUpdateRuleset(t *testing.T) {
 		Description: "Allow UDP Ephemeral Ports",
 		LastUpdated: &lastUpdated,
 		Ref:         "72449e2e0de149619edb35e59c10d801",
-		Enabled:     true,
+		Enabled:     BoolPtr(true),
 	}}
 
 	want := Ruleset{
@@ -748,7 +748,7 @@ func TestUpdateRuleset(t *testing.T) {
 		Name:        "ruleset1",
 		Description: "Test Firewall Ruleset Update",
 		Kind:        "root",
-		Version:     "1",
+		Version:     StringPtr("1"),
 		LastUpdated: &lastUpdated,
 		Phase:       string(RulesetPhaseMagicTransit),
 		Rules:       rules,


### PR DESCRIPTION
Swaps some of the Ruleset types to support the migration to the `terraform-plugin-framework` by providing optional (or possibly unknown values) as pointers to differentiate values vs uninitialised.