### PR TITLE
Avoid serialize the id field in patch request

### DIFF
--- a/addressing_address_map.go
+++ b/addressing_address_map.go
@@ -79,7 +79,7 @@ type CreateAddressMapParams struct {
 
 // UpdateAddressMapParams contains information about an address map to be updated.
 type UpdateAddressMapParams struct {
-	ID          string  `json:"id"`
+	ID          string  `json:"-"`
 	Description *string `json:"description,omitempty"`
 	Enabled     *bool   `json:"enabled,omitempty"`
 	DefaultSNI  *string `json:"default_sni,omitempty"`
@@ -245,7 +245,7 @@ func (api *API) DeleteIPAddressFromAddressMap(ctx context.Context, rc *ResourceC
 	return err
 }
 
-// AddMembershipToAddressMap adds a zone/account as a member of a particular address map.
+// CreateMembershipToAddressMap adds a zone/account as a member of a particular address map.
 //
 // API reference:
 //   - account: https://developers.cloudflare.com/api/operations/ip-address-management-address-maps-add-an-account-membership-to-an-address-map


### PR DESCRIPTION
## Description

The api endpoint does not expect the patch payload contains the `id` field.

## Has your change been tested?

Yes, this has been tested by vendoring it in the Cloudflare Terraform provider.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.
