### PR TITLE
automatically lock issues/PRs after a milestone release

### DIFF
--- a/.github/workflows/milestone-closed.yml
+++ b/.github/workflows/milestone-closed.yml
@@ -18,3 +18,18 @@ jobs:
             This functionality has been released in [${{ github.event.milestone.title }}](https://github.com/${{ github.repository }}/releases/tag/${{ github.event.milestone.title }}).
 
             For further feature requests or bug reports with this functionality, please create a [new GitHub issue](https://github.com/${{ github.repository }}/issues/new/choose) following the template. Thank you!
+  lock-closed-issues:
+    runs-on: ubuntu-latest
+    needs: comment-on-closed-milestone
+    steps:
+      - run: |
+          IFS=',' read -r -a issues <<< "$ISSUES"
+          for element in "${issues[@]}"
+          do
+              echo "Locking $element"
+              echo "no" | gh pr lock -r resolved $element
+              echo "no" | gh issue lock -r resolved $element
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUES: ${{ needs.comment-on-closed-milestone.outputs.ids }}


### PR DESCRIPTION
Updates the release process to automatically lock issues and PRs after a release to get folks to create new issues for problems instead of dogpiling.
