### PR TITLE
AUTH-5081 Add claims and scopes fields to Access IDP config

### DIFF
--- a/.changelog/1237.txt
+++ b/.changelog/1237.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access_identity_provider: add `claims` and `scopes` fields
+```

--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -30,6 +30,8 @@ type AccessIdentityProviderConfiguration struct {
 	CertsURL           string   `json:"certs_url,omitempty"`
 	ClientID           string   `json:"client_id,omitempty"`
 	ClientSecret       string   `json:"client_secret,omitempty"`
+	Claims             []string `json:"claims,omitempty"`
+	Scopes             []string `json:"scopes,omitempty"`
 	DirectoryID        string   `json:"directory_id,omitempty"`
 	EmailAttributeName string   `json:"email_attribute_name,omitempty"`
 	IdpPublicCert      string   `json:"idp_public_cert,omitempty"`


### PR DESCRIPTION
## Description

Adds the `claims` and `scopes` fields to the `AccessIdentityProviderConfiguration` struct, so that we can add it to Terraform as part of AUTH-5081

## Has your change been tested?

Tested it locally to update the claims and scopes of my configured OIDC connector.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
