### PR TITLE
Fix CreateTunnel for tunnels with config_src

### DIFF
--- a/.changelog/1238.txt
+++ b/.changelog/1238.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tunnel: Fix 'CreateTunnel' for tunnels using config_src
+```

--- a/tunnel.go
+++ b/tunnel.go
@@ -275,9 +275,7 @@ func (api *API) CreateTunnel(ctx context.Context, rc *ResourceContainer, params 
 
 	uri := fmt.Sprintf("/accounts/%s/cfd_tunnel", rc.Identifier)
 
-	tunnel := Tunnel{Name: params.Name, Secret: params.Secret}
-
-	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, tunnel)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
 	if err != nil {
 		return Tunnel{}, err
 	}


### PR DESCRIPTION
## Description

CreateTunnel previously did not use config_src in the request. Removed unnecessary reference to Tunnel object and passed params for tunnel creation directly to the URI.

## Has your change been tested?

Yes. Ran all automated tests and none of them have been broken. Also test in tunnel_test.go already covered new tunnel creation with expected config_src.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
