### PR TITLE
add access policies to access application

### DIFF
--- a/access_application.go
+++ b/access_application.go
@@ -43,6 +43,7 @@ type AccessApplication struct {
 	UpdatedAt               *time.Time                     `json:"updated_at,omitempty"`
 	SaasApplication         *SaasApplication               `json:"saas_app,omitempty"`
 	AutoRedirectToIdentity  *bool                          `json:"auto_redirect_to_identity,omitempty"`
+	Policies                []AccessPolicy                 `json:"policies"`
 	SkipInterstitial        *bool                          `json:"skip_interstitial,omitempty"`
 	AppLauncherVisible      *bool                          `json:"app_launcher_visible,omitempty"`
 	EnableBindingCookie     *bool                          `json:"enable_binding_cookie,omitempty"`

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -33,6 +33,50 @@ func TestAccessApplications(t *testing.T) {
 					"session_duration": "24h",
 					"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
 					"auto_redirect_to_identity": false,
+					"policies": [
+						{
+							"id": "699d98642c564d2e855e9661899b7252",
+							"precedence": 1,
+							"decision": "allow",
+							"created_at": "2014-01-01T05:20:00.12345Z",
+							"updated_at": "2014-01-01T05:20:00.12345Z",
+							"name": "Allow devs",
+							"include": [
+								{
+									"email": {
+										"email": "test@example.com"
+									}
+								}
+							],
+							"exclude": [
+								{
+									"email": {
+										"email": "test@example.com"
+									}
+								}
+							],
+							"require": [
+								{
+									"email": {
+										"email": "test@example.com"
+									}
+								}
+							],
+							"purpose_justification_required": true,
+							"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
+							"approval_required": true,
+							"approval_groups": [
+								{
+									"email_list_uuid": "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
+									"approvals_needed": 3
+								},
+								{
+									"email_addresses": ["email1@example.com", "email2@example.com"],
+									"approvals_needed": 1
+								}
+							]
+						}
+					],
 					"enable_binding_cookie": false,
 					"custom_deny_url": "https://www.example.com",
 					"custom_deny_message": "denied!",
@@ -68,6 +112,7 @@ func TestAccessApplications(t *testing.T) {
 		SessionDuration:         "24h",
 		AllowedIdps:             []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
 		AutoRedirectToIdentity:  BoolPtr(false),
+		Policies:                []AccessPolicy{expectedAccessPolicy},
 		EnableBindingCookie:     BoolPtr(false),
 		AppLauncherVisible:      BoolPtr(true),
 		ServiceAuth401Redirect:  BoolPtr(true),


### PR DESCRIPTION
An api call to https://api.cloudflare.com/client/v4/zones/{{zone}}/access/apps; in addition to what is documented at https://developers.cloudflare.com/api/operations/access-applications-list-access-applications will also return the application policies associated with each application.

This field is missing from both the cloudflare-go struct as well as the documentation as far as I can understand.

This can be demonstrated by making a call to the api and viewing the result return.

If this is an expected return value; could this be added to the developer api docs, and then incorporated into the the struct so the return may be usable?

## Has your change been tested?

Yes, it works as expected; added test from access_policy into access_application

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
