### PR TITLE
Enumerate service modes with explicit values

### DIFF
--- a/.changelog/1249.txt
+++ b/.changelog/1249.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+service_mode_v2: update `Mode` field to use new `ServiceMode` string type with explicit const service mode values
+```

--- a/.changelog/1249.txt
+++ b/.changelog/1249.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-service_mode_v2: update `Mode` field to use new `ServiceMode` string type with explicit const service mode values
+devices_policy: update `Mode` field to use new `ServiceMode` string type with explicit const service mode values
 ```

--- a/devices_policy.go
+++ b/devices_policy.go
@@ -17,9 +17,19 @@ type DeviceClientCertificatesZone struct {
 	Result Enabled
 }
 
+type ServiceMode string
+
+const (
+	oneDotOne      ServiceMode = "1dot1"
+	warp           ServiceMode = "warp"
+	proxy          ServiceMode = "proxy"
+	postureOnly    ServiceMode = "posture_only"
+	warpTunnelOnly ServiceMode = "warp_tunnel_only"
+)
+
 type ServiceModeV2 struct {
-	Mode string `json:"mode,omitempty"`
-	Port int    `json:"port,omitempty"`
+	Mode ServiceMode `json:"mode,omitempty"`
+	Port int         `json:"port,omitempty"`
 }
 
 type DeviceSettingsPolicy struct {


### PR DESCRIPTION
## Description

Our current type for the `Mode` field on the `ServiceModeV2` struct is a string. This allows for arbitrary strings, which are not supported service modes.

The `Mode` field now uses a new `ServiceMode` string type that has constant values that can be assigned. These values are all of the existing service modes.

## Has your change been tested?

The underlying `Mode` type has not changed, so we don't need to augment the current tests.
## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
