### PR TITLE
Fix: 'create-or-update' handling of 'name' with 'zone' value

### DIFF
--- a/.changelog/1254.txt
+++ b/.changelog/1254.txt
@@ -1,0 +1,3 @@
+```release-note:note
+dns: improved 'create-or-update' command in flarectl to support 'name' parameters containing 'zone' values
+```

--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -84,7 +84,14 @@ func dnsCreateOrUpdate(c *cli.Context) error {
 		return err
 	}
 
-	records, _, err := api.ListDNSRecords(context.Background(), cloudflare.ZoneIdentifier(zoneID), cloudflare.ListDNSRecordsParams{Name: name + "." + zone})
+	var recordName string
+	if strings.HasSuffix(name, "."+zone) {
+		recordName = name
+	} else {
+		recordName = name + "." + zone
+	}
+
+	records, _, err := api.ListDNSRecords(context.Background(), cloudflare.ZoneIdentifier(zoneID), cloudflare.ListDNSRecordsParams{Name: recordName})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error fetching DNS records: ", err)
 		return err


### PR DESCRIPTION
## Description

In flarectl, the 'flarectl dns create' command can properly process a 'name' parameter even if it includes the value of the 'zone'. However, the 'create-or-update' command does not work if the 'name' parameter contains the value of the 'zone'. I have made a change so that the 'create-or-update' command works even if the 'name' parameter includes the value of the 'zone'.

## Has your change been tested?

It is a minor modification, and I can confirm that it works as intended.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
