### PR TITLE
feat(Access): Add isolation_required flag to access policies

### DIFF
--- a/.changelog/1258.txt
+++ b/.changelog/1258.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access: Add `isolation_required` flag to Access policies
+```

--- a/access_policy.go
+++ b/access_policy.go
@@ -24,6 +24,7 @@ type AccessPolicy struct {
 	UpdatedAt  *time.Time `json:"updated_at"`
 	Name       string     `json:"name"`
 
+	IsolationRequired            *bool                 `json:"isolation_required,omitempty"`
 	PurposeJustificationRequired *bool                 `json:"purpose_justification_required,omitempty"`
 	PurposeJustificationPrompt   *string               `json:"purpose_justification_prompt,omitempty"`
 	ApprovalRequired             *bool                 `json:"approval_required,omitempty"`

--- a/access_policy_test.go
+++ b/access_policy_test.go
@@ -19,6 +19,7 @@ var (
 	updatedAt, _ = time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	expiresAt, _ = time.Parse(time.RFC3339, "2015-01-01T05:20:00.12345Z")
 
+	isolationRequired            = true
 	purposeJustificationRequired = true
 	purposeJustificationPrompt   = "Please provide a business reason for your need to access before continuing."
 	approvalRequired             = true
@@ -39,6 +40,7 @@ var (
 		Require: []interface{}{
 			map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
 		},
+		IsolationRequired:            &isolationRequired,
 		PurposeJustificationRequired: &purposeJustificationRequired,
 		ApprovalRequired:             &approvalRequired,
 		PurposeJustificationPrompt:   &purposeJustificationPrompt,
@@ -95,6 +97,7 @@ func TestAccessPolicies(t *testing.T) {
 							}
 						}
 					],
+					"isolation_required": true,
 					"purpose_justification_required": true,
 					"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 					"approval_required": true,
@@ -176,6 +179,7 @@ func TestAccessPolicy(t *testing.T) {
 						}
 					}
 				],
+				"isolation_required": true,
 				"purpose_justification_required": true,
 				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 				"approval_required": true,
@@ -250,6 +254,7 @@ func TestCreateAccessPolicy(t *testing.T) {
 						}
 					}
 				],
+				"isolation_required": true,
 				"purpose_justification_required": true,
 				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 				"approval_required": true,
@@ -356,6 +361,7 @@ func TestUpdateAccessPolicy(t *testing.T) {
 						}
 					}
 				],
+				"isolation_required": true,
 				"purpose_justification_required": true,
 				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 				"approval_required": true,


### PR DESCRIPTION
Add support for a new flag added to Access policies.

## Description

Access recently released a new feature flag that can require a user to be sent to our browser isolation product.

## Has your change been tested?

Ran all the unit tests locally. Have tested this API a lot.


## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
