### PR TITLE
Add support for missing posture check providers

### DIFF
--- a/.changelog/1268.txt
+++ b/.changelog/1268.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+device_posture_rule: add input fields tanium, intune and kolide
+```

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -182,6 +182,10 @@ type DevicePostureRuleInput struct {
 	Domain           string   `json:"domain,omitempty"`
 	ComplianceStatus string   `json:"compliance_status,omitempty"`
 	ConnectionID     string   `json:"connection_id,omitempty"`
+	IssueCount       string   `json:"issue_count,omitempty"`
+	CountOperator    string   `json:"countOperator,omitempty"`
+	TotalScore       string   `json:"total_score,omitempty"`
+	ScoreOperator    string   `json:"scoreOperator,omitempty"`
 }
 
 // DevicePostureRuleListResponse represents the response from the list


### PR DESCRIPTION
- Intune
- Tanium
- Kolide

We are missing these three posture checks so that we can use it in terraform provider repo.

## Description

Users cannot use terraform to add posture checks of these three type even when they are supported via dash. So we need to provide this functionality via terraform. 

## Has your change been tested?

Yes



## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
