### PR TITLE
Add new Logpush fields for max upload params

### DIFF
--- a/.changelog/1272.txt
+++ b/.changelog/1272.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+logpush: add support for max upload parameters
+```

--- a/logpush.go
+++ b/logpush.go
@@ -11,19 +11,22 @@ import (
 
 // LogpushJob describes a Logpush job.
 type LogpushJob struct {
-	ID                 int                `json:"id,omitempty"`
-	Dataset            string             `json:"dataset"`
-	Enabled            bool               `json:"enabled"`
-	Kind               string             `json:"kind,omitempty"`
-	Name               string             `json:"name"`
-	LogpullOptions     string             `json:"logpull_options"`
-	DestinationConf    string             `json:"destination_conf"`
-	OwnershipChallenge string             `json:"ownership_challenge,omitempty"`
-	LastComplete       *time.Time         `json:"last_complete,omitempty"`
-	LastError          *time.Time         `json:"last_error,omitempty"`
-	ErrorMessage       string             `json:"error_message,omitempty"`
-	Frequency          string             `json:"frequency,omitempty"`
-	Filter             *LogpushJobFilters `json:"filter,omitempty"`
+	ID                       int                `json:"id,omitempty"`
+	Dataset                  string             `json:"dataset"`
+	Enabled                  bool               `json:"enabled"`
+	Kind                     string             `json:"kind,omitempty"`
+	Name                     string             `json:"name"`
+	LogpullOptions           string             `json:"logpull_options"`
+	DestinationConf          string             `json:"destination_conf"`
+	OwnershipChallenge       string             `json:"ownership_challenge,omitempty"`
+	LastComplete             *time.Time         `json:"last_complete,omitempty"`
+	LastError                *time.Time         `json:"last_error,omitempty"`
+	ErrorMessage             string             `json:"error_message,omitempty"`
+	Frequency                string             `json:"frequency,omitempty"`
+	Filter                   *LogpushJobFilters `json:"filter,omitempty"`
+	MaxUploadBytes           int                `json:"max_upload_bytes,omitempty"`
+	MaxUploadRecords         int                `json:"max_upload_records,omitempty"`
+	MaxUploadIntervalSeconds int                `json:"max_upload_interval_seconds,omitempty"`
 }
 
 type LogpushJobFilters struct {

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -28,7 +28,8 @@ const (
 	"last_complete": "%[2]s",
 	"last_error": "%[2]s",
 	"error_message": "test",
-	"frequency": "high"
+	"frequency": "high",
+	"max_upload_bytes": 5000000
   }
 `
 	serverEdgeLogpushJobDescription = `{
@@ -72,6 +73,7 @@ var (
 		LastError:       &testLogpushTimestamp,
 		ErrorMessage:    "test",
 		Frequency:       "high",
+		MaxUploadBytes:  5000000,
 	}
 	expectedEdgeLogpushJobStruct = LogpushJob{
 		ID:              jobID,
@@ -177,18 +179,20 @@ func TestCreateLogpushJob(t *testing.T) {
 	}{
 		"core logpush job": {
 			newJob: LogpushJob{
-				Dataset:         "http_requests",
-				Enabled:         false,
-				Name:            "example.com",
-				LogpullOptions:  "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
-				DestinationConf: "s3://mybucket/logs?region=us-west-2",
+				Dataset:          "http_requests",
+				Enabled:          false,
+				Name:             "example.com",
+				LogpullOptions:   "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
+				DestinationConf:  "s3://mybucket/logs?region=us-west-2",
+				MaxUploadRecords: 1000,
 			},
 			payload: `{
 				"dataset": "http_requests",
 				"enabled":false,
 				"name":"example.com",
 				"logpull_options":"fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
-				"destination_conf":"s3://mybucket/logs?region=us-west-2"
+				"destination_conf":"s3://mybucket/logs?region=us-west-2",
+				"max_upload_records": 1000
 			}`,
 			result: serverLogpushJobDescription,
 			want:   expectedLogpushJobStruct,


### PR DESCRIPTION
## Description

Adds new Logpush fields as documented here https://developers.cloudflare.com/logs/get-started/api-configuration/#max-upload-parameters

- `max_upload_bytes`
- `max_upload_records`
- `max_upload_interval_seconds`

The new fields do have server side validation around the integer values, I wasn't sure whether this client should perform the same validation. Opted out for now as I assume the client doesn't want to be tied into values that could easily change in Cloudflares API.
Similarly, `max_upload_bytes` and `max_upload_records` cannot be used if `kind` is set to `edge`, not sure if that's validation that should be done in the client or not?

## Has your change been tested?

Added to existing logpush tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/


