### PR TITLE
rulesets: allow `PreserveQueryString` to be nullable

### DIFF
--- a/.changelog/1275.txt
+++ b/.changelog/1275.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+rulesets: allow `PreserveQueryString` to be nullable
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -275,7 +275,7 @@ type RulesetRuleActionParametersAutoMinify struct {
 type RulesetRuleActionParametersFromValue struct {
 	StatusCode          uint16                               `json:"status_code,omitempty"`
 	TargetURL           RulesetRuleActionParametersTargetURL `json:"target_url"`
-	PreserveQueryString bool                                 `json:"preserve_query_string,omitempty"`
+	PreserveQueryString *bool                                `json:"preserve_query_string,omitempty"`
 }
 
 type RulesetRuleActionParametersTargetURL struct {

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -523,7 +523,7 @@ func TestGetRuleset_RedirectFromValue(t *testing.T) {
 				TargetURL: RulesetRuleActionParametersTargetURL{
 					Value: "some_host.com",
 				},
-				PreserveQueryString: true,
+				PreserveQueryString: BoolPtr(true),
 			},
 		},
 		Description: "Set dynamic redirect from value",


### PR DESCRIPTION
Updates the `PreserveQueryString` field to be a boolean pointer to be nullable.