### PR TITLE
WR-1279 add waiting room zone-level settings

### DIFF
--- a/.changelog/1276.txt
+++ b/.changelog/1276.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+waiting_room: add support for zone-level settings
+```

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -597,7 +597,7 @@ type UpdateWaitingRoomSettingsParams struct {
 }
 
 // UpdateWaitingRoomSettings lets you replace all zone-level Waiting Room settings. This is in contrast to
-// ChangeWaitingRoomSettings which lets you change individual settings.
+// PatchWaitingRoomSettings which lets you change individual settings.
 //
 // API reference: https://api.cloudflare.com/#waiting-room-update-zone-settings
 func (api *API) UpdateWaitingRoomSettings(ctx context.Context, rc *ResourceContainer, params UpdateWaitingRoomSettingsParams) (WaitingRoomSettings, error) {

--- a/waiting_room_test.go
+++ b/waiting_room_test.go
@@ -97,6 +97,12 @@ var waitingRoomPagePreviewJSON = `
     }
     `
 
+var waitingRoomSettingsJSON = `
+    {
+      "search_engine_crawler_bypass": true
+    }
+   `
+
 var waitingRoom = WaitingRoom{
 	ID:                         waitingRoomID,
 	CreatedOn:                  testTimestampWaitingRoom,
@@ -158,6 +164,18 @@ var waitingRoomRule = WaitingRoomRule{
 	Description: "bypass ip",
 	Enabled:     BoolPtr(true),
 	LastUpdated: &testTimestampWaitingRoom,
+}
+
+var waitingRoomSettings = WaitingRoomSettings{
+	SearchEngineCrawlerBypass: true,
+}
+
+var waitingRoomSettingsUpdate = UpdateWaitingRoomSettingsParams{
+	SearchEngineCrawlerBypass: BoolPtr(true),
+}
+
+var waitingRoomSettingsPatch = PatchWaitingRoomSettingsParams{
+	SearchEngineCrawlerBypass: BoolPtr(true),
 }
 
 func TestListWaitingRooms(t *testing.T) {
@@ -781,6 +799,81 @@ func TestReplaceWaitingRoomRules(t *testing.T) {
 		WaitingRoomID: "699d98642c564d2e855e9661899b7252",
 		Rules:         want,
 	})
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestWaitingRoomSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			  "success": true,
+			  "errors": [],
+			  "messages": [],
+			  "result": %s
+			}
+		`, waitingRoomSettingsJSON)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/waiting_rooms/settings", handler)
+	want := waitingRoomSettings
+
+	actual, err := client.GetWaitingRoomSettings(context.Background(), ZoneIdentifier(testZoneID))
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateWaitingRoomSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			  "success": true,
+			  "errors": [],
+			  "messages": [],
+			  "result": %s
+			}
+		`, waitingRoomSettingsJSON)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/waiting_rooms/settings", handler)
+	want := waitingRoomSettings
+
+	actual, err := client.UpdateWaitingRoomSettings(context.Background(), ZoneIdentifier(testZoneID), waitingRoomSettingsUpdate)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestChangeWaitingRoomSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method, "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			  "success": true,
+			  "errors": [],
+			  "messages": [],
+			  "result": %s
+			}
+		`, waitingRoomSettingsJSON)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/waiting_rooms/settings", handler)
+	want := waitingRoomSettings
+
+	actual, err := client.PatchWaitingRoomSettings(context.Background(), ZoneIdentifier(testZoneID), waitingRoomSettingsPatch)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
 	}


### PR DESCRIPTION
## Description

This adds support for the new Waiting Room zone-level settings, which are used to enable search engine crawler bypass.

## Has your change been tested?

Tests were added, mirroring the other tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
