### PR TITLE
Update Turnstile api

### DIFF
--- a/.changelog/1283.txt
+++ b/.changelog/1283.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+turnstile: Sitekey now required in function calls
+```

--- a/turnstile.go
+++ b/turnstile.go
@@ -34,7 +34,6 @@ type CreateTurnstileWidgetParams struct {
 }
 
 type UpdateTurnstileWidgetParams struct {
-	SiteKey      string   `json:"sitekey,omitempty"`
 	Secret       string   `json:"secret,omitempty"`
 	Name         string   `json:"name,omitempty"`
 	Domains      []string `json:"domains,omitempty"`
@@ -62,7 +61,6 @@ type ListTurnstileWidgetResponse struct {
 }
 
 type RotateTurnstileWidgetParams struct {
-	SiteKey               string
 	InvalidateImmediately bool `json:"invalidate_immediately,omitempty"`
 }
 
@@ -163,16 +161,16 @@ func (api *API) GetTurnstileWidget(ctx context.Context, rc *ResourceContainer, s
 // UpdateTurnstileWidget update the configuration of a widget.
 //
 // API reference: https://api.cloudflare.com/#challenge-widgets-update-a-challenge-widget
-func (api *API) UpdateTurnstileWidget(ctx context.Context, rc *ResourceContainer, params UpdateTurnstileWidgetParams) (TurnstileWidget, error) {
+func (api *API) UpdateTurnstileWidget(ctx context.Context, rc *ResourceContainer, siteKey string, params UpdateTurnstileWidgetParams) (TurnstileWidget, error) {
 	if rc.Identifier == "" {
 		return TurnstileWidget{}, ErrMissingAccountID
 	}
 
-	if params.SiteKey == "" {
+	if siteKey == "" {
 		return TurnstileWidget{}, ErrMissingSiteKey
 	}
 
-	uri := fmt.Sprintf("/accounts/%s/challenges/widgets/%s", rc.Identifier, params.SiteKey)
+	uri := fmt.Sprintf("/accounts/%s/challenges/widgets/%s", rc.Identifier, siteKey)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
 		return TurnstileWidget{}, fmt.Errorf("%s: %w", errMakeRequestError, err)
@@ -193,15 +191,15 @@ func (api *API) UpdateTurnstileWidget(ctx context.Context, rc *ResourceContainer
 // Note that secrets cannot be rotated again during the grace period.
 //
 // API reference: https://api.cloudflare.com/#challenge-widgets-rotate-secret-for-a-challenge-widget
-func (api *API) RotateTurnstileWidget(ctx context.Context, rc *ResourceContainer, param RotateTurnstileWidgetParams) (TurnstileWidget, error) {
+func (api *API) RotateTurnstileWidget(ctx context.Context, rc *ResourceContainer, siteKey string, param RotateTurnstileWidgetParams) (TurnstileWidget, error) {
 	if rc.Identifier == "" {
 		return TurnstileWidget{}, ErrMissingAccountID
 	}
-	if param.SiteKey == "" {
+	if siteKey == "" {
 		return TurnstileWidget{}, ErrMissingSiteKey
 	}
 
-	uri := fmt.Sprintf("/accounts/%s/challenges/widgets/%s/rotate_secret", rc.Identifier, param.SiteKey)
+	uri := fmt.Sprintf("/accounts/%s/challenges/widgets/%s/rotate_secret", rc.Identifier, siteKey)
 	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, param)
 
 	if err != nil {

--- a/turnstile_test.go
+++ b/turnstile_test.go
@@ -226,13 +226,13 @@ func TestTurnstileWidgets_Update(t *testing.T) {
 		assert.Equal(t, ErrMissingAccountID, err)
 	}
 
-	_, err = client.UpdateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), UpdateTurnstileWidgetParams{})
+	_, err = client.UpdateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), "", UpdateTurnstileWidgetParams{})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrMissingSiteKey, err)
 	}
 
-	out, err := client.UpdateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), UpdateTurnstileWidgetParams{
-		SiteKey: testTurnstileWidgetSiteKey,
+	out, err := client.UpdateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), testTurnstileWidgetSiteKey, UpdateTurnstileWidgetParams{
+		Mode: "invisible",
 	})
 	if assert.NoError(t, err) {
 		assert.Equal(t, expectedTurnstileWidget, out, "update challenge_widgets structs not equal")
@@ -276,12 +276,12 @@ func TestTurnstileWidgets_RotateSecret(t *testing.T) {
 		assert.Equal(t, ErrMissingAccountID, err)
 	}
 
-	_, err = client.RotateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), RotateTurnstileWidgetParams{})
+	_, err = client.RotateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), "", RotateTurnstileWidgetParams{})
 	if assert.Error(t, err) {
 		assert.Equal(t, ErrMissingSiteKey, err)
 	}
 
-	out, err := client.RotateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), RotateTurnstileWidgetParams{SiteKey: testTurnstileWidgetSiteKey})
+	out, err := client.RotateTurnstileWidget(context.Background(), AccountIdentifier(testAccountID), testTurnstileWidgetSiteKey, RotateTurnstileWidgetParams{})
 	if assert.NoError(t, err) {
 		assert.Equal(t, expectedTurnstileWidget, out, "rotate challenge_widgets structs not equal")
 	}


### PR DESCRIPTION
## Description

Accept the sitekey as argument in Update/Delete/RotateSecret. This more closely matches the underlying API, and makes more sense? The sitekey is mandatory and used in the URL, it's not part of the request body. This would be similar to the account id / zone id, in that regard.

Without these changes, the Go API is "broken": the APIs try to send requests including the sitekey in the request body, which is rejected by the API. For these reasons, I don't believe there are any users for this cloudflare-go interface, yet.

## Has your change been tested?

Updated the Go tests.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
