### PR TITLE
Fix RotateTurnstileWidget

### DIFF
--- a/.changelog/1285.txt
+++ b/.changelog/1285.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+turnstile: remove `SiteKey` being sent in rotate secret's request body
+```

--- a/turnstile.go
+++ b/turnstile.go
@@ -61,8 +61,8 @@ type ListTurnstileWidgetResponse struct {
 }
 
 type RotateTurnstileWidgetParams struct {
-	SiteKey               string
-	InvalidateImmediately bool `json:"invalidate_immediately,omitempty"`
+	SiteKey               string `json:"-"`
+	InvalidateImmediately bool   `json:"invalidate_immediately,omitempty"`
 }
 
 // CreateTurnstileWidget creates a new challenge widgets.


### PR DESCRIPTION

## Description

Don't send the Sitekey in the request body.
Server-side API will reject the request if it contains the sitekey (because it belongs in the URL)

Similar to #1284, but for the other method. Promise the other 2 functions don't need a similar fix

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented (api.cloudflare.com or developers.cloudflare.com) and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
