### PR TITLE
Fix priority not being set when updating MX records

### DIFF
--- a/.changelog/1290.txt
+++ b/.changelog/1290.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dns: fix MX record priority not set by UpdateDNSRecord
+```

--- a/dns.go
+++ b/dns.go
@@ -74,7 +74,7 @@ type UpdateDNSRecordParams struct {
 	Content  string      `json:"content,omitempty"`
 	Data     interface{} `json:"data,omitempty"` // data for: SRV, LOC
 	ID       string      `json:"-"`
-	Priority *uint16     `json:"-"` // internal use only
+	Priority *uint16     `json:"priority,omitempty`
 	TTL      int         `json:"ttl,omitempty"`
 	Proxied  *bool       `json:"proxied,omitempty"`
 	Comment  string      `json:"comment"`

--- a/dns.go
+++ b/dns.go
@@ -74,7 +74,7 @@ type UpdateDNSRecordParams struct {
 	Content  string      `json:"content,omitempty"`
 	Data     interface{} `json:"data,omitempty"` // data for: SRV, LOC
 	ID       string      `json:"-"`
-	Priority *uint16     `json:"priority,omitempty`
+	Priority *uint16     `json:"priority,omitempty"`
 	TTL      int         `json:"ttl,omitempty"`
 	Proxied  *bool       `json:"proxied,omitempty"`
 	Comment  string      `json:"comment"`


### PR DESCRIPTION
## Description

Since #1170 , it is not possible to update the priority of an MX record. The priority is not sent in the PATCH update request. Also discussed in #1282 .

## Has your change been tested?

I've tested this manually with flarectl.

## Types of changes

What sort of change does your code introduce/modify?

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.