### PR TITLE
tunnels: add support for `access` and `http2Origin` keys

### DIFF
--- a/.changelog/1291.txt
+++ b/.changelog/1291.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+tunnels: add support for `access` and `http2Origin` keys
+```

--- a/tunnel.go
+++ b/tunnel.go
@@ -153,6 +153,20 @@ type OriginRequestConfig struct {
 	ProxyType *string `json:"proxyType,omitempty"`
 	// IP rules for the proxy service
 	IPRules []IngressIPRule `json:"ipRules,omitempty"`
+	// Attempt to connect to origin with HTTP/2
+	Http2Origin *bool `json:"http2Origin,omitempty"`
+	// Access holds all access related configs
+	Access *AccessConfig `json:"access,omitempty"`
+}
+
+type AccessConfig struct {
+	// Required when set to true will fail every request that does not arrive
+	// through an access authenticated endpoint.
+	Required bool `yaml:"required" json:"required,omitempty"`
+	// TeamName is the organization team name to get the public key certificates for.
+	TeamName string `yaml:"teamName" json:"teamName"`
+	// AudTag is the AudTag to verify access JWT against.
+	AudTag []string `yaml:"audTag" json:"audTag"`
 }
 
 type IngressIPRule struct {


### PR DESCRIPTION
Follows on from #1138 with `access` and `http2Origin` keys