### PR TITLE
custom_hostname: add support for `bundle_method`

### DIFF
--- a/.changelog/1298.txt
+++ b/.changelog/1298.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+custom_hostname: add support for `bundle_method` TLS configuration
+```

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -79,6 +79,7 @@ type CustomHostnameSSL struct {
 	SSLValidationRecord
 	ValidationRecords []SSLValidationRecord `json:"validation_records,omitempty"`
 	ValidationErrors  []SSLValidationError  `json:"validation_errors,omitempty"`
+	BundleMethod      string                `json:"bundle_method,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.


### PR DESCRIPTION
Adds support for using `BundleMethod` in custom hostname certificates.