### PR TITLE
Add cookie_suffix and additional_routes fields to Waiting Room object

### DIFF
--- a/.changelog/1311.txt
+++ b/.changelog/1311.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-waiting_room: add support for two new fields, namely, `additional_routes` and `cookie_suffix`
+waiting_room: add support for `additional_routes` and `cookie_suffix`
 ```

--- a/.changelog/1311.txt
+++ b/.changelog/1311.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+waiting_room: add support for two new fields, namely, `additional_routes` and `cookie_suffix`
+```

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -16,25 +16,27 @@ var (
 
 // WaitingRoom describes a WaitingRoom object.
 type WaitingRoom struct {
-	CreatedOn                  time.Time  `json:"created_on,omitempty"`
-	ModifiedOn                 time.Time  `json:"modified_on,omitempty"`
-	Path                       string     `json:"path"`
-	Name                       string     `json:"name"`
-	Description                string     `json:"description,omitempty"`
-	QueueingMethod             string     `json:"queueing_method,omitempty"`
-	CustomPageHTML             string     `json:"custom_page_html,omitempty"`
-	DefaultTemplateLanguage    string     `json:"default_template_language,omitempty"`
-	Host                       string     `json:"host"`
-	ID                         string     `json:"id,omitempty"`
-	NewUsersPerMinute          int        `json:"new_users_per_minute"`
-	TotalActiveUsers           int        `json:"total_active_users"`
-	SessionDuration            int        `json:"session_duration"`
-	QueueAll                   bool       `json:"queue_all"`
-	DisableSessionRenewal      bool       `json:"disable_session_renewal"`
-	Suspended                  bool       `json:"suspended"`
-	JsonResponseEnabled        bool       `json:"json_response_enabled"`
-	NextEventPrequeueStartTime *time.Time `json:"next_event_prequeue_start_time,omitempty"`
-	NextEventStartTime         *time.Time `json:"next_event_start_time,omitempty"`
+	CreatedOn                  time.Time           `json:"created_on,omitempty"`
+	ModifiedOn                 time.Time           `json:"modified_on,omitempty"`
+	Path                       string              `json:"path"`
+	Name                       string              `json:"name"`
+	Description                string              `json:"description,omitempty"`
+	QueueingMethod             string              `json:"queueing_method,omitempty"`
+	CustomPageHTML             string              `json:"custom_page_html,omitempty"`
+	DefaultTemplateLanguage    string              `json:"default_template_language,omitempty"`
+	Host                       string              `json:"host"`
+	ID                         string              `json:"id,omitempty"`
+	NewUsersPerMinute          int                 `json:"new_users_per_minute"`
+	TotalActiveUsers           int                 `json:"total_active_users"`
+	SessionDuration            int                 `json:"session_duration"`
+	QueueAll                   bool                `json:"queue_all"`
+	DisableSessionRenewal      bool                `json:"disable_session_renewal"`
+	Suspended                  bool                `json:"suspended"`
+	JsonResponseEnabled        bool                `json:"json_response_enabled"`
+	NextEventPrequeueStartTime *time.Time          `json:"next_event_prequeue_start_time,omitempty"`
+	NextEventStartTime         *time.Time          `json:"next_event_start_time,omitempty"`
+	CookieSuffix               string              `json:"cookie_suffix"`
+	AdditionalRoutes           []*WaitingRoomRoute `json:"additional_routes,omitempty"`
 }
 
 // WaitingRoomStatus describes the status of a waiting room.
@@ -90,6 +92,12 @@ type WaitingRoomPagePreviewURL struct {
 // WaitingRoomPagePreviewCustomHTML describes a WaitingRoomPagePreviewCustomHTML object.
 type WaitingRoomPagePreviewCustomHTML struct {
 	CustomHTML string `json:"custom_html"`
+}
+
+// WaitingRoomRoute describes a WaitingRoomRoute object.
+type WaitingRoomRoute struct {
+	Host string `json:"host"`
+	Path string `json:"path"`
 }
 
 // WaitingRoomDetailResponse is the API response, containing a single WaitingRoom.

--- a/waiting_room_test.go
+++ b/waiting_room_test.go
@@ -39,7 +39,9 @@ var waitingRoomJSON = fmt.Sprintf(`
       "custom_page_html": "{{#waitTimeKnown}} {{waitTime}} mins {{/waitTimeKnown}} {{^waitTimeKnown}} Queue all enabled {{/waitTimeKnown}}",
       "default_template_language": "en-US",
       "next_event_prequeue_start_time": null,
-      "next_event_start_time": "%s"
+      "next_event_start_time": "%s",
+			"cookie_suffix": "example_shop",
+			"additional_routes": [{"host": "shop2.example.com", "path": "/shop/checkout"}]
     }
    `, waitingRoomID, testTimestampWaitingRoom.Format(time.RFC3339Nano), testTimestampWaitingRoom.Format(time.RFC3339Nano),
 	testTimestampWaitingRoomEventStart.Format(time.RFC3339Nano))
@@ -123,6 +125,8 @@ var waitingRoom = WaitingRoom{
 	DefaultTemplateLanguage:    "en-US",
 	NextEventStartTime:         &testTimestampWaitingRoomEventStart,
 	NextEventPrequeueStartTime: nil,
+	CookieSuffix:               "example_shop",
+	AdditionalRoutes:           []*WaitingRoomRoute{{Host: "shop2.example.com", Path: "/shop/checkout"}},
 }
 
 var waitingRoomEvent = WaitingRoomEvent{


### PR DESCRIPTION
This PR adds the 2 new fields that has been added to the Waiting Room object, namely, `additional_routes` and `cookie_suffix` to support the functionality of multihost and multipath feature. 

https://developers.cloudflare.com/api/operations/waiting-room-create-waiting-room#request-body

## Description

The documentation has been updated however the client needs a sync and therefore the terraform changes. 

## Has your change been tested?

Yes, Waiting Room relevant tests have been updated to handle the addition of these 2 new fields. 

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
