### PR TITLE
cloudflare: remove all references to `api.AccountID`

### DIFF
--- a/.changelog/1315.txt
+++ b/.changelog/1315.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+cloudflare: remove `api.AccountID` from client struct
+```
+
+```release-note:breaking-change
+cloudflare: remove `UsingAccount` in favour of resource specific attributes
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -45,7 +45,6 @@ type API struct {
 	APIUserServiceKey string
 	APIToken          string
 	BaseURL           string
-	AccountID         string
 	UserAgent         string
 	headers           http.Header
 	httpClient        *http.Client
@@ -147,7 +146,7 @@ func (api *API) SetAuthType(authType int) {
 // ZoneIDByName retrieves a zone's ID from the name.
 func (api *API) ZoneIDByName(zoneName string) (string, error) {
 	zoneName = normalizeZoneName(zoneName)
-	res, err := api.ListZonesContext(context.Background(), WithZoneFilters(zoneName, api.AccountID, ""))
+	res, err := api.ListZonesContext(context.Background(), WithZoneFilters(zoneName, "", ""))
 	if err != nil {
 		return "", fmt.Errorf("ListZonesContext command failed: %w", err)
 	}
@@ -414,19 +413,6 @@ func (api *API) request(ctx context.Context, method, uri string, reqBody io.Read
 	}
 
 	return resp, nil
-}
-
-// Returns the base URL to use for API endpoints that exist for accounts.
-// If an account option was used when creating the API instance, returns
-// the account URL.
-//
-// accountBase is the base URL for endpoints referring to the current user.
-// It exists as a parameter because it is not consistent across APIs.
-func (api *API) userBaseURL(accountBase string) string {
-	if api.AccountID != "" {
-		return "/accounts/" + api.AccountID
-	}
-	return accountBase
 }
 
 // copyHeader copies all headers for `source` and sets them on `target`.

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -352,7 +352,7 @@ func TestZoneIDByNameWithNonUniqueZonesWithoutOrgID(t *testing.T) {
 }
 
 func TestZoneIDByNameWithIDN(t *testing.T) {
-	setup(UsingAccount("01a7362d577a6c3019a474fd6f485823"))
+	setup()
 	defer teardown()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -44,10 +44,6 @@ func initializeAPI(c *cli.Context) error {
 		return err
 	}
 
-	if c.IsSet("account-id") {
-		cloudflare.UsingAccount(c.String("account-id"))(api) // nolint
-	}
-
 	return nil
 }
 

--- a/options.go
+++ b/options.go
@@ -28,17 +28,6 @@ func Headers(headers http.Header) Option {
 	}
 }
 
-// UsingAccount allows you to apply account-level changes (Load Balancing,
-// Railguns) to an account instead.
-//
-// Deprecated: Resources should define the `AccountID` parameter explicitly.
-func UsingAccount(accountID string) Option {
-	return func(api *API) error {
-		api.AccountID = accountID
-		return nil
-	}
-}
-
 // UsingRateLimit applies a non-default rate limit to client API requests
 // If not specified the default of 4rps will be applied.
 func UsingRateLimit(rps float64) Option {


### PR DESCRIPTION
Now that all references to `api.AccountID` are removed, we can pull out the
helpers that were setting it along with any other method references.

Closes #1154