### PR TITLE
feat(workers): configure tail consumers

### DIFF
--- a/.changelog/1317.txt
+++ b/.changelog/1317.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers: Add ability to specify tail Workers in script metadata
+```

--- a/utils.go
+++ b/utils.go
@@ -9,6 +9,10 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
+func ptr[T any](val T) *T {
+	return &val
+}
+
 // buildURI assembles the base path and queries.
 func buildURI(path string, options interface{}) string {
 	v, _ := query.Values(options)

--- a/utils.go
+++ b/utils.go
@@ -9,10 +9,6 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-func ptr[T any](val T) *T {
-	return &val
-}
-
 // buildURI assembles the base path and queries.
 func buildURI(path string, options interface{}) string {
 	v, _ := query.Values(options)

--- a/workers.go
+++ b/workers.go
@@ -90,6 +90,11 @@ type WorkerScript struct {
 	UsageModel string `json:"usage_model,omitempty"`
 }
 
+type WorkersTailConsumer struct {
+	Service     string  `json:"service"`
+	Environment *string `json:"environment,omitempty"`
+}
+
 // WorkerMetaData contains worker script information such as size, creation & modification dates.
 type WorkerMetaData struct {
 	ID               string         `json:"id,omitempty"`

--- a/workers.go
+++ b/workers.go
@@ -28,12 +28,15 @@ type CreateWorkerParams struct {
 	// ES Module syntax script.
 	Module bool
 
-	// Logpush opts the worker into Workers Logpush logging. A nil value leaves the current setting unchanged.
-	//  https://developers.cloudflare.com/workers/platform/logpush/
+	// Logpush opts the worker into Workers Logpush logging. A nil value leaves
+	// the current setting unchanged.
+	//
+	// Documentation: https://developers.cloudflare.com/workers/platform/logpush/
 	Logpush *bool
 
-	// TailConsumers specifices a list of Workers that will consume the logs of the attached Worker.
-	//  https://developers.cloudflare.com/workers/platform/tail-workers/
+	// TailConsumers specifies a list of Workers that will consume the logs of
+	// the attached Worker.
+	// Documentation: https://developers.cloudflare.com/workers/platform/tail-workers/
 	TailConsumers *[]WorkersTailConsumer
 
 	// Bindings should be a map where the keys are the binding name, and the

--- a/workers_test.go
+++ b/workers_test.go
@@ -239,9 +239,9 @@ var (
 		ID:                "e7a57d8746e74ae49c25994dadb421b1",
 		ETAG:              "279cf40d86d70b82f6cd3ba90a646b3ad995912da446836d7371c21c6a43977a",
 		Size:              191,
-		LastDeployedFrom:  ptr("dash"),
-		Logpush:           ptr(false),
-		CompatibilityDate: ptr("2022-07-12"),
+		LastDeployedFrom:  StringPtr("dash"),
+		Logpush:           BoolPtr(false),
+		CompatibilityDate: StringPtr("2022-07-12"),
 	}
 )
 
@@ -545,8 +545,8 @@ func TestUploadWorker_Basic(t *testing.T) {
 				ETAG:             "279cf40d86d70b82f6cd3ba90a646b3ad995912da446836d7371c21c6a43977a",
 				Size:             191,
 				ModifiedOn:       formattedTime,
-				Logpush:          ptr(false),
-				LastDeployedFrom: ptr("dash"),
+				Logpush:          BoolPtr(false),
+				LastDeployedFrom: StringPtr("dash"),
 			},
 		}}
 	if assert.NoError(t, err) {
@@ -588,8 +588,8 @@ func TestUploadWorker_Module(t *testing.T) {
 				ETAG:             "279cf40d86d70b82f6cd3ba90a646b3ad995912da446836d7371c21c6a43977a",
 				Size:             191,
 				CreatedOn:        formattedCreatedTime,
-				Logpush:          ptr(false),
-				LastDeployedFrom: ptr("dash"),
+				Logpush:          BoolPtr(false),
+				LastDeployedFrom: StringPtr("dash"),
 			},
 		}}
 	if assert.NoError(t, err) {
@@ -680,8 +680,8 @@ func TestUploadWorker_WithInheritBinding(t *testing.T) {
 				ETAG:             "279cf40d86d70b82f6cd3ba90a646b3ad995912da446836d7371c21c6a43977a",
 				Size:             191,
 				ModifiedOn:       formattedTime,
-				Logpush:          ptr(false),
-				LastDeployedFrom: ptr("dash"),
+				Logpush:          BoolPtr(false),
+				LastDeployedFrom: StringPtr("dash"),
 			},
 		}}
 
@@ -952,7 +952,7 @@ func TestUploadWorker_WithLogpush(t *testing.T) {
 
 	var (
 		formattedTime, _ = time.Parse(time.RFC3339Nano, "2018-06-09T15:17:01.989141Z")
-		logpush          = ptr(true)
+		logpush          = BoolPtr(true)
 	)
 	mux.HandleFunc("/accounts/"+testAccountID+"/workers/scripts/foo", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
@@ -978,7 +978,7 @@ func TestUploadWorker_WithLogpush(t *testing.T) {
 				Size:             191,
 				ModifiedOn:       formattedTime,
 				Logpush:          logpush,
-				LastDeployedFrom: ptr("dash"),
+				LastDeployedFrom: StringPtr("dash"),
 			},
 		}}
 	if assert.NoError(t, err) {
@@ -1059,7 +1059,7 @@ func TestUploadWorker_WithSmartPlacementEnabled(t *testing.T) {
 	defer teardown()
 
 	placementMode := PlacementModeSmart
-	response := workersScriptResponse(t, withWorkerScript(expectedWorkersModuleWorkerScript), withWorkerPlacementMode(ptr("smart")))
+	response := workersScriptResponse(t, withWorkerScript(expectedWorkersModuleWorkerScript), withWorkerPlacementMode(StringPtr("smart")))
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
@@ -1124,7 +1124,7 @@ func TestUploadWorker_WithTailConsumers(t *testing.T) {
 	t.Run("adds tail consumers", func(t *testing.T) {
 		tailConsumers := []WorkersTailConsumer{
 			{Service: "my-service-a"},
-			{Service: "my-service-b", Environment: ptr("production")},
+			{Service: "my-service-b", Environment: StringPtr("production")},
 		}
 		response = workersScriptResponse(t,
 			withWorkerScript(expectedWorkersModuleWorkerScript),
@@ -1133,7 +1133,7 @@ func TestUploadWorker_WithTailConsumers(t *testing.T) {
 		worker, err := client.UploadWorker(context.Background(), AccountIdentifier(testAccountID), CreateWorkerParams{
 			ScriptName:    "bar",
 			Script:        workerScript,
-			TailConsumers: ptr(tailConsumers),
+			TailConsumers: &tailConsumers,
 		})
 		assert.NoError(t, err)
 		require.NotNil(t, worker.TailConsumers)

--- a/workers_test.go
+++ b/workers_test.go
@@ -963,7 +963,7 @@ func TestUploadWorker_WithLogpush(t *testing.T) {
 		assert.Equal(t, &expected, mpUpload.Logpush)
 
 		w.Header().Set("content-type", "application/json")
-		fmt.Fprint(w, workersScriptResponse(t, withWorkerLogpush(logpush), withWorkerModifiedOn(formattedTime)))
+		fmt.Fprint(w, workersScriptResponse(t, withWorkerScript(expectedWorkersModuleWorkerScript), withWorkerLogpush(logpush), withWorkerModifiedOn(formattedTime)))
 	})
 	res, err := client.UploadWorker(context.Background(), AccountIdentifier(testAccountID), CreateWorkerParams{ScriptName: "foo", Script: workerScript, Logpush: logpush})
 	want := WorkerScriptResponse{

--- a/workers_test.go
+++ b/workers_test.go
@@ -245,54 +245,67 @@ var (
 	}
 )
 
+//nolint:unused
 func withWorkerScript(content string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.Script = content }
 }
 
+//nolint:unused
 func withWorkerUsageModel(um string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.UsageModel = um }
 }
 
+//nolint:unused
 func withWorkerHandlers(h []string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.Handlers = h }
 }
 
+//nolint:unused
 func withWorkerID(id string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.ID = id }
 }
 
+//nolint:unused
 func withWorkerEtag(etag string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.ETAG = etag }
 }
 
+//nolint:unused
 func withWorkerSize(size uint) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.Size = size }
 }
 
+//nolint:unused
 func withWorkerCreatedOn(co time.Time) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.CreatedOn = co.Format(time.RFC3339Nano) }
 }
 
+//nolint:unused
 func withWorkerModifiedOn(mo time.Time) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.ModifiedOn = mo.Format(time.RFC3339Nano) }
 }
 
+//nolint:unused
 func withWorkerLogpush(logpush *bool) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.Logpush = logpush }
 }
 
+//nolint:unused
 func withWorkerPlacementMode(mode *string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.PlacementMode = mode }
 }
 
+//nolint:unused
 func withWorkerTailConsumers(consumers ...WorkersTailConsumer) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.TailConsumers = &consumers }
 }
 
+//nolint:unused
 func withWorkerLastDeployedFrom(from *string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.LastDeployedFrom = from }
 }
 
+//nolint:unused
 func withWorkerDeploymentId(dID *string) workersTestResponseOpt {
 	return func(r *WorkersTestScriptResponse) { r.DeploymentId = dID }
 }


### PR DESCRIPTION
Hello from the Workers team :wave: 

## Description

This adds the necessary functionality to the sdk to allow customers to set [Tail Workers](https://developers.cloudflare.com/workers/platform/tail-workers/) as consumers on their scripts. Tail Consumers are also included in the response metadata, and the updates the response to reflect that.

Additionally, this does a fairly large refactor to the Workers test suite, moving script response to a variadic parameters setup. Many of the existing hardcoded responses were out of date or half complete, so this ensures an easy way to make changes in 1 spot going forward for consistent & up to date api shapes.

For reviewing purposes these have been broken into separate commits.

## Has your change been tested?

A test has been added to cover uploading a Tail Consumer.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
