### PR TITLE
Add ability to retrieve zone DCV delegation information

### DIFF
--- a/.changelog/1321.txt
+++ b/.changelog/1321.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+zone: adds `ZoneDCVDelegation` function to retrieve zone DCV delegation information
+```

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -175,6 +175,11 @@ func zoneInfo(c *cli.Context) error {
 	}
 	output := make([][]string, 0, len(zones))
 	for _, z := range zones {
+		dcvDelegation, err := api.ZoneDCVDelegation(context.Background(), z.ID)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
 		var nameservers []string
 		if len(z.VanityNS) > 0 {
 			nameservers = z.VanityNS
@@ -189,9 +194,10 @@ func zoneInfo(c *cli.Context) error {
 			strings.Join(nameservers, ", "),
 			fmt.Sprintf("%t", z.Paused),
 			z.Type,
+			fmt.Sprintf("%s%s", dcvDelegation.UUID, cloudflare.ZoneDCVDelegationHostname),
 		})
 	}
-	writeTable(c, output, "ID", "Zone", "Plan", "Status", "Name Servers", "Paused", "Type")
+	writeTable(c, output, "ID", "Zone", "Plan", "Status", "Name Servers", "Paused", "Type", "DCV Delegation")
 
 	return nil
 }

--- a/zone.go
+++ b/zone.go
@@ -19,6 +19,11 @@ var (
 	ErrMissingSettingName = errors.New("zone setting name required but missing")
 )
 
+const (
+	// ZoneDCVDelegationHostname is the DCV delegation hostname
+	ZoneDCVDelegationHostname = ".dcv.cloudflare.com"
+)
+
 // Owner describes the resource owner.
 type Owner struct {
 	ID        string `json:"id"`
@@ -108,6 +113,17 @@ type ZoneID struct {
 type ZoneResponse struct {
 	Response
 	Result Zone `json:"result"`
+}
+
+// ZoneDCVDelegationResponse represents the response from the Zone DCV Delegation.
+type ZoneDCVDelegationResponse struct {
+	Response
+	Result ZoneDCVDelegation `json:"result"`
+}
+
+// ZoneDCVDelegation contains only the DCV delegation UUID.
+type ZoneDCVDelegation struct {
+	UUID string `json:"uuid"`
 }
 
 // ZonesResponse represents the response from the Zone endpoint containing an array of zones.
@@ -836,6 +852,21 @@ func (api *API) ZoneSSLSettings(ctx context.Context, zoneID string) (ZoneSSLSett
 	err = json.Unmarshal(res, &r)
 	if err != nil {
 		return ZoneSSLSetting{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+	return r.Result, nil
+}
+
+// ZoneDCVDelegation returns information about DCV Delegation to the specified zone.
+func (api *API) ZoneDCVDelegation(ctx context.Context, zoneID string) (ZoneDCVDelegation, error) {
+	uri := fmt.Sprintf("/zones/%s/dcv_delegation/uuid", zoneID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return ZoneDCVDelegation{}, err
+	}
+	var r ZoneDCVDelegationResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return ZoneDCVDelegation{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 	return r.Result, nil
 }

--- a/zone_test.go
+++ b/zone_test.go
@@ -1610,3 +1610,22 @@ func TestUpdateZoneSettingWithCustomPathPrefix(t *testing.T) {
 		assert.Equal(t, s.ModifiedOn, "2014-01-01T05:20:00.12345Z")
 	}
 }
+
+func TestZoneDCVDelegation(t *testing.T) {
+	setup()
+	defer teardown()
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method '%s', got %s", http.MethodGet, r.Method)
+		w.Header().Set("content-type", "application/json")
+		_, _ = fmt.Fprintf(w, `{
+			"result": {
+				"UUID": "johv1uc9ii4cheeg"
+			}
+		}`)
+	}
+	mux.HandleFunc("/zones/foo/dcv_delegation/uuid", handler)
+	s, err := client.ZoneDCVDelegation(context.Background(), "foo")
+	if assert.NoError(t, err) {
+		assert.Equal(t, s.UUID, "johv1uc9ii4cheeg")
+	}
+}


### PR DESCRIPTION
Add ability to retrieve zone DCV delegation information

## Description

To automatically create a DNS CNAME record, the DCV delegation hostname is required, I use the undocumented `/zones/<zone-id>/dcv_delegation/uuid` endpoint to get the UUID for this.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.
