### PR TITLE
dispatch namespace features

### DIFF
--- a/.changelog/1330.txt
+++ b/.changelog/1330.txt
@@ -1,0 +1,15 @@
+```release-note:enhancement
+workers: Add support for uploading scripts to a Workers for Platforms namespace.
+```
+
+```release-note:enhancement
+workers: Add support for declaring arbitrary bindings with UnsafeBinding.
+```
+
+```release-note:enhancement
+workers: Add support for uploading workers with Workers for Platforms namespace bindings.
+```
+
+```release-note:enhancement
+workers: Add `pipeline_hash` field to Workers script response struct.
+```

--- a/workers.go
+++ b/workers.go
@@ -114,6 +114,7 @@ type WorkerMetaData struct {
 	LastDeployedFrom *string                `json:"last_deployed_from,omitempty"`
 	DeploymentId     *string                `json:"deployment_id,omitempty"`
 	PlacementMode    *PlacementMode         `json:"placement_mode,omitempty"`
+	PipelineHash     *string                `json:"pipeline_hash,omitempty"`
 }
 
 // WorkerListResponse wrapper struct for API response to worker script list API call.

--- a/workers.go
+++ b/workers.go
@@ -24,6 +24,9 @@ type CreateWorkerParams struct {
 	ScriptName string
 	Script     string
 
+	// DispatchNamespaceName uploads the worker to a WFP dispatch namespace if provided
+	DispatchNamespaceName *string
+
 	// Module changes the Content-Type header to specify the script is an
 	// ES Module syntax script.
 	Module bool
@@ -273,6 +276,10 @@ func (api *API) UploadWorker(ctx context.Context, rc *ResourceContainer, params 
 	}
 
 	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s", rc.Identifier, params.ScriptName)
+	if params.DispatchNamespaceName != nil {
+		uri = fmt.Sprintf("/accounts/%s/workers/namespaces/%s/scripts/%s", rc.Identifier, *params.DispatchNamespaceName, params.ScriptName)
+	}
+
 	headers := make(http.Header)
 	headers.Set("Content-Type", contentType)
 	res, err := api.makeRequestContextWithHeaders(ctx, http.MethodPut, uri, body, headers)

--- a/workers_bindings.go
+++ b/workers_bindings.go
@@ -407,6 +407,19 @@ func (b DispatchNamespaceBinding) serialize(bindingName string) (workerBindingMe
 	return meta, nil, nil
 }
 
+// UnsafeBinding is for experimental or deprecated bindings, and allows specifying any binding type or property
+type UnsafeBinding map[string]interface{}
+
+// Type returns the type of the binding.
+func (b UnsafeBinding) Type() WorkerBindingType {
+	return ""
+}
+
+func (b UnsafeBinding) serialize(bindingName string) (workerBindingMeta, workerBindingBodyWriter, error) {
+	b["name"] = bindingName
+	return b, nil, nil
+}
+
 // Each binding that adds a part to the multipart form body will need
 // a unique part name so we just generate a random 128bit hex string.
 func getRandomPartName() string {

--- a/workers_bindings.go
+++ b/workers_bindings.go
@@ -41,6 +41,8 @@ const (
 	WorkerAnalyticsEngineBindingType WorkerBindingType = "analytics_engine"
 	// WorkerQueueBindingType is the type for queue bindings.
 	WorkerQueueBindingType WorkerBindingType = "queue"
+	// DispatchNamespaceBindingType is the type for WFP namespace bindings.
+	DispatchNamespaceBindingType WorkerBindingType = "dispatch_namespace"
 )
 
 type ListWorkerBindingsParams struct {
@@ -337,6 +339,72 @@ func (b WorkerQueueBinding) serialize(bindingName string) (workerBindingMeta, wo
 		"name":       b.Binding,
 		"queue_name": b.Queue,
 	}, nil, nil
+}
+
+// DispatchNamespaceBinding is a binding to a Workers for Platforms namespace
+//
+// https://developers.cloudflare.com/workers/platform/bindings/#dispatch-namespace-bindings-workers-for-platforms
+type DispatchNamespaceBinding struct {
+	Binding   string
+	Namespace string
+	Outbound  *NamespaceOutboundOptions
+}
+
+type NamespaceOutboundOptions struct {
+	Worker WorkerReference
+	Params []OutboundParamSchema
+}
+
+type WorkerReference struct {
+	Service     string
+	Environment *string
+}
+
+type OutboundParamSchema struct {
+	Name string
+}
+
+// Type returns the type of the binding.
+func (b DispatchNamespaceBinding) Type() WorkerBindingType {
+	return DispatchNamespaceBindingType
+}
+
+func (b DispatchNamespaceBinding) serialize(bindingName string) (workerBindingMeta, workerBindingBodyWriter, error) {
+	if b.Binding == "" {
+		return nil, nil, fmt.Errorf(`Binding name for binding "%s" cannot be empty`, bindingName)
+	}
+	if b.Namespace == "" {
+		return nil, nil, fmt.Errorf(`Namespace name for binding "%s" cannot be empty`, bindingName)
+	}
+
+	meta := workerBindingMeta{
+		"type":      b.Type(),
+		"name":      b.Binding,
+		"namespace": b.Namespace,
+	}
+
+	if b.Outbound != nil {
+		if b.Outbound.Worker.Service == "" {
+			return nil, nil, fmt.Errorf(`Outbound options for binding "%s" must have a service name`, bindingName)
+		}
+
+		var params []map[string]interface{}
+		for _, param := range b.Outbound.Params {
+			params = append(params, map[string]interface{}{
+				"name": param.Name,
+			})
+		}
+
+		meta["outbound"] = map[string]interface{}{
+			"worker": map[string]interface{}{
+				"service":     b.Outbound.Worker.Service,
+				"environment": b.Outbound.Worker.Environment,
+			},
+			"params": params,
+		}
+	}
+
+	return meta, nil, nil
 }
 
 // Each binding that adds a part to the multipart form body will need

--- a/workers_bindings.go
+++ b/workers_bindings.go
@@ -407,7 +407,7 @@ func (b DispatchNamespaceBinding) serialize(bindingName string) (workerBindingMe
 	return meta, nil, nil
 }
 
-// UnsafeBinding is for experimental or deprecated bindings, and allows specifying any binding type or property
+// UnsafeBinding is for experimental or deprecated bindings, and allows specifying any binding type or property.
 type UnsafeBinding map[string]interface{}
 
 // Type returns the type of the binding.

--- a/workers_bindings_test.go
+++ b/workers_bindings_test.go
@@ -1,7 +1,9 @@
 package cloudflare
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -94,4 +96,47 @@ func TestListWorkerBindings(t *testing.T) {
 		},
 	})
 	assert.Equal(t, WorkerAnalyticsEngineBindingType, res.BindingList[7].Binding.Type())
+}
+
+func ExampleUnsafeBinding() {
+	pretty := func(meta workerBindingMeta) string {
+		buf := bytes.NewBufferString("")
+		encoder := json.NewEncoder(buf)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(meta); err != nil {
+			fmt.Println("error:", err)
+		}
+		return buf.String()
+	}
+
+	binding_a := WorkerServiceBinding{
+		Service: "foo",
+	}
+	meta_a, _, _ := binding_a.serialize("my_binding")
+	meta_a_json := pretty(meta_a)
+	fmt.Println(meta_a_json)
+
+	binding_b := UnsafeBinding{
+		"type":    "service",
+		"service": "foo",
+	}
+	meta_b, _, _ := binding_b.serialize("my_binding")
+	meta_b_json := pretty(meta_b)
+	fmt.Println(meta_b_json)
+
+	fmt.Println(meta_a_json == meta_b_json)
+	// Output:
+	// {
+	//   "name": "my_binding",
+	//   "service": "foo",
+	//   "type": "service"
+	// }
+	//
+	// {
+	//   "name": "my_binding",
+	//   "service": "foo",
+	//   "type": "service"
+	// }
+	//
+	// true
 }

--- a/workers_test.go
+++ b/workers_test.go
@@ -1209,7 +1209,7 @@ func TestUploadWorker_ToDispatchNamespace(t *testing.T) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 
 		mpUpload, err := parseMultipartUpload(r)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, workerScript, mpUpload.Script)
 
@@ -1242,7 +1242,7 @@ func TestUploadWorker_UnsafeBinding(t *testing.T) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 
 		mpUpload, err := parseMultipartUpload(r)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, workerScript, mpUpload.Script)
 

--- a/workers_test.go
+++ b/workers_test.go
@@ -1054,6 +1054,64 @@ func TestUploadWorker_WithQueueBinding(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestUploadWorker_WithDispatchNamespaceBinding(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+
+		mpUpload, err := parseMultipartUpload(r)
+		assert.NoError(t, err)
+
+		expectedBindings := map[string]workerBindingMeta{
+			"b1": {
+				"name":      "b1",
+				"type":      "dispatch_namespace",
+				"namespace": "n1",
+				"outbound": map[string]interface{}{
+					"worker": map[string]interface{}{
+						"service":     "w1",
+						"environment": "e1",
+					},
+					"params": []interface{}{
+						map[string]interface{}{"name": "param1"},
+					},
+				},
+			},
+		}
+		assert.Equal(t, workerScript, mpUpload.Script)
+		assert.Equal(t, expectedBindings, mpUpload.BindingMeta)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, workersScriptResponse(t))
+	}
+	mux.HandleFunc("/accounts/"+testAccountID+"/workers/scripts/bar", handler)
+
+	environmentName := "e1"
+	_, err := client.UploadWorker(context.Background(), AccountIdentifier(testAccountID), CreateWorkerParams{
+		ScriptName: "bar",
+		Script:     workerScript,
+		Bindings: map[string]WorkerBinding{
+			"b1": DispatchNamespaceBinding{
+				Binding:   "b1",
+				Namespace: "n1",
+				Outbound: &NamespaceOutboundOptions{
+					Worker: WorkerReference{
+						Service:     "w1",
+						Environment: &environmentName,
+					},
+					Params: []OutboundParamSchema{
+						{
+							Name: "param1",
+						},
+					},
+				},
+			},
+		}})
+	assert.NoError(t, err)
+}
+
 func TestUploadWorker_WithSmartPlacementEnabled(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description

Adds support for several Workers for Platforms features:
- dispatch namespace bindings
- uploading workers 'to' a dispatch namespace

Also includes a few internal-ish items:
- 'unsafe' bindings, similar to wrangler's: https://github.com/cloudflare/workers-sdk/pull/411
- 'pipeline_hash', which is used internally and in a few experimental features. This is also present in wrangler: https://github.com/cloudflare/workers-sdk/blob/1ce32968b990fef59953b8cd61172b98fb2386e5/packages/wrangler/src/deploy/deploy.ts#L635

## Has your change been tested?

Yes, besides `pipeline_hash`, but they've only been tested against the mock handlers in the included tests.

## Types of changes

What sort of change does your code introduce/modify?

- [❌ ] Bug fix (non-breaking change which fixes an issue)
- [✅ ] New feature (non-breaking change which adds functionality)
- [❌ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [✅] My code follows the code style of this project.
- [❓] My change requires a change to the documentation.
  - Possibly. The public features are documented on ` developers.cloudflare.com `, but I don't believe the library changes are.
- [❌] I have updated the documentation accordingly.
- [✅] I have added tests to cover my changes.
- [✅] All new and existing tests passed.
- [❓] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.
  - The WFP APIs should be stable.
  - The 'unsafe' binding API is specifically to avoid adding support for some unstable features.
  - The `pipeline_hash` field is internal and unstable, but has been requested by some users.
