### PR TITLE
Add support for client_certificate and sentinelone_s2s posture rules

### DIFF
--- a/.changelog/1339.txt
+++ b/.changelog/1339.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+device_posture_rule: support certificate_id and cn for client_certificate posture rule
+```
+
+```release-note:enhancement
+device_posture_rule: support active_threats, network_status, infected, and is_active for sentinelone_s2s posture rule
+```

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -187,6 +187,12 @@ type DevicePostureRuleInput struct {
 	CountOperator    string   `json:"countOperator,omitempty"`
 	TotalScore       string   `json:"total_score,omitempty"`
 	ScoreOperator    string   `json:"scoreOperator,omitempty"`
+	CertificateID    string   `json:"certificate_id,omitempty"`
+	CommonName       string   `json:"cn,omitempty"`
+	ActiveThreats    int      `json:"active_threats,omitempty"`
+	NetworkStatus    string   `json:"network_status,omitempty"`
+	Infected         bool     `json:"infected,omitempty"`
+	IsActive         bool     `json:"is_active,omitempty"`
 }
 
 // DevicePostureRuleListResponse represents the response from the list

--- a/device_posture_rule_test.go
+++ b/device_posture_rule_test.go
@@ -541,6 +541,61 @@ func TestDevicePostureDomainJoinedRule(t *testing.T) {
 	}
 }
 
+func TestDevicePostureClientCertificateRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+				"schedule": "1h",
+				"expiration": "1h",
+				"type": "client_certificate",
+				"name": "My rule name",
+				"description": "My description",
+				"match": [
+					{
+						"platform": "windows"
+					}
+				],
+				"input": {
+					"certificate_id": "d2c04b78-3ba2-4294-8efa-4e85aef0777f",
+					"cn": "example.com"
+				}
+			}
+		}
+		`)
+	}
+
+	want := DevicePostureRule{
+		ID:          "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:        "My rule name",
+		Description: "My description",
+		Type:        "client_certificate",
+		Schedule:    "1h",
+		Expiration:  "1h",
+		Match:       []DevicePostureRuleMatch{{Platform: "windows"}},
+		Input: DevicePostureRuleInput{
+			CertificateID: "d2c04b78-3ba2-4294-8efa-4e85aef0777f",
+			CommonName:    "example.com",
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/devices/posture/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err := client.DevicePostureRule(context.Background(), testAccountID, "480f4f69-1a28-4fdd-9240-1ed29f0ac1db")
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
 func TestCreateDevicePostureRule(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description

Added fields to DevicePostureRuleInput to accommodate needed inputs for the new posture types: client_certificate and sentinelone_s2s.

## Has your change been tested?

Because it is just adding fields to the DevicePostureRuleInput struct, this should not affect existing uses of it. There has been a test created to test the creation of the client_certificate posture rule to test out the added fields.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
