### PR TITLE
Fix CreateOrUpdate needs the record name

### DIFF
--- a/.changelog/1341.txt
+++ b/.changelog/1341.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-dns: allow for create or update to actually create the record
+flarectl: allow for create or update to actually create the record
 ```

--- a/.changelog/1341.txt
+++ b/.changelog/1341.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dns: allow for create or update to actually create the record
+```

--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -114,13 +114,14 @@ func dnsCreateOrUpdate(c *cli.Context) error {
 		}
 	} else {
 		// Record doesn't exist - create it
-		rr := cloudflare.CreateDNSRecordParams{}
-		rr.Type = rtype
-		rr.Content = content
-		rr.TTL = ttl
-		rr.Proxied = &proxy
-		rr.Priority = &priority
-		rr.Name = name
+		rr := cloudflare.CreateDNSRecordParams{
+			Name:     name,
+			Type:     rtype,
+			Content:  content,
+			TTL:      ttl,
+			Proxied:  &proxy,
+			Priority: &priority,
+		}
 
 		// TODO: Print the response.
 		result, err = api.CreateDNSRecord(context.Background(), cloudflare.ZoneIdentifier(zoneID), rr)

--- a/cmd/flarectl/dns.go
+++ b/cmd/flarectl/dns.go
@@ -120,6 +120,8 @@ func dnsCreateOrUpdate(c *cli.Context) error {
 		rr.TTL = ttl
 		rr.Proxied = &proxy
 		rr.Priority = &priority
+		rr.Name = name
+
 		// TODO: Print the response.
 		result, err = api.CreateDNSRecord(context.Background(), cloudflare.ZoneIdentifier(zoneID), rr)
 		if err != nil {


### PR DESCRIPTION
For now, it was failing because we were not passing the name to the record to be created if it was not present.


## Description

Make the CLI act as expected in `create-or-update` when no records are found 

## Has your change been tested?

Yes - ran it against a host I have

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
