### PR TITLE
access_service_token: add support for `Duration`

### DIFF
--- a/.changelog/1347.txt
+++ b/.changelog/1347.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access_service_token: add support for managing `Duration`
+```

--- a/access_service_tokens.go
+++ b/access_service_tokens.go
@@ -21,6 +21,7 @@ type AccessServiceToken struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	UpdatedAt *time.Time `json:"updated_at"`
+	Duration  string     `json:"duration,omitempty"`
 }
 
 // AccessServiceTokenUpdateResponse represents the response from the API
@@ -33,6 +34,7 @@ type AccessServiceTokenUpdateResponse struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	ClientID  string     `json:"client_id"`
+	Duration  string     `json:"duration,omitempty"`
 }
 
 // AccessServiceTokenRefreshResponse represents the response from the API
@@ -44,6 +46,7 @@ type AccessServiceTokenRefreshResponse struct {
 	ID        string     `json:"id"`
 	Name      string     `json:"name"`
 	ClientID  string     `json:"client_id"`
+	Duration  string     `json:"duration,omitempty"`
 }
 
 // AccessServiceTokenCreateResponse is the same API response as the Update
@@ -57,6 +60,7 @@ type AccessServiceTokenCreateResponse struct {
 	Name         string     `json:"name"`
 	ClientID     string     `json:"client_id"`
 	ClientSecret string     `json:"client_secret"`
+	Duration     string     `json:"duration,omitempty"`
 }
 
 // AccessServiceTokenRotateResponse is the same API response as the Create
@@ -69,6 +73,7 @@ type AccessServiceTokenRotateResponse struct {
 	Name         string     `json:"name"`
 	ClientID     string     `json:"client_id"`
 	ClientSecret string     `json:"client_secret"`
+	Duration     string     `json:"duration,omitempty"`
 }
 
 // AccessServiceTokensListResponse represents the response from the list
@@ -127,12 +132,14 @@ type AccessServiceTokensRotateSecretDetailResponse struct {
 type ListAccessServiceTokensParams struct{}
 
 type CreateAccessServiceTokenParams struct {
-	Name string `json:"name"`
+	Name     string `json:"name"`
+	Duration string `json:"duration,omitempty"`
 }
 
 type UpdateAccessServiceTokenParams struct {
-	Name string `json:"name"`
-	UUID string `json:"-"`
+	Name     string `json:"name"`
+	UUID     string `json:"-"`
+	Duration string `json:"duration,omitempty"`
 }
 
 func (api *API) ListAccessServiceTokens(ctx context.Context, rc *ResourceContainer, params ListAccessServiceTokensParams) ([]AccessServiceToken, ResultInfo, error) {

--- a/access_service_tokens_test.go
+++ b/access_service_tokens_test.go
@@ -28,7 +28,8 @@ func TestAccessServiceTokens(t *testing.T) {
 					"expires_at": "2015-01-01T05:20:00.12345Z",
 					"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 					"name": "CI/CD token",
-					"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com"
+					"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com",
+					"duration": "8760h"
 				}
 			]
 		}
@@ -47,6 +48,7 @@ func TestAccessServiceTokens(t *testing.T) {
 			ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 			Name:      "CI/CD token",
 			ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
+			Duration:  "8760h",
 		},
 	}
 
@@ -85,7 +87,8 @@ func TestCreateAccessServiceToken(t *testing.T) {
 				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 				"name": "CI/CD token",
 				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com",
-				"client_secret": "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5"
+				"client_secret": "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5",
+				"duration": "8760h"
 			}
 		}
 		`)
@@ -99,6 +102,7 @@ func TestCreateAccessServiceToken(t *testing.T) {
 		Name:         "CI/CD token",
 		ClientID:     "88bf3b6d86161464f6509f7219099e57.access.example.com",
 		ClientSecret: "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5",
+		Duration:     "8760h",
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/service_tokens", handler)
@@ -135,7 +139,8 @@ func TestUpdateAccessServiceToken(t *testing.T) {
 				"expires_at": "2015-01-01T05:20:00.12345Z",
 				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 				"name": "CI/CD token",
-				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com"
+				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com",
+				"duration": "8760h"
 			}
 		}
 		`)
@@ -148,6 +153,7 @@ func TestUpdateAccessServiceToken(t *testing.T) {
 		ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name:      "CI/CD token",
 		ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
+		Duration:  "8760h",
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)
@@ -184,7 +190,8 @@ func TestRefreshAccessServiceToken(t *testing.T) {
 				"expires_at": "2015-01-01T05:20:00.12345Z",
 				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 				"name": "CI/CD token",
-				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com"
+				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com",
+				"duration": "8760h"
 			}
 		}
 		`)
@@ -197,6 +204,7 @@ func TestRefreshAccessServiceToken(t *testing.T) {
 		ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name:      "CI/CD token",
 		ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
+		Duration:  "8760h",
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/refresh", handler)
@@ -226,7 +234,8 @@ func TestRotateAccessServiceToken(t *testing.T) {
 				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 				"name": "CI/CD token",
 				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com",
-				"client_secret": "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5"
+				"client_secret": "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5",
+				"duration": "8760h"
 			}
 		}
 		`)
@@ -240,6 +249,7 @@ func TestRotateAccessServiceToken(t *testing.T) {
 		Name:         "CI/CD token",
 		ClientID:     "88bf3b6d86161464f6509f7219099e57.access.example.com",
 		ClientSecret: "bdd31cbc4dec990953e39163fbbb194c93313ca9f0a6e420346af9d326b1d2a5",
+		Duration:     "8760h",
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415/rotate", handler)
@@ -268,7 +278,8 @@ func TestDeleteAccessServiceToken(t *testing.T) {
 				"expires_at": "2015-01-01T05:20:00.12345Z",
 				"id": "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 				"name": "CI/CD token",
-				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com"
+				"client_id": "88bf3b6d86161464f6509f7219099e57.access.example.com",
+				"duration": "8760h"
 			}
 		}
 		`)
@@ -281,6 +292,7 @@ func TestDeleteAccessServiceToken(t *testing.T) {
 		ID:        "f174e90a-fafe-4643-bbbc-4a0ed4fc8415",
 		Name:      "CI/CD token",
 		ClientID:  "88bf3b6d86161464f6509f7219099e57.access.example.com",
+		Duration:  "8760h",
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/service_tokens/f174e90a-fafe-4643-bbbc-4a0ed4fc8415", handler)


### PR DESCRIPTION
Allows setting individual durations for service tokens.

API documentation: https://developers.cloudflare.com/api/operations/zone-level-access-service-tokens-create-a-service-token