### PR TITLE
replace `encoding/json` with `github.com/goccy/go-json`

### DIFF
--- a/.changelog/1360.txt
+++ b/.changelog/1360.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+cloudflare: swap `encoding/json` for `github.com/goccy/go-json`
+```
+
+```release-note:bug
+cache_purge: don't escape HTML entity values in URLs for cache keys
+```

--- a/access_application.go
+++ b/access_application.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessApplicationType represents the application type.

--- a/access_audit_log.go
+++ b/access_audit_log.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessAuditLogRecord is the structure of a single Access Audit Log entry.

--- a/access_audit_log_example_test.go
+++ b/access_audit_log_example_test.go
@@ -2,9 +2,10 @@ package cloudflare_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
+
+	"github.com/goccy/go-json"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 )

--- a/access_bookmark.go
+++ b/access_bookmark.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessBookmark represents an Access bookmark application.

--- a/access_ca_certificate.go
+++ b/access_ca_certificate.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessCACertificate is the structure of the CA certificate used for

--- a/access_custom_page.go
+++ b/access_custom_page.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrMissingUID = errors.New("required UID missing")

--- a/access_group.go
+++ b/access_group.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessGroup defines a group for allowing or disallowing access to

--- a/access_identity_provider.go
+++ b/access_identity_provider.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessIdentityProvider is the structure of the provider object.

--- a/access_keys.go
+++ b/access_keys.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type AccessKeysConfig struct {

--- a/access_keys_test.go
+++ b/access_keys_test.go
@@ -2,12 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/access_mutual_tls_certificates.go
+++ b/access_mutual_tls_certificates.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessMutualTLSCertificate is the structure of a single Access Mutual TLS

--- a/access_organization.go
+++ b/access_organization.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessOrganization represents an Access organization.

--- a/access_policy.go
+++ b/access_policy.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/access_service_tokens.go
+++ b/access_service_tokens.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/account_members.go
+++ b/account_members.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // AccountMember is the definition of a member of an account.

--- a/account_roles.go
+++ b/account_roles.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // AccountRole defines the roles that a member can have attached.

--- a/accounts.go
+++ b/accounts.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccountSettings outlines the available options for an account.

--- a/addressing_address_map.go
+++ b/addressing_address_map.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AddressMap contains information about an address map.

--- a/addressing_ip_prefix.go
+++ b/addressing_ip_prefix.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // IPPrefix contains information about an IP prefix.

--- a/api_shield.go
+++ b/api_shield.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // AuthIdCharacteristics a single option from

--- a/api_token.go
+++ b/api_token.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // APIToken is the full API token.

--- a/argo.go
+++ b/argo.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var validSettingValues = []string{"on", "off"}

--- a/argo_tunnel.go
+++ b/argo_tunnel.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // ArgoTunnel is the struct definition of a tunnel.

--- a/auditlogs.go
+++ b/auditlogs.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AuditLogAction is a member of AuditLog, the action that was taken.

--- a/authenticated_origin_pulls.go
+++ b/authenticated_origin_pulls.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AuthenticatedOriginPulls represents global AuthenticatedOriginPulls (tls_client_auth) metadata.

--- a/authenticated_origin_pulls_per_hostname.go
+++ b/authenticated_origin_pulls_per_hostname.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // PerHostnameAuthenticatedOriginPullsCertificateDetails represents the metadata for a Per Hostname AuthenticatedOriginPulls certificate.

--- a/authenticated_origin_pulls_per_zone.go
+++ b/authenticated_origin_pulls_per_zone.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // PerZoneAuthenticatedOriginPullsSettings represents the settings for Per Zone AuthenticatedOriginPulls.

--- a/cache_reserve.go
+++ b/cache_reserve.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // CacheReserve is the structure of the API object for the cache reserve

--- a/certificate_packs.go
+++ b/certificate_packs.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // CertificatePackGeoRestrictions is for the structure of the geographic

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -4,7 +4,6 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"golang.org/x/time/rate"
 )

--- a/cloudflare_experimental.go
+++ b/cloudflare_experimental.go
@@ -3,7 +3,6 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/hashicorp/go-retryablehttp"
 )

--- a/cloudflare_test.go
+++ b/cloudflare_test.go
@@ -2,13 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/flarectl/misc.go
+++ b/cmd/flarectl/misc.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
+	"github.com/goccy/go-json"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 )

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -2,13 +2,14 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // CustomHostnameStatus is the enumeration of valid state values in the CustomHostnameSSL.

--- a/custom_nameservers.go
+++ b/custom_nameservers.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type CustomNameserverRecord struct {

--- a/custom_pages.go
+++ b/custom_pages.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // CustomPage represents a custom page configuration.

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // DevicePostureIntegrationConfig contains authentication information

--- a/device_posture_rule_test.go
+++ b/device_posture_rule_test.go
@@ -240,7 +240,7 @@ func TestDevicePostureIntegrationDelete(t *testing.T) {
 			"success": true,
 			"errors": [],
 			"messages": [],
-			"result": null 
+			"result": null
 		}`)
 	}
 

--- a/devices_dex.go
+++ b/devices_dex.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type DeviceDexTestData map[string]interface{}

--- a/devices_managed_networks.go
+++ b/devices_managed_networks.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type Config struct {

--- a/devices_policy.go
+++ b/devices_policy.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type Enabled struct {

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // DiagnosticsTracerouteConfiguration is the overarching structure of the

--- a/diagnostics_test.go
+++ b/diagnostics_test.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/dlp_payload_log.go
+++ b/dlp_payload_log.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type DLPPayloadLogSettings struct {

--- a/dlp_payload_log_test.go
+++ b/dlp_payload_log_test.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/dlp_profile.go
+++ b/dlp_profile.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/dlp_profile_test.go
+++ b/dlp_profile_test.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/dns.go
+++ b/dns.go
@@ -3,7 +3,6 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/goccy/go-json"
 	"golang.org/x/net/idna"
 )
 

--- a/dns_firewall.go
+++ b/dns_firewall.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrMissingClusterID = errors.New("missing required cluster ID")

--- a/dns_test.go
+++ b/dns_test.go
@@ -2,12 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/duration.go
+++ b/duration.go
@@ -1,8 +1,9 @@
 package cloudflare
 
 import (
-	"encoding/json"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // Duration implements json.Marshaler and json.Unmarshaler for time.Duration

--- a/duration_test.go
+++ b/duration_test.go
@@ -1,9 +1,10 @@
 package cloudflare
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 func ExampleDuration() {

--- a/email_routing_destination.go
+++ b/email_routing_destination.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type EmailRoutingDestinationAddress struct {

--- a/email_routing_rules.go
+++ b/email_routing_rules.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrMissingRuleID = errors.New("required rule id missing")

--- a/email_routing_settings.go
+++ b/email_routing_settings.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type EmailRoutingSettings struct {

--- a/fallback_domain.go
+++ b/fallback_domain.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // FallbackDomainResponse represents the response from the get fallback

--- a/filter.go
+++ b/filter.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrNotEnoughFilterIDsProvided = errors.New("at least one filter ID must be provided.")

--- a/firewall.go
+++ b/firewall.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // AccessRule represents a firewall access rule.

--- a/firewall_rules.go
+++ b/firewall_rules.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // FirewallRule is the struct of the firewall rule.

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/healthchecks.go
+++ b/healthchecks.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // Healthcheck describes a Healthcheck object.

--- a/images.go
+++ b/images.go
@@ -3,13 +3,14 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/images_test.go
+++ b/images_test.go
@@ -3,13 +3,14 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/intelligence_asn.go
+++ b/intelligence_asn.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // ErrMissingASN is for when ASN is required but not set.

--- a/intelligence_domain.go
+++ b/intelligence_domain.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // ErrMissingDomain is for when domain is needed but not given.

--- a/intelligence_ip.go
+++ b/intelligence_ip.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // IPIntelligence represents IP intelligence information.

--- a/intelligence_phishing.go
+++ b/intelligence_phishing.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // PhishingScan represent information about a phishing scan.

--- a/intelligence_whois.go
+++ b/intelligence_whois.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // WHOIS represents whois information.

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -19,6 +19,7 @@ package tools
 //go:generate go install golang.org/x/lint/golint
 //go:generate go install golang.org/x/oauth2
 //go:generate go install golang.org/x/tools/gopls@latest
+//go:generate go install golang.org/x/tools/cmd/goimports@latest
 
 import (
 	// local development tooling for linting and debugging.
@@ -35,6 +36,7 @@ import (
 	_ "github.com/securego/gosec/v2/cmd/gosec"
 	_ "github.com/uudashr/gopkgs/v2/cmd/gopkgs"
 	_ "golang.org/x/lint/golint"
+	_ "golang.org/x/tools/cmd/goimports@latest"
 	_ "golang.org/x/tools/gopls"
 
 	// used for changelog-check tooling

--- a/ip_list.go
+++ b/ip_list.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // The definitions in this file are deprecated and should be removed after

--- a/ips.go
+++ b/ips.go
@@ -1,11 +1,12 @@
 package cloudflare
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/goccy/go-json"
 )
 
 // IPRangesResponse contains the structure for the API response, not modified.

--- a/keyless.go
+++ b/keyless.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // KeylessSSL represents Keyless SSL configuration.

--- a/keyless_test.go
+++ b/keyless_test.go
@@ -2,12 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/list.go
+++ b/list.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/load_balancing.go
+++ b/load_balancing.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // LoadBalancerPool represents a load balancer pool's properties.

--- a/lockdown.go
+++ b/lockdown.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // ZoneLockdown represents a Zone Lockdown rule. A rule only permits access to

--- a/lockdown_test.go
+++ b/lockdown_test.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/logpull.go
+++ b/logpull.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // LogpullRetentionConfiguration describes a the structure of a Logpull Retention

--- a/logpush.go
+++ b/logpush.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // LogpushJob describes a Logpush job.

--- a/logpush_example_test.go
+++ b/logpush_example_test.go
@@ -2,9 +2,10 @@ package cloudflare_test
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
+
+	"github.com/goccy/go-json"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 )

--- a/logpush_test.go
+++ b/logpush_test.go
@@ -2,13 +2,14 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"strconv"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	"time"
 

--- a/magic_firewall_rulesets.go
+++ b/magic_firewall_rulesets.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/magic_transit_gre_tunnel.go
+++ b/magic_transit_gre_tunnel.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // Magic Transit GRE Tunnel Error messages.

--- a/magic_transit_ipsec_tunnel.go
+++ b/magic_transit_ipsec_tunnel.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // Magic Transit IPsec Tunnel Error messages.

--- a/magic_transit_static_routes.go
+++ b/magic_transit_static_routes.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // Magic Transit Static Routes Error messages.

--- a/managed_headers.go
+++ b/managed_headers.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type ListManagedHeadersResponse struct {

--- a/mtls_certificates.go
+++ b/mtls_certificates.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // MTLSAssociation represents the metadata for an existing association

--- a/notifications.go
+++ b/notifications.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // NotificationMechanismData holds a single public facing mechanism data

--- a/notifications_test.go
+++ b/notifications_test.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/options.go
+++ b/options.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"net/http"
-
 	"time"
 
 	"golang.org/x/time/rate"

--- a/origin_ca.go
+++ b/origin_ca.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // OriginCACertificate represents a Cloudflare-issued certificate.
@@ -38,13 +39,13 @@ type CreateOriginCertificateParams struct {
 // UnmarshalJSON handles custom parsing from an API response to an OriginCACertificate
 // http://choly.ca/post/go-json-marshalling/
 func (c *OriginCACertificate) UnmarshalJSON(data []byte) error {
-	type alias OriginCACertificate
+	type Alias OriginCACertificate
 
 	aux := &struct {
 		ExpiresOn string `json:"expires_on"`
-		*alias
+		*Alias
 	}{
-		alias: (*alias)(c),
+		Alias: (*Alias)(c),
 	}
 
 	var err error

--- a/origin_ca_test.go
+++ b/origin_ca_test.go
@@ -2,13 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/page_rules.go
+++ b/page_rules.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // PageRuleTarget is the target to evaluate on a request.

--- a/page_rules_test.go
+++ b/page_rules_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-
 	"time"
 
 	"github.com/stretchr/testify/assert"

--- a/pages_deployment.go
+++ b/pages_deployment.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // SizeOptions can be passed to a list request to configure size and cursor location.

--- a/pages_deployment_test.go
+++ b/pages_deployment_test.go
@@ -305,7 +305,7 @@ func TestListPagesDeploymentsPagination(t *testing.T) {
 			fmt.Fprintf(w, `{
 				"success": true,
 				"errors": [],
-				"messages": [],	
+				"messages": [],
 				"result": [
 					%s
 				],
@@ -321,7 +321,7 @@ func TestListPagesDeploymentsPagination(t *testing.T) {
 			fmt.Fprintf(w, `{
 				"success": true,
 				"errors": [],
-				"messages": [],	
+				"messages": [],
 				"result": [
 					%s
 				],

--- a/pages_domain.go
+++ b/pages_domain.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // PagesDomain represents a pages domain.

--- a/pages_project.go
+++ b/pages_project.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type PagesPreviewDeploymentSetting string

--- a/permission_group.go
+++ b/permission_group.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type PermissionGroup struct {

--- a/queue.go
+++ b/queue.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/r2_bucket.go
+++ b/r2_bucket.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/rate_limiting.go
+++ b/rate_limiting.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // RateLimit is a policy than can be applied to limit traffic within a customer domain.

--- a/regional_hostnames.go
+++ b/regional_hostnames.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type Region struct {

--- a/regional_tiered_cache.go
+++ b/regional_tiered_cache.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // RegionalTieredCache is the structure of the API object for the regional tiered cache

--- a/registrar.go
+++ b/registrar.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // RegistrarDomain is the structure of the API response for a new

--- a/rulesets.go
+++ b/rulesets.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/secondary_dns_primaries.go
+++ b/secondary_dns_primaries.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/secondary_dns_tsig.go
+++ b/secondary_dns_tsig.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/secondary_dns_zone.go
+++ b/secondary_dns_zone.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 const (

--- a/spectrum.go
+++ b/spectrum.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // ProxyProtocol implements json.Unmarshaler in order to support deserializing of the deprecated boolean

--- a/split_tunnel.go
+++ b/split_tunnel.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // SplitTunnelResponse represents the response from the get split

--- a/ssl.go
+++ b/ssl.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // ZoneCustomSSL represents custom SSL certificate metadata.

--- a/stream.go
+++ b/stream.go
@@ -3,7 +3,6 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -11,6 +10,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/sts.go
+++ b/sts.go
@@ -1,11 +1,12 @@
 package cloudflare
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/goccy/go-json"
 
 	"github.com/hashicorp/go-retryablehttp"
 )

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type TeamsAccount struct {

--- a/teams_devices.go
+++ b/teams_devices.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type TeamsDevicesList struct {

--- a/teams_list.go
+++ b/teams_list.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrMissingListID = errors.New("required missing list ID")

--- a/teams_locations.go
+++ b/teams_locations.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type TeamsLocationsListResponse struct {

--- a/teams_proxy_endpoints.go
+++ b/teams_proxy_endpoints.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type TeamsProxyEndpointListResponse struct {

--- a/teams_rules.go
+++ b/teams_rules.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type TeamsRuleSettings struct {

--- a/tiered_cache.go
+++ b/tiered_cache.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type TieredCacheType int

--- a/total_tls.go
+++ b/total_tls.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type TotalTLS struct {

--- a/tunnel.go
+++ b/tunnel.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // A TunnelDuration is a Duration that has custom serialization for JSON.

--- a/tunnel_routes.go
+++ b/tunnel_routes.go
@@ -2,13 +2,14 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/tunnel_virtual_networks.go
+++ b/tunnel_virtual_networks.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrMissingVnetName = errors.New("required missing virtual network name")

--- a/turnstile.go
+++ b/turnstile.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrMissingSiteKey = errors.New("required site key missing")

--- a/universal_ssl.go
+++ b/universal_ssl.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // UniversalSSLSetting represents a universal ssl setting's properties.

--- a/url_normalization_settings.go
+++ b/url_normalization_settings.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type URLNormalizationSettings struct {

--- a/user.go
+++ b/user.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // User describes a user account.

--- a/user_agent.go
+++ b/user_agent.go
@@ -2,12 +2,13 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/goccy/go-json"
 )
 
 // UserAgentRule represents a User-Agent Block. These rules can be used to

--- a/waf.go
+++ b/waf.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
+
+	"github.com/goccy/go-json"
 )
 
 // WAFPackage represents a WAF package configuration.

--- a/waf_overrides.go
+++ b/waf_overrides.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // WAFOverridesResponse represents the response form the WAF overrides endpoint.

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/web3.go
+++ b/web3.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/workers.go
+++ b/workers.go
@@ -3,7 +3,6 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -12,6 +11,8 @@ import (
 	"net/textproto"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // WorkerRequestParams provides parameters for worker requests for both enterprise and standard requests.

--- a/workers_account_settings.go
+++ b/workers_account_settings.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type WorkersAccountSettings struct {

--- a/workers_bindings.go
+++ b/workers_bindings.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	rand "crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+
+	"github.com/goccy/go-json"
 )
 
 // WorkerBindingType represents a particular type of binding.

--- a/workers_bindings_test.go
+++ b/workers_bindings_test.go
@@ -3,11 +3,12 @@ package cloudflare
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/workers_cron_triggers.go
+++ b/workers_cron_triggers.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // WorkerCronTriggerResponse represents the response from the Worker cron trigger

--- a/workers_domain.go
+++ b/workers_domain.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/workers_kv.go
+++ b/workers_kv.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+
+	"github.com/goccy/go-json"
 )
 
 // CreateWorkersKVNamespaceParams provides parameters for creating and updating storage namespaces.

--- a/workers_routes.go
+++ b/workers_routes.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 var ErrMissingWorkerRouteID = errors.New("missing required route ID")

--- a/workers_secrets.go
+++ b/workers_secrets.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // WorkersPutSecretRequest provides parameters for creating and updating secrets.

--- a/workers_subdomain.go
+++ b/workers_subdomain.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 type WorkersSubdomain struct {

--- a/workers_tail.go
+++ b/workers_tail.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (

--- a/workers_test.go
+++ b/workers_test.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/zone.go
+++ b/zone.go
@@ -2,7 +2,6 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"golang.org/x/net/idna"
 )

--- a/zone.go
+++ b/zone.go
@@ -672,8 +672,15 @@ func (api *API) PurgeCache(ctx context.Context, zoneID string, pcr PurgeCacheReq
 //
 // API reference: https://api.cloudflare.com/#zone-purge-individual-files-by-url-and-cache-tags
 func (api *API) PurgeCacheContext(ctx context.Context, zoneID string, pcr PurgeCacheRequest) (PurgeCacheResponse, error) {
+	// manually build the payload to ensure we don't escape HTML entities to
+	// match their keys for purging.
+	payload, err := json.MarshalWithOption(pcr, json.DisableHTMLEscape())
+	if err != nil {
+		return PurgeCacheResponse{}, err
+	}
+
 	uri := fmt.Sprintf("/zones/%s/purge_cache", zoneID)
-	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, pcr)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, payload)
 	if err != nil {
 		return PurgeCacheResponse{}, err
 	}

--- a/zone_cache_variants.go
+++ b/zone_cache_variants.go
@@ -2,10 +2,11 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 type ZoneCacheVariantsValues struct {

--- a/zone_test.go
+++ b/zone_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/md5"   //nolint:gosec
 	"encoding/hex" // for generating IDs
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/zones.go
+++ b/zones.go
@@ -2,8 +2,9 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+
+	"github.com/goccy/go-json"
 )
 
 const defaultZonesPerPage = 100


### PR DESCRIPTION
The stdlib has some, ermm, quirks with how certain methods handle strings
without a way to customise that behaviour. This bites us in cases where our API
payloads (represented as bytes) *shouldn't* be escaping HTML entities however
they end up escaped and won't match our internal representation of them.

Instead of doing hacky work arounds, I've just swapped out `encoding/json` with
`github.com/goccy/go-json` which mentions it is a drop in replacement but, it
includes a way to customise certain behaviours as needed.

As a side benefit, this will also considerably speed up JSON 
marshaling/unmarshaling on larger and more complex payloads.

Closes #1350