### PR TITLE
Update support for tanium_s2s posture rules

### DIFF
--- a/.changelog/1366.txt
+++ b/.changelog/1366.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+device_posture_rule: support eid_last_seen and risk_level and correct total_score for Tanium posture rule
+```

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -186,7 +186,7 @@ type DevicePostureRuleInput struct {
 	ConnectionID     string   `json:"connection_id,omitempty"`
 	IssueCount       string   `json:"issue_count,omitempty"`
 	CountOperator    string   `json:"countOperator,omitempty"`
-	TotalScore       string   `json:"total_score,omitempty"`
+	TotalScore       int      `json:"total_score,omitempty"`
 	ScoreOperator    string   `json:"scoreOperator,omitempty"`
 	CertificateID    string   `json:"certificate_id,omitempty"`
 	CommonName       string   `json:"cn,omitempty"`
@@ -194,6 +194,8 @@ type DevicePostureRuleInput struct {
 	NetworkStatus    string   `json:"network_status,omitempty"`
 	Infected         bool     `json:"infected,omitempty"`
 	IsActive         bool     `json:"is_active,omitempty"`
+	EidLastSeen      string   `json:"eid_last_seen,omitempty"`
+	RiskLevel        string   `json:"risk_level,omitempty"`
 }
 
 // DevicePostureRuleListResponse represents the response from the list


### PR DESCRIPTION
## Description
Added EidLastSeen and RiskLevel as well as updated TotalScore to be an int in DevicePostureRuleInput. Adding these additional fields were at the request of Tanium.

## Has your change been tested?

Because it is just adding fields to the DevicePostureRuleInput struct, this should not affect existing uses of it. 

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
