### PR TITLE
add support for tags to CreateWorkerParams

### DIFF
--- a/.changelog/1368.txt
+++ b/.changelog/1368.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers: add support for tagging Worker scripts
+```


### PR DESCRIPTION
## Description

Our API supports tagging scripts (primarily for Workers for Platforms, but they also work for non-WFP scripts), and `cloudflare-go` support for them has been requested.

## Has your change been tested?

Yes, in the unit tests, but no against the API. It's still using the same endpoints it was before, so at least it won't have the same bug my last PR did :)

## Types of changes

What sort of change does your code introduce/modify?

- [❌] Bug fix (non-breaking change which fixes an issue)
- [✅] New feature (non-breaking change which adds functionality)
- [❌] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [✅] My code follows the code style of this project.
- [✅] My change requires a change to the documentation.
- [❌] I have updated the documentation accordingly.
  - I will ensure this field is documented in our API schema after opening the PR.
- [✅] I have added tests to cover my changes.
- [✅] All new and existing tests passed.
- [❌, ✅] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
