### PR TITLE
Add support for Read Timeout in Rulesets API

### DIFF
--- a/.changelog/1374.txt
+++ b/.changelog/1374.txt
@@ -1,0 +1,3 @@
+```release_note:enhancement
+rulesets: Add support for Proxy Read Timeout configuration via the Rulesets/Cache Rules API
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -247,6 +247,7 @@ type RulesetRuleActionParameters struct {
 	Mirage                  *bool                                             `json:"mirage,omitempty"`
 	OpportunisticEncryption *bool                                             `json:"opportunistic_encryption,omitempty"`
 	Polish                  *Polish                                           `json:"polish,omitempty"`
+	ReadTimeout             *uint                                             `json:"read_timeout,omitempty"`
 	RocketLoader            *bool                                             `json:"rocket_loader,omitempty"`
 	SecurityLevel           *SecurityLevel                                    `json:"security_level,omitempty"`
 	ServerSideExcludes      *bool                                             `json:"server_side_excludes,omitempty"`

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -241,6 +241,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 						}
 					}
 				},
+				"read_timeout": 1000,
 				"origin_error_page_passthru":true
 			},
 			"description": "Set all available cache settings in one rule",
@@ -324,6 +325,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 					},
 				},
 			},
+			ReadTimeout:             UintPtr(1000),
 			OriginErrorPagePassthru: BoolPtr(true),
 		},
 		Description: "Set all available cache settings in one rule",


### PR DESCRIPTION
## Description

Adds support for the usage of the `read_timeout` field which has been added to the rulesets API. This controls the Proxy Read Timeout for connections to the origin to allow for longer wait times before closing the connection.

## Has your change been tested?

The API has been tested thoroughly. Unit tests have been modified to include validation of the API response. Additional testing may be required.

<!--
Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.
-->

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
