### PR TITLE
feat(workers): allow namespaced scripts to be used as Worker tail consumers

### DIFF
--- a/.changelog/1377.txt
+++ b/.changelog/1377.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers: allow namespaced scripts to be used as Worker tail consumers
+```

--- a/workers.go
+++ b/workers.go
@@ -174,6 +174,7 @@ type WorkerScript struct {
 type WorkersTailConsumer struct {
 	Service     string  `json:"service"`
 	Environment *string `json:"environment,omitempty"`
+	Namespace   *string `json:"namespace,omitempty"`
 }
 
 // WorkerMetaData contains worker script information such as size, creation & modification dates.

--- a/workers_test.go
+++ b/workers_test.go
@@ -1283,6 +1283,7 @@ func TestUploadWorker_WithTailConsumers(t *testing.T) {
 		tailConsumers := []WorkersTailConsumer{
 			{Service: "my-service-a"},
 			{Service: "my-service-b", Environment: StringPtr("production")},
+			{Service: "a-namespaced-service", Namespace: StringPtr("a-dispatch-namespace")},
 		}
 		response = workersScriptResponse(t,
 			withWorkerScript(expectedWorkersModuleWorkerScript),
@@ -1295,7 +1296,7 @@ func TestUploadWorker_WithTailConsumers(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		require.NotNil(t, worker.TailConsumers)
-		assert.Len(t, *worker.TailConsumers, 2)
+		assert.Len(t, *worker.TailConsumers, 3)
 	})
 }
 


### PR DESCRIPTION
## Description
Fixes CUSTESC-32212.

We have recently added additional functionality to Tail Workers to allow scripts within a dispatch namespace to be used. This adds support for that optional field to the Tail Worker configuration.

See the [tail consumers section of the Workers script upload docs](
https://developers.cloudflare.com/api/operations/worker-script-upload-worker-module?schema_url=https%3A%2F%2Fraw.githubusercontent.com%2Fcloudflare%2Fapi-schemas%2Fmain%2Fopenapi.yaml#Responses)

## Has your change been tested?

Tests changes are included.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.