### PR TITLE
Add support for Cache Reserve Configuration in the Rulesets API

### DIFF
--- a/.changelog/1394.txt
+++ b/.changelog/1394.txt
@@ -1,0 +1,3 @@
+```release_note:enhancement
+rulesets: Add support for Cache Reserve configuration via the Rulesets/Cache Rules API
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -237,6 +237,7 @@ type RulesetRuleActionParameters struct {
 	CacheKey                 *RulesetRuleActionParametersCacheKey              `json:"cache_key,omitempty"`
 	OriginCacheControl       *bool                                             `json:"origin_cache_control,omitempty"`
 	OriginErrorPagePassthru  *bool                                             `json:"origin_error_page_passthru,omitempty"`
+	CacheReserve             *RulesetRuleActionParametersCacheReserve          `json:"cache_reserve,omitempty"`
 	FromList                 *RulesetRuleActionParametersFromList              `json:"from_list,omitempty"`
 	FromValue                *RulesetRuleActionParametersFromValue             `json:"from_value,omitempty"`
 	AutomaticHTTPSRewrites   *bool                                             `json:"automatic_https_rewrites,omitempty"`
@@ -314,6 +315,11 @@ type RulesetRuleActionParametersCacheKey struct {
 	IgnoreQueryStringsOrder *bool                                 `json:"ignore_query_strings_order,omitempty"`
 	CacheDeceptionArmor     *bool                                 `json:"cache_deception_armor,omitempty"`
 	CustomKey               *RulesetRuleActionParametersCustomKey `json:"custom_key,omitempty"`
+}
+
+type RulesetRuleActionParametersCacheReserve struct {
+	Eligible        *bool `json:"eligible,omitempty"`
+	MinimumFileSize *uint `json:"minimum_file_size,omitempty"`
 }
 
 type RulesetRuleActionParametersCustomKey struct {

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -244,7 +244,11 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 				"additional_cacheable_ports": [1,2,3,4],
 				"origin_cache_control": true,
 				"read_timeout": 1000,
-				"origin_error_page_passthru":true
+				"origin_error_page_passthru":true,
+				"cache_reserve": {
+					"eligible": true,
+					"minimum_file_size": 1000
+				}
 			},
 			"description": "Set all available cache settings in one rule",
 			"last_updated": "2020-12-18T09:28:09.655749Z",
@@ -331,6 +335,10 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 			OriginCacheControl:       BoolPtr(true),
 			ReadTimeout:              UintPtr(1000),
 			OriginErrorPagePassthru:  BoolPtr(true),
+			CacheReserve: &RulesetRuleActionParametersCacheReserve{
+				Eligible:        BoolPtr(true),
+				MinimumFileSize: UintPtr(1000),
+			},
 		},
 		Description: "Set all available cache settings in one rule",
 		LastUpdated: &lastUpdated,


### PR DESCRIPTION
Cache Reserve asset eligibility is currently just a global feature toggle. The ability to control the Cache Reserve asset eligibility via Cache Rules is a highly requested feature. This will give customers better control over their Cache Reserve costs.

## Description

Adds the ability to configure some aspects of eligibility for Cache Reserve with a Cache Rule

## Has your change been tested?

Thorough testing for the API and internally.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
