### PR TITLE
Add support for Get/Post/Delete operations in API Shield Endpoint Management

### DIFF
--- a/.changelog/1397.txt
+++ b/.changelog/1397.txt
@@ -1,0 +1,3 @@
+```release_note:enhancement
+api_shield: Add support for Get/Post/Delete operations in API Shield Endpoint Management
+```

--- a/api_shield_operations.go
+++ b/api_shield_operations.go
@@ -13,13 +13,13 @@ import (
 type APIShieldOperation struct {
 	APIShieldBasicOperation
 	ID          string         `json:"operation_id"`
-	LastUpdated time.Time      `json:"last_updated"`
+	LastUpdated *time.Time     `json:"last_updated"`
 	Features    map[string]any `json:"features,omitempty"`
 }
 
 // GetAPIShieldOperationParams represents the parameters to pass when retrieving an operation.
 //
-// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-an-operation
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-an-operation
 type GetAPIShieldOperationParams struct {
 	// The Operation ID to retrieve
 	OperationID string `url:"-"`
@@ -30,7 +30,7 @@ type GetAPIShieldOperationParams struct {
 
 // CreateAPIShieldOperationsParams represents the parameters to pass when adding one or more operations.
 //
-// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-add-operations-to-a-zone
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-add-operations-to-a-zone
 type CreateAPIShieldOperationsParams struct {
 	// Operations are a slice of operations to be created in API Shield Endpoint Management
 	Operations []APIShieldBasicOperation `url:"-"`
@@ -45,7 +45,7 @@ type APIShieldBasicOperation struct {
 
 // DeleteAPIShieldOperationParams represents the parameters to pass to delete an operation.
 //
-// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-delete-an-operation
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-delete-an-operation
 type DeleteAPIShieldOperationParams struct {
 	// OperationID is the operation to be deleted
 	OperationID string `url:"-"`
@@ -53,7 +53,7 @@ type DeleteAPIShieldOperationParams struct {
 
 // ListAPIShieldOperationsParams represents the parameters to pass when retrieving operations
 //
-// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-all-operations-on-a-zone
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-all-operations-on-a-zone
 type ListAPIShieldOperationsParams struct {
 	// Features represents a set of features to return in `features` object when
 	// performing making read requests against an Operation or listing operations.
@@ -70,7 +70,7 @@ type ListAPIShieldOperationsParams struct {
 
 // APIShieldListOperationsFilters represents the filtering query parameters to set when retrieving operations
 //
-// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-all-operations-on-a-zone
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-all-operations-on-a-zone
 type APIShieldListOperationsFilters struct {
 	// Hosts filters results to only include the specified hosts.
 	Hosts []string `url:"host,omitempty"`

--- a/api_shield_operations.go
+++ b/api_shield_operations.go
@@ -1,0 +1,221 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// APIShieldCreateOperation should be used when creating an operation in API Shield Endpoint Management.
+type APIShieldCreateOperation struct {
+	Method   string `json:"method"`
+	Host     string `json:"host"`
+	Endpoint string `json:"endpoint"`
+}
+
+// APIShieldOperation represents an operation stored in API Shield Endpoint Management.
+type APIShieldOperation struct {
+	APIShieldCreateOperation
+	ID          string         `json:"operation_id"`
+	LastUpdated time.Time      `json:"last_updated"`
+	Features    map[string]any `json:"features,omitempty"`
+}
+
+// APIShieldGetOperationParams represents the query parameters to set when retrieving an operation.
+//
+// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-an-operation
+type APIShieldGetOperationParams struct {
+	// Features represents a set of features to return in `features` object when
+	// performing making read requests against an Operation or listing operations.
+	Features []string
+}
+
+// APIShieldGetOperationsParams represents the query parameters to set when retrieving operations
+//
+// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-all-operations-on-a-zone
+type APIShieldGetOperationsParams struct {
+	// Features represents a set of features to return in `features` object when
+	// performing making read requests against an Operation or listing operations.
+	Features []string
+	// Direction to order results.
+	Direction string
+	// OrderBy when requesting a feature, the feature keys are available for ordering as well, e.g., thresholds.suggested_threshold.
+	OrderBy string
+	// Filters to only return operations that match filtering criteria, see APIShieldGetOperationsFilters
+	Filters *APIShieldGetOperationsFilters
+	// Pagination options to apply to the request.
+	Pagination *PaginationOptions
+}
+
+// APIShieldGetOperationsFilters represents the filtering query parameters to set when retrieving operations
+//
+// See API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-all-operations-on-a-zone
+type APIShieldGetOperationsFilters struct {
+	// Host filters results to only include the specified hosts.
+	Hosts []string
+	// Host filters results to only include the specified methods.
+	Methods []string
+	// Endpoint filter results to only include endpoints containing this pattern.
+	Endpoint string
+}
+
+// APIShieldGetOperationResponse represents the response from the api_gateway/operations/{id} endpoint.
+type APIShieldGetOperationResponse struct {
+	Result APIShieldOperation `json:"result"`
+	Response
+}
+
+// APIShieldGetOperationsResponse represents the response from the api_gateway/operations endpoint.
+type APIShieldGetOperationsResponse struct {
+	Result     []APIShieldOperation `json:"result"`
+	ResultInfo `json:"result_info"`
+	Response
+}
+
+// APIShieldDeleteOperationResponse represents the response from the api_gateway/operations/{id} endpoint (DELETE).
+type APIShieldDeleteOperationResponse struct {
+	Result interface{} `json:"result"`
+	Response
+}
+
+// GetAPIShieldOperation returns information about an operation
+//
+// API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-an-operation
+func (api *API) GetAPIShieldOperation(ctx context.Context, rc *ResourceContainer, operationID string, params *APIShieldGetOperationParams) (*APIShieldOperation, error) {
+	uri := fmt.Sprintf("/zones/%s/api_gateway/operations/%s", rc.Identifier, operationID)
+
+	if params != nil {
+		uri = strings.Join([]string{uri, params.Encode()}, "?")
+	}
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var asResponse APIShieldGetOperationResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return &asResponse.Result, nil
+}
+
+// GetAPIShieldOperations retrieve information about all operations on a zone
+//
+// API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-all-operations-on-a-zone
+func (api *API) GetAPIShieldOperations(ctx context.Context, rc *ResourceContainer, params *APIShieldGetOperationsParams) ([]APIShieldOperation, ResultInfo, error) {
+	uri := fmt.Sprintf("/zones/%s/api_gateway/operations", rc.Identifier)
+	if params != nil {
+		uri = strings.Join([]string{uri, params.Encode()}, "?")
+	}
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, ResultInfo{}, err
+	}
+
+	var asResponse APIShieldGetOperationsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, ResultInfo{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return asResponse.Result, asResponse.ResultInfo, nil
+}
+
+// PostAPIShieldOperations add one or more operations to a zone.
+//
+// API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-add-operations-to-a-zone
+func (api *API) PostAPIShieldOperations(ctx context.Context, rc *ResourceContainer, operations []APIShieldCreateOperation) ([]APIShieldOperation, error) {
+	uri := fmt.Sprintf("/zones/%s/api_gateway/operations", rc.Identifier)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, operations)
+	if err != nil {
+		return nil, err
+	}
+
+	// Result should be all the operations added to the zone, similar to doing GetAPIShieldOperations
+	var asResponse APIShieldGetOperationsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return asResponse.Result, nil
+}
+
+// DeleteAPIShieldOperation deletes a single operation
+//
+// API documentation https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-delete-an-operation
+func (api *API) DeleteAPIShieldOperation(ctx context.Context, rc *ResourceContainer, operationID string) error {
+	uri := fmt.Sprintf("/zones/%s/api_gateway/operations/%s", rc.Identifier, operationID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	if err != nil {
+		return err
+	}
+
+	var asResponse APIShieldDeleteOperationResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return nil
+}
+
+// Encode is a custom method for encoding APIShieldGetOperationParams into a usable HTTP
+// query parameter string.
+func (a APIShieldGetOperationParams) Encode() string {
+	v := url.Values{}
+	for _, f := range a.Features {
+		v.Add("feature", f)
+	}
+
+	return v.Encode()
+}
+
+// Encode is a custom method for encoding APIShieldGetOperationsParams into a usable HTTP
+// query parameter string.
+func (a APIShieldGetOperationsParams) Encode() string {
+	v := url.Values{}
+	for _, f := range a.Features {
+		v.Add("feature", f)
+	}
+
+	if a.Direction != "" {
+		v.Set("direction", a.Direction)
+	}
+
+	if a.OrderBy != "" {
+		v.Set("order", a.OrderBy)
+	}
+
+	if a.Pagination != nil {
+		v.Set("page", strconv.Itoa(a.Pagination.Page))
+		v.Set("per_page", strconv.Itoa(a.Pagination.PerPage))
+	}
+
+	if a.Filters != nil {
+		if a.Filters.Endpoint != "" {
+			v.Set("endpoint", a.Filters.Endpoint)
+		}
+
+		for _, h := range a.Filters.Hosts {
+			v.Add("host", h)
+		}
+
+		for _, m := range a.Filters.Methods {
+			v.Add("method", m)
+		}
+	}
+
+	return v.Encode()
+}

--- a/api_shield_operations_test.go
+++ b/api_shield_operations_test.go
@@ -50,6 +50,7 @@ func TestGetAPIShieldOperation(t *testing.T) {
 		},
 	)
 
+	time := time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC)
 	expected := &APIShieldOperation{
 		APIShieldBasicOperation: APIShieldBasicOperation{
 			Method:   "POST",
@@ -57,7 +58,7 @@ func TestGetAPIShieldOperation(t *testing.T) {
 			Endpoint: "/client/v4/zones",
 		},
 		ID:          testAPIShieldOperationId,
-		LastUpdated: time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC),
+		LastUpdated: &time,
 		Features:    nil,
 	}
 
@@ -131,6 +132,7 @@ func TestGetAPIShieldOperationWithParams(t *testing.T) {
 				test.getParams,
 			)
 
+			time := time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC)
 			expected := &APIShieldOperation{
 				APIShieldBasicOperation: APIShieldBasicOperation{
 					Method:   "POST",
@@ -138,7 +140,7 @@ func TestGetAPIShieldOperationWithParams(t *testing.T) {
 					Endpoint: "/client/v4/zones",
 				},
 				ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
-				LastUpdated: time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC),
+				LastUpdated: &time,
 				Features: map[string]any{
 					"thresholds":        map[string]any{},
 					"parameter_schemas": map[string]any{},
@@ -193,6 +195,7 @@ func TestListAPIShieldOperations(t *testing.T) {
 		ListAPIShieldOperationsParams{},
 	)
 
+	time := time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC)
 	expectedOps := []APIShieldOperation{
 		{
 			APIShieldBasicOperation: APIShieldBasicOperation{
@@ -201,7 +204,7 @@ func TestListAPIShieldOperations(t *testing.T) {
 				Endpoint: "/client/v4/zones",
 			},
 			ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
-			LastUpdated: time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC),
+			LastUpdated: &time,
 			Features:    nil,
 		},
 	}
@@ -371,6 +374,7 @@ func TestListAPIShieldOperationsWithParams(t *testing.T) {
 				test.params,
 			)
 
+			time := time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC)
 			expected := []APIShieldOperation{
 				{
 					APIShieldBasicOperation: APIShieldBasicOperation{
@@ -379,7 +383,7 @@ func TestListAPIShieldOperationsWithParams(t *testing.T) {
 						Endpoint: "/client/v4/zones",
 					},
 					ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
-					LastUpdated: time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC),
+					LastUpdated: &time,
 					Features: map[string]any{
 						"thresholds": map[string]any{},
 					},
@@ -440,6 +444,7 @@ func TestCreateAPIShieldOperations(t *testing.T) {
 		},
 	)
 
+	time := time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC)
 	expected := []APIShieldOperation{
 		{
 			APIShieldBasicOperation: APIShieldBasicOperation{
@@ -448,7 +453,7 @@ func TestCreateAPIShieldOperations(t *testing.T) {
 				Endpoint: "/client/v4/zones",
 			},
 			ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
-			LastUpdated: time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC),
+			LastUpdated: &time,
 			Features:    nil,
 		},
 	}

--- a/api_shield_operations_test.go
+++ b/api_shield_operations_test.go
@@ -45,12 +45,13 @@ func TestGetAPIShieldOperation(t *testing.T) {
 	actual, err := client.GetAPIShieldOperation(
 		context.Background(),
 		ZoneIdentifier(testZoneID),
-		testAPIShieldOperationId,
-		nil,
+		GetAPIShieldOperationParams{
+			OperationID: testAPIShieldOperationId,
+		},
 	)
 
 	expected := &APIShieldOperation{
-		APIShieldCreateOperation: APIShieldCreateOperation{
+		APIShieldBasicOperation: APIShieldBasicOperation{
 			Method:   "POST",
 			Host:     "api.cloudflare.com",
 			Endpoint: "/client/v4/zones",
@@ -65,7 +66,7 @@ func TestGetAPIShieldOperation(t *testing.T) {
 	}
 }
 
-func TestGetAPIShieldOperationWithOptions(t *testing.T) {
+func TestGetAPIShieldOperationWithParams(t *testing.T) {
 	endpoint := fmt.Sprintf("/zones/%s/api_gateway/operations/%s", testZoneID, testAPIShieldOperationId)
 	response := `{
 		"success" : true,
@@ -86,13 +87,14 @@ func TestGetAPIShieldOperationWithOptions(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		getOptions     *APIShieldGetOperationParams
+		getParams      GetAPIShieldOperationParams
 		expectedParams url.Values
 	}{
 		{
 			name: "one feature",
-			getOptions: &APIShieldGetOperationParams{
-				Features: []string{"thresholds"},
+			getParams: GetAPIShieldOperationParams{
+				OperationID: testAPIShieldOperationId,
+				Features:    []string{"thresholds"},
 			},
 			expectedParams: url.Values{
 				"feature": []string{"thresholds"},
@@ -100,8 +102,9 @@ func TestGetAPIShieldOperationWithOptions(t *testing.T) {
 		},
 		{
 			name: "more than one feature",
-			getOptions: &APIShieldGetOperationParams{
-				Features: []string{"thresholds", "parameter_schemas"},
+			getParams: GetAPIShieldOperationParams{
+				OperationID: testAPIShieldOperationId,
+				Features:    []string{"thresholds", "parameter_schemas"},
 			},
 			expectedParams: url.Values{
 				"feature": []string{"thresholds", "parameter_schemas"},
@@ -125,12 +128,11 @@ func TestGetAPIShieldOperationWithOptions(t *testing.T) {
 			actual, err := client.GetAPIShieldOperation(
 				context.Background(),
 				ZoneIdentifier(testZoneID),
-				testAPIShieldOperationId,
-				test.getOptions,
+				test.getParams,
 			)
 
 			expected := &APIShieldOperation{
-				APIShieldCreateOperation: APIShieldCreateOperation{
+				APIShieldBasicOperation: APIShieldBasicOperation{
 					Method:   "POST",
 					Host:     "api.cloudflare.com",
 					Endpoint: "/client/v4/zones",
@@ -150,7 +152,7 @@ func TestGetAPIShieldOperationWithOptions(t *testing.T) {
 	}
 }
 
-func TestGetAPIShieldOperations(t *testing.T) {
+func TestListAPIShieldOperations(t *testing.T) {
 	endpoint := fmt.Sprintf("/zones/%s/api_gateway/operations", testZoneID)
 	response := `{
 		"success" : true,
@@ -185,15 +187,15 @@ func TestGetAPIShieldOperations(t *testing.T) {
 
 	mux.HandleFunc(endpoint, handler)
 
-	actual, actualResultInfo, err := client.GetAPIShieldOperations(
+	actual, actualResultInfo, err := client.ListAPIShieldOperations(
 		context.Background(),
 		ZoneIdentifier(testZoneID),
-		nil,
+		ListAPIShieldOperationsParams{},
 	)
 
 	expectedOps := []APIShieldOperation{
 		{
-			APIShieldCreateOperation: APIShieldCreateOperation{
+			APIShieldBasicOperation: APIShieldBasicOperation{
 				Method:   "POST",
 				Host:     "api.cloudflare.com",
 				Endpoint: "/client/v4/zones",
@@ -217,7 +219,7 @@ func TestGetAPIShieldOperations(t *testing.T) {
 	}
 }
 
-func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
+func TestListAPIShieldOperationsWithParams(t *testing.T) {
 	endpoint := fmt.Sprintf("/zones/%s/api_gateway/operations", testZoneID)
 	response := `{
 		"success" : true,
@@ -245,21 +247,21 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		params         *APIShieldGetOperationsParams
+		params         ListAPIShieldOperationsParams
 		expectedParams url.Values
 	}{
 		{
 			name: "all params",
-			params: &APIShieldGetOperationsParams{
+			params: ListAPIShieldOperationsParams{
 				Features:  []string{"thresholds", "parameter_schemas"},
 				Direction: "desc",
 				OrderBy:   "host",
-				Filters: &APIShieldGetOperationsFilters{
+				APIShieldListOperationsFilters: APIShieldListOperationsFilters{
 					Hosts:    []string{"api.cloudflare.com", "developers.cloudflare.com"},
 					Methods:  []string{"GET", "PUT"},
 					Endpoint: "/client",
 				},
-				Pagination: &PaginationOptions{
+				PaginationOptions: PaginationOptions{
 					Page:    1,
 					PerPage: 25,
 				},
@@ -277,7 +279,7 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 		},
 		{
 			name: "features only",
-			params: &APIShieldGetOperationsParams{
+			params: ListAPIShieldOperationsParams{
 				Features: []string{"thresholds", "parameter_schemas"},
 			},
 			expectedParams: url.Values{
@@ -286,7 +288,7 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 		},
 		{
 			name: "direction only",
-			params: &APIShieldGetOperationsParams{
+			params: ListAPIShieldOperationsParams{
 				Direction: "desc",
 			},
 			expectedParams: url.Values{
@@ -295,7 +297,7 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 		},
 		{
 			name: "order only",
-			params: &APIShieldGetOperationsParams{
+			params: ListAPIShieldOperationsParams{
 				OrderBy: "host",
 			},
 			expectedParams: url.Values{
@@ -304,8 +306,8 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 		},
 		{
 			name: "hosts only",
-			params: &APIShieldGetOperationsParams{
-				Filters: &APIShieldGetOperationsFilters{
+			params: ListAPIShieldOperationsParams{
+				APIShieldListOperationsFilters: APIShieldListOperationsFilters{
 					Hosts: []string{"api.cloudflare.com", "developers.cloudflare.com"},
 				},
 			},
@@ -315,8 +317,8 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 		},
 		{
 			name: "methods only",
-			params: &APIShieldGetOperationsParams{
-				Filters: &APIShieldGetOperationsFilters{
+			params: ListAPIShieldOperationsParams{
+				APIShieldListOperationsFilters: APIShieldListOperationsFilters{
 					Methods: []string{"GET", "PUT"},
 				},
 			},
@@ -326,8 +328,8 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 		},
 		{
 			name: "endpoint only",
-			params: &APIShieldGetOperationsParams{
-				Filters: &APIShieldGetOperationsFilters{
+			params: ListAPIShieldOperationsParams{
+				APIShieldListOperationsFilters: APIShieldListOperationsFilters{
 					Endpoint: "/client",
 				},
 			},
@@ -337,8 +339,8 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 		},
 		{
 			name: "pagination only",
-			params: &APIShieldGetOperationsParams{
-				Pagination: &PaginationOptions{
+			params: ListAPIShieldOperationsParams{
+				PaginationOptions: PaginationOptions{
 					Page:    1,
 					PerPage: 25,
 				},
@@ -363,7 +365,7 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 
 			mux.HandleFunc(endpoint, handler)
 
-			actual, _, err := client.GetAPIShieldOperations(
+			actual, _, err := client.ListAPIShieldOperations(
 				context.Background(),
 				ZoneIdentifier(testZoneID),
 				test.params,
@@ -371,7 +373,7 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 
 			expected := []APIShieldOperation{
 				{
-					APIShieldCreateOperation: APIShieldCreateOperation{
+					APIShieldBasicOperation: APIShieldBasicOperation{
 						Method:   "POST",
 						Host:     "api.cloudflare.com",
 						Endpoint: "/client/v4/zones",
@@ -391,7 +393,7 @@ func TestGetAPIShieldOperationsWithOptions(t *testing.T) {
 	}
 }
 
-func TestPostAPIShieldOperations(t *testing.T) {
+func TestCreateAPIShieldOperations(t *testing.T) {
 	setup()
 	t.Cleanup(teardown)
 
@@ -424,21 +426,23 @@ func TestPostAPIShieldOperations(t *testing.T) {
 
 	mux.HandleFunc(endpoint, handler)
 
-	actual, err := client.PostAPIShieldOperations(
+	actual, err := client.CreateAPIShieldOperations(
 		context.Background(),
 		ZoneIdentifier(testZoneID),
-		[]APIShieldCreateOperation{
-			{
-				Method:   "POST",
-				Host:     "api.cloudflare.com",
-				Endpoint: "/client/v4/zones",
+		CreateAPIShieldOperationsParams{
+			Operations: []APIShieldBasicOperation{
+				{
+					Method:   "POST",
+					Host:     "api.cloudflare.com",
+					Endpoint: "/client/v4/zones",
+				},
 			},
 		},
 	)
 
 	expected := []APIShieldOperation{
 		{
-			APIShieldCreateOperation: APIShieldCreateOperation{
+			APIShieldBasicOperation: APIShieldBasicOperation{
 				Method:   "POST",
 				Host:     "api.cloudflare.com",
 				Endpoint: "/client/v4/zones",
@@ -473,7 +477,9 @@ func TestDeleteAPIShieldOperation(t *testing.T) {
 	err := client.DeleteAPIShieldOperation(
 		context.Background(),
 		ZoneIdentifier(testZoneID),
-		testAPIShieldOperationId,
+		DeleteAPIShieldOperationParams{
+			OperationID: testAPIShieldOperationId,
+		},
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
This change adds support for the following API Shield related endpoints related to endpoint management:

- [Add operations to a zone](https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-add-operations-to-a-zone)
- [Delete an operation](https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-delete-an-operation)
- [Retrieve information about an operation](https://developers.cloudflare.com/api/operations/api-shield-endpoint-management-retrieve-information-about-an-operation)


## Description

This change adds support for API Shield related endpoints related to managing operations in API Shield Endpoint Management. This is so they can be used from the library and will enable this feature to be added to terraform in the future. 

## Has your change been tested?

- Unit tests
- Local testing using API


## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

Supersedes #1054