### PR TITLE
lint: only use `github.com/goccy/go-json` for JSON marshaling/unmarshaling

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -33,3 +33,16 @@ rules:
         - pattern: |
             errors.Wrap(...)
     severity: WARNING
+  - id: no-use-of-stdlib-json
+    languages:
+      - go
+    message: Favour "github.com/goccy/go-json" instead of "encoding/json" to allow better customisation of marshaling and unmarshaling JSON attributes. See https://github.com/cloudflare/cloudflare-go/pull/1360 for full details.
+    paths:
+      include:
+        - '*.go'
+    patterns:
+      - pattern-regex: '\"encoding\/json\"'
+    fix-regex:
+      regex: \".*\"
+      replacement: '"github.com/goccy/go-json"'
+    severity: WARNING

--- a/bot_management.go
+++ b/bot_management.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/goccy/go-json"
 )
 
 // BotManagement represents the bots config for a zone.

--- a/per_hostname_tls_settings.go
+++ b/per_hostname_tls_settings.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 // HostnameTLSSetting represents the metadata for a user-created tls setting.

--- a/web_analytics.go
+++ b/web_analytics.go
@@ -2,11 +2,12 @@ package cloudflare
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/goccy/go-json"
 )
 
 var (


### PR DESCRIPTION
Adds a semgrep rule to ensure we are only using
`github.com/goccy/go-json` for JSON needs and move away from stdlib.

See #1360 for full details.
