### PR TITLE
 AUTH-5428: added app launcher customization fields to access applica…

### DIFF
--- a/.changelog/1407.txt
+++ b/.changelog/1407.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access_application: Add support for app launcher customization fields
+```

--- a/access_application.go
+++ b/access_application.go
@@ -54,6 +54,7 @@ type AccessApplication struct {
 	PathCookieAttribute      *bool                          `json:"path_cookie_attribute,omitempty"`
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
+	AppLauncherCustomization
 }
 
 type AccessApplicationGatewayRule struct {
@@ -116,6 +117,26 @@ type SaasApplication struct {
 	CustomAttributes   []SAMLAttributeConfig `json:"custom_attributes,omitempty"`
 }
 
+type AppLauncherCustomization struct {
+	LandingPageDesign     AccessLandingPageDesign `json:"landing_page_design"`
+	LogoURL               string                  `json:"app_launcher_logo_url"`
+	HeaderBackgroundColor string                  `json:"header_bg_color"`
+	BackgroundColor       string                  `json:"bg_color"`
+	FooterLinks           []AccessFooterLink      `json:"footer_links"`
+}
+
+type AccessFooterLink struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type AccessLandingPageDesign struct {
+	Title           string `json:"title"`
+	Message         string `json:"message"`
+	ImageURL        string `json:"image_url"`
+	ButtonColor     string `json:"button_color"`
+	ButtonTextColor string `json:"button_text_color"`
+}
 type ListAccessApplicationsParams struct {
 	ResultInfo
 }
@@ -146,6 +167,7 @@ type CreateAccessApplicationParams struct {
 	Type                     AccessApplicationType          `json:"type,omitempty"`
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
+	AppLauncherCustomization
 }
 
 type UpdateAccessApplicationParams struct {
@@ -175,6 +197,7 @@ type UpdateAccessApplicationParams struct {
 	Type                     AccessApplicationType          `json:"type,omitempty"`
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
+	AppLauncherCustomization
 }
 
 // ListAccessApplications returns all applications within an account or zone.

--- a/access_application.go
+++ b/access_application.go
@@ -54,7 +54,7 @@ type AccessApplication struct {
 	PathCookieAttribute      *bool                          `json:"path_cookie_attribute,omitempty"`
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
-	AppLauncherCustomization
+	AccessAppLauncherCustomization
 }
 
 type AccessApplicationGatewayRule struct {
@@ -117,7 +117,7 @@ type SaasApplication struct {
 	CustomAttributes   []SAMLAttributeConfig `json:"custom_attributes,omitempty"`
 }
 
-type AppLauncherCustomization struct {
+type AccessAppLauncherCustomization struct {
 	LandingPageDesign     AccessLandingPageDesign `json:"landing_page_design"`
 	LogoURL               string                  `json:"app_launcher_logo_url"`
 	HeaderBackgroundColor string                  `json:"header_bg_color"`
@@ -167,7 +167,7 @@ type CreateAccessApplicationParams struct {
 	Type                     AccessApplicationType          `json:"type,omitempty"`
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
-	AppLauncherCustomization
+	AccessAppLauncherCustomization
 }
 
 type UpdateAccessApplicationParams struct {
@@ -197,7 +197,7 @@ type UpdateAccessApplicationParams struct {
 	Type                     AccessApplicationType          `json:"type,omitempty"`
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
-	AppLauncherCustomization
+	AccessAppLauncherCustomization
 }
 
 // ListAccessApplications returns all applications within an account or zone.

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -760,7 +760,7 @@ func TestCreateSaasAccessApplications(t *testing.T) {
 	}
 }
 
-func TestCreateApplicationWithAppLauncherCustomization(t *testing.T) {
+func TestCreateApplicationWithAccessAppLauncherCustomization(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -825,7 +825,7 @@ func TestCreateApplicationWithAppLauncherCustomization(t *testing.T) {
 		SkipInterstitial:       BoolPtr(true),
 		CreatedAt:              &createdAt,
 		UpdatedAt:              &updatedAt,
-		AppLauncherCustomization: AppLauncherCustomization{
+		AccessAppLauncherCustomization: AccessAppLauncherCustomization{
 			LandingPageDesign: AccessLandingPageDesign{
 				Title:           "A title",
 				Message:         "a message",
@@ -850,7 +850,7 @@ func TestCreateApplicationWithAppLauncherCustomization(t *testing.T) {
 		Name:            "Admin Site",
 		SessionDuration: "24h",
 		Type:            "app_launcher",
-		AppLauncherCustomization: AppLauncherCustomization{
+		AccessAppLauncherCustomization: AccessAppLauncherCustomization{
 			LandingPageDesign: AccessLandingPageDesign{
 				Title:           "A title",
 				Message:         "a message",

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -759,3 +759,117 @@ func TestCreateSaasAccessApplications(t *testing.T) {
 		assert.Equal(t, fullAccessApplication, actual)
 	}
 }
+
+func TestCreateApplicationWithAppLauncherCustomization(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z",
+				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+				"name": "App Launcher",
+				"type": "app_launcher",
+				"session_duration": "24h",
+				"auto_redirect_to_identity": false,
+				"enable_binding_cookie": false,
+				"custom_deny_url": "https://www.example.com",
+				"custom_deny_message": "denied!",
+				"logo_url": "https://www.example.com/example.png",
+				"skip_interstitial": true,
+				"app_launcher_visible": false,
+				"service_auth_401_redirect": false,
+				"landing_page_design": {
+					"title": "A title",
+					"message": "a message",
+					"image_url": "https://www.example.com/example.png",
+					"button_color": "green",
+					"button_text_color": "red"
+				},
+				"header_bg_color": "red",
+				"bg_color": "blue",
+				"footer_links": [
+					{
+						"url": "https://somesite.com",
+						"name": "bug"
+					}
+				]
+			}
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	fullAccessApplication := AccessApplication{
+		ID:                     "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:                   "App Launcher",
+		Type:                   "app_launcher",
+		SessionDuration:        "24h",
+		AUD:                    "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		AutoRedirectToIdentity: BoolPtr(false),
+		EnableBindingCookie:    BoolPtr(false),
+		AppLauncherVisible:     BoolPtr(false),
+		ServiceAuth401Redirect: BoolPtr(false),
+		CustomDenyMessage:      "denied!",
+		CustomDenyURL:          "https://www.example.com",
+		LogoURL:                "https://www.example.com/example.png",
+		SkipInterstitial:       BoolPtr(true),
+		CreatedAt:              &createdAt,
+		UpdatedAt:              &updatedAt,
+		AppLauncherCustomization: AppLauncherCustomization{
+			LandingPageDesign: AccessLandingPageDesign{
+				Title:           "A title",
+				Message:         "a message",
+				ImageURL:        "https://www.example.com/example.png",
+				ButtonColor:     "green",
+				ButtonTextColor: "red",
+			},
+			HeaderBackgroundColor: "red",
+			BackgroundColor:       "blue",
+			FooterLinks: []AccessFooterLink{
+				{
+					URL:  "https://somesite.com",
+					Name: "bug",
+				},
+			},
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/apps", handler)
+
+	actual, err := client.CreateAccessApplication(context.Background(), AccountIdentifier(testAccountID), CreateAccessApplicationParams{
+		Name:            "Admin Site",
+		SessionDuration: "24h",
+		Type:            "app_launcher",
+		AppLauncherCustomization: AppLauncherCustomization{
+			LandingPageDesign: AccessLandingPageDesign{
+				Title:           "A title",
+				Message:         "a message",
+				ImageURL:        "https://www.example.com/example.png",
+				ButtonColor:     "green",
+				ButtonTextColor: "red",
+			},
+			HeaderBackgroundColor: "red",
+			BackgroundColor:       "blue",
+			FooterLinks: []AccessFooterLink{
+				{
+					URL:  "https://somesite.com",
+					Name: "bug",
+				},
+			},
+		},
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fullAccessApplication, actual)
+	}
+}


### PR DESCRIPTION


## Description

This adds the ability to update the access app launcher application with customized display settings
## Has your change been tested?

build the provider locally and used the fields on my own account

unit tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
