### PR TITLE
Added the policies to AccessApplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ BREAKING CHANGES:
 
 ENHANCEMENTS:
 
+* access_application: Add support for policies ([#1408](https://github.com/cloudflare/cloudflare-go/issues/1408))
 * access_application: Add support for tags ([#1403](https://github.com/cloudflare/cloudflare-go/issues/1403))
 * access_tag: Add support for tags ([#1403](https://github.com/cloudflare/cloudflare-go/issues/1403))
 * observatory: add support for observatory API ([#1401](https://github.com/cloudflare/cloudflare-go/issues/1401))

--- a/access_application.go
+++ b/access_application.go
@@ -39,6 +39,7 @@ type AccessApplication struct {
 	CustomDenyURL            string                         `json:"custom_deny_url,omitempty"`
 	CustomNonIdentityDenyURL string                         `json:"custom_non_identity_deny_url,omitempty"`
 	Name                     string                         `json:"name"`
+        Policies                 []AccessPolicy                 `json:"policies"`
 	ID                       string                         `json:"id,omitempty"`
 	PrivateAddress           string                         `json:"private_address"`
 	CorsHeaders              *AccessApplicationCorsHeaders  `json:"cors_headers,omitempty"`


### PR DESCRIPTION
The AccessApplication API's allow to retrieve and set the attached policies but in the type-struct the policies attribute is missing.

## Description

Added the missing policies attribute to the struct.

## Has your change been tested?

yes --- it works for me.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
