### PR TITLE
fix: incorrect data type in UpdateCustomNameserverZoneMetadataParams

### DIFF
--- a/.changelog/1410.txt
+++ b/.changelog/1410.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cloudflare: fix incorrect data type in UpdateCustomNameserverZoneMetadataParams struct
+custom_nameservers: change `NSSet` from string to int to match API response
 ```

--- a/.changelog/1410.txt
+++ b/.changelog/1410.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cloudflare: fix incorrect data type in UpdateCustomNameserverZoneMetadataParams struct
+```

--- a/custom_nameservers.go
+++ b/custom_nameservers.go
@@ -68,9 +68,8 @@ type GetEligibleZonesAccountCustomNameserversParams struct{}
 type GetCustomNameserverZoneMetadataParams struct{}
 
 type UpdateCustomNameserverZoneMetadataParams struct {
-	Type    string `json:"type"`
-	NSSet   string `json:"ns_set"`
-	Enabled bool   `json:"enabled"`
+	NSSet   int  `json:"ns_set"`
+	Enabled bool `json:"enabled"`
 }
 
 // GetCustomNameservers lists custom nameservers.

--- a/custom_nameservers.go
+++ b/custom_nameservers.go
@@ -28,9 +28,8 @@ type CustomNameserverResult struct {
 }
 
 type CustomNameserverZoneMetadata struct {
-	Type    string `json:"type"`
-	NSSet   string `json:"ns_set"`
-	Enabled bool   `json:"enabled"`
+	NSSet   int  `json:"ns_set"`
+	Enabled bool `json:"enabled"`
 }
 
 type customNameserverListResponse struct {

--- a/custom_nameservers.go
+++ b/custom_nameservers.go
@@ -199,7 +199,6 @@ func (api *API) UpdateCustomNameserverZoneMetadata(ctx context.Context, rc *Reso
 
 	uri := fmt.Sprintf("/%s/%s/custom_ns", rc.Level, rc.Identifier)
 
-	params.Type = ""
 	_, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
 	if err != nil {
 		return err

--- a/custom_nameservers_test.go
+++ b/custom_nameservers_test.go
@@ -196,7 +196,6 @@ func TestAccountCustomNameserver_GetAccountCustomNameserverZoneMetadata(t *testi
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
 			"result": {
-				"type": "account",
 				"ns_set": "1",
 				"enabled": true
 			},
@@ -208,7 +207,6 @@ func TestAccountCustomNameserver_GetAccountCustomNameserverZoneMetadata(t *testi
 
 	mux.HandleFunc("/zones/"+testZoneID+"/custom_ns", handler)
 	want := CustomNameserverZoneMetadata{
-		Type:    "account",
 		NSSet:   "1",
 		Enabled: true,
 	}

--- a/custom_nameservers_test.go
+++ b/custom_nameservers_test.go
@@ -196,7 +196,7 @@ func TestAccountCustomNameserver_GetAccountCustomNameserverZoneMetadata(t *testi
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprintf(w, `{
 			"result": {
-				"ns_set": "1",
+				"ns_set": 1,
 				"enabled": true
 			},
 			"success": true,
@@ -207,7 +207,7 @@ func TestAccountCustomNameserver_GetAccountCustomNameserverZoneMetadata(t *testi
 
 	mux.HandleFunc("/zones/"+testZoneID+"/custom_ns", handler)
 	want := CustomNameserverZoneMetadata{
-		NSSet:   "1",
+		NSSet:   1,
 		Enabled: true,
 	}
 


### PR DESCRIPTION
<!-- 
Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points. 
-->

## Description

Incorrect data type in UpdateCustomNameserverZoneMetadataParams struct.  Using as-is would return a 500.

the `ns_set` field is an `int` but the struct is currently setup with a `string`
## Has your change been tested?

Found out the API would not accept the request without being an int.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
