### PR TITLE
Add r2 list objects

### DIFF
--- a/.changelog/1411.txt
+++ b/.changelog/1411.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+r2: Add list objects support
+```

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -447,13 +447,15 @@ type ResultInfoCursors struct {
 
 // ResultInfo contains metadata about the Response.
 type ResultInfo struct {
-	Page       int               `json:"page" url:"page,omitempty"`
-	PerPage    int               `json:"per_page" url:"per_page,omitempty"`
-	TotalPages int               `json:"total_pages" url:"-"`
-	Count      int               `json:"count" url:"-"`
-	Total      int               `json:"total_count" url:"-"`
-	Cursor     string            `json:"cursor" url:"cursor,omitempty"`
-	Cursors    ResultInfoCursors `json:"cursors" url:"cursors,omitempty"`
+	Page        int               `json:"page" url:"page,omitempty"`
+	PerPage     int               `json:"per_page" url:"per_page,omitempty"`
+	TotalPages  int               `json:"total_pages" url:"-"`
+	Count       int               `json:"count" url:"-"`
+	Total       int               `json:"total_count" url:"-"`
+	Cursor      string            `json:"cursor" url:"cursor,omitempty"`
+	Cursors     ResultInfoCursors `json:"cursors" url:"cursors,omitempty"`
+	Delimited   string            `json:"delimited" url:"delimited,omitempty"`
+	IsTruncated bool              `json:"is_truncated" url:"is_truncated,omitempty"`
 }
 
 // RawResponse keeps the result as JSON form.

--- a/r2_object.go
+++ b/r2_object.go
@@ -1,0 +1,54 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/goccy/go-json"
+)
+
+type R2Object struct {
+	Key            string            `json:"key"`
+	Etag           string            `json:"etag"`
+	LastModified   time.Time         `json:"last_modified"`
+	Size           int64             `json:"size"`
+	HTTPMetadata   map[string]any    `json:"http_metadata"`
+	CustomMetadata map[string]string `json:"custom_metadata"`
+}
+
+type ListR2ObjectsParams struct {
+	StartAfter string `url:"start_after,omitempty"`
+	Prefix     string `url:"prefix,omitempty"`
+	Cursor     string `url:"cursor,omitempty"`
+	PerPage    int    `url:"per_page,omitempty"`
+	Delimiter  string `url:"delimiter,omitempty"`
+}
+
+type R2ListObjectsResponse struct {
+	Result     []R2Object `json:"result"`
+	ResultInfo `json:"result_info"`
+	Response
+}
+
+// ListR2Objects lists R2 objects in a given bucket.
+func (api *API) ListR2Objects(ctx context.Context, rc *ResourceContainer, bucket string, params ListR2ObjectsParams) ([]R2Object, *ResultInfo, error) {
+	if rc.Identifier == "" {
+		return nil, nil, ErrMissingAccountID
+	}
+
+	uri := buildURI(fmt.Sprintf("/accounts/%s/r2/buckets/%s/objects", rc.Identifier, bucket), params)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var resp R2ListObjectsResponse
+	err = json.Unmarshal(res, &resp)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return resp.Result, &resp.ResultInfo, nil
+}

--- a/r2_object_test.go
+++ b/r2_object_test.go
@@ -1,0 +1,83 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestR2_ListObjects(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/accounts/%s/r2/buckets/%s/objects", testAccountID, testBucketName), func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+  "success": true,
+  "errors": [],
+  "messages": [],
+  "result": [
+	{
+		"key": "cf1.txt",
+		"etag": "d41d8cd98f00b204e9800998ecf8427e",
+		"last_modified": "2022-06-24T19:58:49.477Z",
+		"size": 104,
+		"http_metadata": {"contentType":"text/plain"},
+		"custom_metadata": {}
+	},
+	{
+		"key": "cf2.txt",
+		"etag": "d41d8cd98f00b204e9800998ecf8427e",
+		"last_modified": "2022-06-24T19:58:49.477Z",
+		"size": 104,
+		"http_metadata": {"contentType":"text/plain"},
+		"custom_metadata": {}
+	}
+  ],
+  "result_info": {
+	"per_page": 2,
+	"cursor": "some-text",
+	"is_truncated": true
+  }
+}`)
+	})
+
+	lastModified, _ := time.Parse(time.RFC3339, "2022-06-24T19:58:49.477Z")
+	want := []R2Object{
+		{
+			Key:          "cf1.txt",
+			Etag:         "d41d8cd98f00b204e9800998ecf8427e",
+			LastModified: lastModified,
+			Size:         104,
+			HTTPMetadata: map[string]any{
+				"contentType": "text/plain",
+			},
+			CustomMetadata: map[string]string{},
+		},
+		{
+			Key:          "cf2.txt",
+			Etag:         "d41d8cd98f00b204e9800998ecf8427e",
+			LastModified: lastModified,
+			Size:         104,
+			HTTPMetadata: map[string]any{
+				"contentType": "text/plain",
+			},
+			CustomMetadata: map[string]string{},
+		},
+	}
+	wantInfo := &ResultInfo{
+		PerPage:     2,
+		Cursor:      "some-text",
+		IsTruncated: true,
+	}
+	actual, info, err := client.ListR2Objects(context.Background(), AccountIdentifier(testAccountID), testBucketName, ListR2ObjectsParams{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+		assert.Equal(t, wantInfo, info)
+	}
+}


### PR DESCRIPTION
## Description

Add missing R2 list objects support. 
Came up in wrangler, wanted to add it here too but it's not a part of publicly documented API so feel free to close.

## Has your change been tested?

Yes

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
