### PR TITLE
Add support for Get/Patch API Shield API Discovery Operations

### DIFF
--- a/.changelog/1413.txt
+++ b/.changelog/1413.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-Add support for Get/Patch API Shield API Discovery Operations
+api_shield_discovery: Add support for Get/Patch API Shield API Discovery Operations
 ```

--- a/.changelog/1413.txt
+++ b/.changelog/1413.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add support for Get/Patch API Shield API Discovery Operations
+```

--- a/api_shield_api_discovery.go
+++ b/api_shield_api_discovery.go
@@ -1,0 +1,174 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/goccy/go-json"
+)
+
+// APIShieldDiscoveryOperation is an operation that was discovered by API Discovery.
+type APIShieldDiscoveryOperation struct {
+	// ID represents the ID of the operation
+	ID string `json:"id"`
+	// Origin represents the API discovery engine(s) that discovered this operation
+	Origin []string `json:"origin"`
+	// State represents the state of operation in API Discovery
+	State string `json:"state"`
+	// LastUpdated timestamp of when this operation was last updated
+	LastUpdated *time.Time `json:"last_updated,omitempty"`
+	// Features are additional data about the operation
+	Features map[string]any `json:"features,omitempty"`
+
+	Method   string `json:"method"`
+	Host     string `json:"host"`
+	Endpoint string `json:"endpoint"`
+}
+
+// ListAPIShieldDiscoveryOperationsParams represents the parameters to pass when retrieving discovered operations.
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-api-discovery-retrieve-discovered-operations-on-a-zone
+type ListAPIShieldDiscoveryOperationsParams struct {
+	// Direction to order results.
+	Direction string `url:"direction,omitempty"`
+	// OrderBy when requesting a feature, the feature keys are available for ordering as well, e.g., thresholds.suggested_threshold.
+	OrderBy string `url:"order,omitempty"`
+	// Filters to only return operations that match filtering criteria, see APIShieldGetOperationsFilters
+	APIShieldListDiscoveryOperationsFilters
+	// Pagination options to apply to the request.
+	PaginationOptions
+}
+
+// APIShieldListDiscoveryOperationsFilters represents the filtering query parameters to set when retrieving discovery operations.
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-api-discovery-retrieve-discovered-operations-on-a-zone
+type APIShieldListDiscoveryOperationsFilters struct {
+	// Hosts filters results to only include the specified hosts.
+	Hosts []string `url:"host,omitempty"`
+	// Methods filters results to only include the specified methods.
+	Methods []string `url:"method,omitempty"`
+	// Endpoint filter results to only include endpoints containing this pattern.
+	Endpoint string `url:"endpoint,omitempty"`
+	// Diff when true, only return API Discovery results that are not saved into API Shield Endpoint Management
+	Diff bool `url:"diff,omitempty"`
+	// Origin filter results to only include discovery results sourced from a particular discovery engine
+	Origin string `url:"origin,omitempty"`
+	// State filter results to only include discovery results in a particular state.
+	State string `url:"state,omitempty"`
+}
+
+// PatchAPIShieldDiscoveryOperationParams represents the parameters to pass to patch a discovery operation
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-api-patch-discovered-operation
+type PatchAPIShieldDiscoveryOperationParams struct {
+	// OperationID is the operation to be patched
+	OperationID string `json:"-" url:"-"`
+
+	PatchAPIShieldDiscoveryOperation
+}
+
+// PatchAPIShieldDiscoveryOperationsParams maps discovery operation IDs to PatchAPIShieldDiscoveryOperation structs
+//
+// Example:
+//
+//	PatchAPIShieldDiscoveryOperations{
+//			"99522293-a505-45e5-bbad-bbc339f5dc40": PatchAPIShieldDiscoveryOperation{ State: "review" },
+//	}
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-api-patch-discovered-operations
+type PatchAPIShieldDiscoveryOperationsParams map[string]PatchAPIShieldDiscoveryOperation
+
+// PatchAPIShieldDiscoveryOperation represents the state to set on a discovery operation.
+type PatchAPIShieldDiscoveryOperation struct {
+	// State is the state to set on the operation
+	State string `json:"state" url:"-"`
+}
+
+// APIShieldListDiscoveryOperationsResponse represents the response from the api_gateway/discovery/operations endpoint.
+type APIShieldListDiscoveryOperationsResponse struct {
+	Result     []APIShieldDiscoveryOperation `json:"result"`
+	ResultInfo `json:"result_info"`
+	Response
+}
+
+// APIShieldPatchDiscoveryOperationResponse represents the response from the PATCH api_gateway/discovery/operations/{id} endpoint.
+type APIShieldPatchDiscoveryOperationResponse struct {
+	Result PatchAPIShieldDiscoveryOperation `json:"result"`
+	Response
+}
+
+// APIShieldPatchDiscoveryOperationsResponse represents the response from the PATCH api_gateway/discovery/operations endpoint.
+type APIShieldPatchDiscoveryOperationsResponse struct {
+	Result PatchAPIShieldDiscoveryOperationsParams `json:"result"`
+	Response
+}
+
+// ListAPIShieldDiscoveryOperations retrieve the most up to date view of discovered operations.
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-api-discovery-retrieve-discovered-operations-on-a-zone
+func (api *API) ListAPIShieldDiscoveryOperations(ctx context.Context, rc *ResourceContainer, params ListAPIShieldDiscoveryOperationsParams) ([]APIShieldDiscoveryOperation, ResultInfo, error) {
+	path := fmt.Sprintf("/zones/%s/api_gateway/discovery/operations", rc.Identifier)
+
+	uri := buildURI(path, params)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, ResultInfo{}, err
+	}
+
+	var asResponse APIShieldListDiscoveryOperationsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, ResultInfo{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return asResponse.Result, asResponse.ResultInfo, nil
+}
+
+// PatchAPIShieldDiscoveryOperation updates certain fields on a discovered operation
+//
+// API Documentation: https://developers.cloudflare.com/api/operations/api-shield-api-patch-discovered-operation
+func (api *API) PatchAPIShieldDiscoveryOperation(ctx context.Context, rc *ResourceContainer, params PatchAPIShieldDiscoveryOperationParams) (*PatchAPIShieldDiscoveryOperation, error) {
+	if params.OperationID == "" {
+		return nil, fmt.Errorf("params.OperationID must be provided")
+	}
+
+	uri := fmt.Sprintf("/zones/%s/api_gateway/discovery/operations/%s", rc.Identifier, params.OperationID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Result should be the updated schema that was patched
+	var asResponse APIShieldPatchDiscoveryOperationResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return &asResponse.Result, nil
+}
+
+// PatchAPIShieldDiscoveryOperations bulk updates certain fields on multiple discovered operations
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-api-patch-discovered-operations
+func (api *API) PatchAPIShieldDiscoveryOperations(ctx context.Context, rc *ResourceContainer, params PatchAPIShieldDiscoveryOperationsParams) (*PatchAPIShieldDiscoveryOperationsParams, error) {
+	uri := fmt.Sprintf("/zones/%s/api_gateway/discovery/operations", rc.Identifier)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Result should be the updated schema that was patched
+	var asResponse APIShieldPatchDiscoveryOperationsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return &asResponse.Result, nil
+}

--- a/api_shield_api_discovery_test.go
+++ b/api_shield_api_discovery_test.go
@@ -65,8 +65,8 @@ func TestListAPIShieldDiscoveryOperations(t *testing.T) {
 			Endpoint:    "/client/v4/zones",
 			ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
 			LastUpdated: &lastUpdated,
-			Origin:      []string{"ML"},
-			State:       "review",
+			Origin:      []APIShieldDiscoveryOrigin{APIShieldDiscoveryOriginML},
+			State:       APIShieldDiscoveryStateReview,
 		},
 	}
 
@@ -96,8 +96,8 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 				"host": "api.cloudflare.com",
 				"endpoint": "/client/v4/zones",
 				"last_updated": "2023-03-02T15:46:06.000000Z",
-				"origin": ["ML"],
-				"state": "review",
+				"origin": ["SessionIdentifier"],
+				"state": "saved",
 				"features": {
 					"traffic_stats": {}
 				}
@@ -121,14 +121,12 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 			params: ListAPIShieldDiscoveryOperationsParams{
 				Direction: "desc",
 				OrderBy:   "host",
-				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
-					Hosts:    []string{"api.cloudflare.com", "developers.cloudflare.com"},
-					Methods:  []string{"GET", "PUT"},
-					Endpoint: "/client",
-					Origin:   "ML",
-					State:    "review",
-					Diff:     true,
-				},
+				Hosts:     []string{"api.cloudflare.com", "developers.cloudflare.com"},
+				Methods:   []string{"GET", "PUT"},
+				Endpoint:  "/client",
+				Origin:    APIShieldDiscoveryOriginSessionIdentifier,
+				State:     APIShieldDiscoveryStateSaved,
+				Diff:      true,
 				PaginationOptions: PaginationOptions{
 					Page:    1,
 					PerPage: 25,
@@ -140,8 +138,8 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 				"host":      []string{"api.cloudflare.com", "developers.cloudflare.com"},
 				"method":    []string{"GET", "PUT"},
 				"endpoint":  []string{"/client"},
-				"origin":    []string{"ML"},
-				"state":     []string{"review"},
+				"origin":    []string{"SessionIdentifier"},
+				"state":     []string{"saved"},
 				"diff":      []string{"true"},
 				"page":      []string{"1"},
 				"per_page":  []string{"25"},
@@ -168,9 +166,7 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 		{
 			name: "hosts only",
 			params: ListAPIShieldDiscoveryOperationsParams{
-				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
-					Hosts: []string{"api.cloudflare.com", "developers.cloudflare.com"},
-				},
+				Hosts: []string{"api.cloudflare.com", "developers.cloudflare.com"},
 			},
 			expectedParams: url.Values{
 				"host": []string{"api.cloudflare.com", "developers.cloudflare.com"},
@@ -179,9 +175,7 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 		{
 			name: "methods only",
 			params: ListAPIShieldDiscoveryOperationsParams{
-				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
-					Methods: []string{"GET", "PUT"},
-				},
+				Methods: []string{"GET", "PUT"},
 			},
 			expectedParams: url.Values{
 				"method": []string{"GET", "PUT"},
@@ -190,9 +184,7 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 		{
 			name: "endpoint only",
 			params: ListAPIShieldDiscoveryOperationsParams{
-				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
-					Endpoint: "/client",
-				},
+				Endpoint: "/client",
 			},
 			expectedParams: url.Values{
 				"endpoint": []string{"/client"},
@@ -201,31 +193,25 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 		{
 			name: "origin only",
 			params: ListAPIShieldDiscoveryOperationsParams{
-				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
-					Origin: "ML",
-				},
+				Origin: APIShieldDiscoveryOriginSessionIdentifier,
 			},
 			expectedParams: url.Values{
-				"origin": []string{"ML"},
+				"origin": []string{"SessionIdentifier"},
 			},
 		},
 		{
 			name: "state only",
 			params: ListAPIShieldDiscoveryOperationsParams{
-				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
-					State: "review",
-				},
+				State: APIShieldDiscoveryStateSaved,
 			},
 			expectedParams: url.Values{
-				"state": []string{"review"},
+				"state": []string{"saved"},
 			},
 		},
 		{
 			name: "diff only",
 			params: ListAPIShieldDiscoveryOperationsParams{
-				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
-					Diff: true,
-				},
+				Diff: true,
 			},
 			expectedParams: url.Values{
 				"diff": []string{"true"},
@@ -273,8 +259,8 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 					Endpoint:    "/client/v4/zones",
 					ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
 					LastUpdated: &lastUpdated,
-					Origin:      []string{"ML"},
-					State:       "review",
+					Origin:      []APIShieldDiscoveryOrigin{APIShieldDiscoveryOriginSessionIdentifier},
+					State:       APIShieldDiscoveryStateSaved,
 					Features: map[string]any{
 						"traffic_stats": map[string]any{},
 					},
@@ -288,7 +274,7 @@ func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
 	}
 }
 
-func TestPatchAPIShieldDiscoveryOperation(t *testing.T) {
+func TestUpdateAPIShieldDiscoveryOperation(t *testing.T) {
 	setup()
 	t.Cleanup(teardown)
 
@@ -316,21 +302,19 @@ func TestPatchAPIShieldDiscoveryOperation(t *testing.T) {
 
 	mux.HandleFunc(endpoint, handler)
 
-	actual, err := client.PatchAPIShieldDiscoveryOperation(
+	actual, err := client.UpdateAPIShieldDiscoveryOperation(
 		context.Background(),
 		ZoneIdentifier(testZoneID),
-		PatchAPIShieldDiscoveryOperationParams{
+		UpdateAPIShieldDiscoveryOperationParams{
 			OperationID: testAPIShieldDiscoveryOperationID,
-			PatchAPIShieldDiscoveryOperation: PatchAPIShieldDiscoveryOperation{
-				State: "ignored",
-			},
+			State:       APIShieldDiscoveryStateIgnored,
 		},
 	)
 
 	// patch result is a cut down representation of the schema
 	// so metadata like created date is not populated
-	expected := &PatchAPIShieldDiscoveryOperation{
-		State: "ignored",
+	expected := &UpdateAPIShieldDiscoveryOperation{
+		State: APIShieldDiscoveryStateIgnored,
 	}
 
 	if assert.NoError(t, err) {
@@ -340,7 +324,7 @@ func TestPatchAPIShieldDiscoveryOperation(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestPatchAPIShieldDiscoveryOperations(t *testing.T) {
+func TestUpdateAPIShieldDiscoveryOperations(t *testing.T) {
 	setup()
 	t.Cleanup(teardown)
 
@@ -369,18 +353,18 @@ func TestPatchAPIShieldDiscoveryOperations(t *testing.T) {
 
 	mux.HandleFunc(endpoint, handler)
 
-	actual, err := client.PatchAPIShieldDiscoveryOperations(
+	actual, err := client.UpdateAPIShieldDiscoveryOperations(
 		context.Background(),
 		ZoneIdentifier(testZoneID),
-		PatchAPIShieldDiscoveryOperationsParams{
-			"9b16ce22-d1bf-425d-869f-a11f8240fafb": PatchAPIShieldDiscoveryOperation{State: "ignored"},
-			"c51c2ea1-a690-48fd-8e3f-7fc79b269947": PatchAPIShieldDiscoveryOperation{State: "review"},
+		UpdateAPIShieldDiscoveryOperationsParams{
+			"9b16ce22-d1bf-425d-869f-a11f8240fafb": UpdateAPIShieldDiscoveryOperation{State: APIShieldDiscoveryStateIgnored},
+			"c51c2ea1-a690-48fd-8e3f-7fc79b269947": UpdateAPIShieldDiscoveryOperation{State: APIShieldDiscoveryStateReview},
 		},
 	)
 
-	expected := &PatchAPIShieldDiscoveryOperationsParams{
-		"9b16ce22-d1bf-425d-869f-a11f8240fafb": PatchAPIShieldDiscoveryOperation{State: "ignored"},
-		"c51c2ea1-a690-48fd-8e3f-7fc79b269947": PatchAPIShieldDiscoveryOperation{State: "review"},
+	expected := &UpdateAPIShieldDiscoveryOperationsParams{
+		"9b16ce22-d1bf-425d-869f-a11f8240fafb": UpdateAPIShieldDiscoveryOperation{State: APIShieldDiscoveryStateIgnored},
+		"c51c2ea1-a690-48fd-8e3f-7fc79b269947": UpdateAPIShieldDiscoveryOperation{State: APIShieldDiscoveryStateReview},
 	}
 
 	if assert.NoError(t, err) {
@@ -394,6 +378,6 @@ func TestMustProvideDiscoveryOperationID(t *testing.T) {
 	setup()
 	t.Cleanup(teardown)
 
-	_, err := client.PatchAPIShieldDiscoveryOperation(context.Background(), ZoneIdentifier(testZoneID), PatchAPIShieldDiscoveryOperationParams{})
-	require.ErrorContains(t, err, "params.OperationID must be provided")
+	_, err := client.UpdateAPIShieldDiscoveryOperation(context.Background(), ZoneIdentifier(testZoneID), UpdateAPIShieldDiscoveryOperationParams{})
+	require.ErrorContains(t, err, "operation ID must be provided")
 }

--- a/api_shield_api_discovery_test.go
+++ b/api_shield_api_discovery_test.go
@@ -1,0 +1,399 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAPIShieldDiscoveryOperationID = "d3f614c0-7d73-4e4f-8d17-4215e7d78b77"
+
+func TestListAPIShieldDiscoveryOperations(t *testing.T) {
+	endpoint := fmt.Sprintf("/zones/%s/api_gateway/discovery/operations", testZoneID)
+	response := `{
+		"success" : true,
+		"errors": [],
+		"messages": [],
+		"result": [
+			{
+				"id": "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
+				"method": "POST",
+				"host": "api.cloudflare.com",
+				"endpoint": "/client/v4/zones",
+				"last_updated": "2023-03-02T15:46:06.000000Z",
+				"origin": ["ML"],
+				"state": "review"
+			}
+		],
+		"result_info": {
+			"page": 3,
+			"per_page": 20,
+			"count": 1,
+			"total_count": 2000
+		}
+	}`
+
+	setup()
+	t.Cleanup(teardown)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		require.Empty(t, r.URL.Query())
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, response)
+	}
+
+	mux.HandleFunc(endpoint, handler)
+
+	actual, actualResultInfo, err := client.ListAPIShieldDiscoveryOperations(
+		context.Background(),
+		ZoneIdentifier(testZoneID),
+		ListAPIShieldDiscoveryOperationsParams{},
+	)
+
+	lastUpdated := time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC)
+	expectedOps := []APIShieldDiscoveryOperation{
+		{
+			Method:      "POST",
+			Host:        "api.cloudflare.com",
+			Endpoint:    "/client/v4/zones",
+			ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
+			LastUpdated: &lastUpdated,
+			Origin:      []string{"ML"},
+			State:       "review",
+		},
+	}
+
+	expectedResultInfo := ResultInfo{
+		Page:    3,
+		PerPage: 20,
+		Count:   1,
+		Total:   2000,
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedOps, actual)
+		assert.Equal(t, expectedResultInfo, actualResultInfo)
+	}
+}
+
+func TestListAPIShieldDiscoveryOperationsWithParams(t *testing.T) {
+	endpoint := fmt.Sprintf("/zones/%s/api_gateway/discovery/operations", testZoneID)
+	response := `{
+		"success" : true,
+		"errors": [],
+		"messages": [],
+		"result": [
+			{
+				"id": "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
+				"method": "POST",
+				"host": "api.cloudflare.com",
+				"endpoint": "/client/v4/zones",
+				"last_updated": "2023-03-02T15:46:06.000000Z",
+				"origin": ["ML"],
+				"state": "review",
+				"features": {
+					"traffic_stats": {}
+				}
+			}
+		],
+		"result_info": {
+			"page": 3,
+			"per_page": 20,
+			"count": 1,
+			"total_count": 2000
+		}
+	}`
+
+	tests := []struct {
+		name           string
+		params         ListAPIShieldDiscoveryOperationsParams
+		expectedParams url.Values
+	}{
+		{
+			name: "all params",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				Direction: "desc",
+				OrderBy:   "host",
+				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
+					Hosts:    []string{"api.cloudflare.com", "developers.cloudflare.com"},
+					Methods:  []string{"GET", "PUT"},
+					Endpoint: "/client",
+					Origin:   "ML",
+					State:    "review",
+					Diff:     true,
+				},
+				PaginationOptions: PaginationOptions{
+					Page:    1,
+					PerPage: 25,
+				},
+			},
+			expectedParams: url.Values{
+				"direction": []string{"desc"},
+				"order":     []string{"host"},
+				"host":      []string{"api.cloudflare.com", "developers.cloudflare.com"},
+				"method":    []string{"GET", "PUT"},
+				"endpoint":  []string{"/client"},
+				"origin":    []string{"ML"},
+				"state":     []string{"review"},
+				"diff":      []string{"true"},
+				"page":      []string{"1"},
+				"per_page":  []string{"25"},
+			},
+		},
+		{
+			name: "direction only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				Direction: "desc",
+			},
+			expectedParams: url.Values{
+				"direction": []string{"desc"},
+			},
+		},
+		{
+			name: "order only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				OrderBy: "host",
+			},
+			expectedParams: url.Values{
+				"order": []string{"host"},
+			},
+		},
+		{
+			name: "hosts only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
+					Hosts: []string{"api.cloudflare.com", "developers.cloudflare.com"},
+				},
+			},
+			expectedParams: url.Values{
+				"host": []string{"api.cloudflare.com", "developers.cloudflare.com"},
+			},
+		},
+		{
+			name: "methods only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
+					Methods: []string{"GET", "PUT"},
+				},
+			},
+			expectedParams: url.Values{
+				"method": []string{"GET", "PUT"},
+			},
+		},
+		{
+			name: "endpoint only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
+					Endpoint: "/client",
+				},
+			},
+			expectedParams: url.Values{
+				"endpoint": []string{"/client"},
+			},
+		},
+		{
+			name: "origin only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
+					Origin: "ML",
+				},
+			},
+			expectedParams: url.Values{
+				"origin": []string{"ML"},
+			},
+		},
+		{
+			name: "state only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
+					State: "review",
+				},
+			},
+			expectedParams: url.Values{
+				"state": []string{"review"},
+			},
+		},
+		{
+			name: "diff only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				APIShieldListDiscoveryOperationsFilters: APIShieldListDiscoveryOperationsFilters{
+					Diff: true,
+				},
+			},
+			expectedParams: url.Values{
+				"diff": []string{"true"},
+			},
+		},
+		{
+			name: "pagination only",
+			params: ListAPIShieldDiscoveryOperationsParams{
+				PaginationOptions: PaginationOptions{
+					Page:    1,
+					PerPage: 25,
+				},
+			},
+			expectedParams: url.Values{
+				"page":     []string{"1"},
+				"per_page": []string{"25"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setup()
+			t.Cleanup(teardown)
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+				require.Equal(t, test.expectedParams, r.URL.Query())
+				w.Header().Set("content-type", "application/json")
+				fmt.Fprint(w, response)
+			}
+
+			mux.HandleFunc(endpoint, handler)
+
+			actual, _, err := client.ListAPIShieldDiscoveryOperations(
+				context.Background(),
+				ZoneIdentifier(testZoneID),
+				test.params,
+			)
+
+			lastUpdated := time.Date(2023, time.March, 2, 15, 46, 6, 0, time.UTC)
+			expected := []APIShieldDiscoveryOperation{
+				{
+					Method:      "POST",
+					Host:        "api.cloudflare.com",
+					Endpoint:    "/client/v4/zones",
+					ID:          "9def2cb0-3ed0-4737-92ca-f09efa4718fd",
+					LastUpdated: &lastUpdated,
+					Origin:      []string{"ML"},
+					State:       "review",
+					Features: map[string]any{
+						"traffic_stats": map[string]any{},
+					},
+				},
+			}
+
+			if assert.NoError(t, err) {
+				assert.Equal(t, expected, actual)
+			}
+		})
+	}
+}
+
+func TestPatchAPIShieldDiscoveryOperation(t *testing.T) {
+	setup()
+	t.Cleanup(teardown)
+
+	endpoint := fmt.Sprintf("/zones/%s/api_gateway/discovery/operations/%s", testZoneID, testAPIShieldDiscoveryOperationID)
+	response := `{
+		"success" : true,
+		"errors": [],
+		"messages": [],
+		"result": {
+			"state": "ignored"
+		}
+	}`
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method, "Expected method 'PATCH', got %s", r.Method)
+		require.Empty(t, r.URL.Query())
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, `{"state":"ignored"}`, string(body))
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, response)
+	}
+
+	mux.HandleFunc(endpoint, handler)
+
+	actual, err := client.PatchAPIShieldDiscoveryOperation(
+		context.Background(),
+		ZoneIdentifier(testZoneID),
+		PatchAPIShieldDiscoveryOperationParams{
+			OperationID: testAPIShieldDiscoveryOperationID,
+			PatchAPIShieldDiscoveryOperation: PatchAPIShieldDiscoveryOperation{
+				State: "ignored",
+			},
+		},
+	)
+
+	// patch result is a cut down representation of the schema
+	// so metadata like created date is not populated
+	expected := &PatchAPIShieldDiscoveryOperation{
+		State: "ignored",
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, actual)
+	}
+
+	assert.NoError(t, err)
+}
+
+func TestPatchAPIShieldDiscoveryOperations(t *testing.T) {
+	setup()
+	t.Cleanup(teardown)
+
+	endpoint := fmt.Sprintf("/zones/%s/api_gateway/discovery/operations", testZoneID)
+	response := `{
+		"success" : true,
+		"errors": [],
+		"messages": [],
+		"result": {
+			"9b16ce22-d1bf-425d-869f-a11f8240fafb": { "state": "ignored" },
+			"c51c2ea1-a690-48fd-8e3f-7fc79b269947": { "state": "review" }
+		}
+	}`
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPatch, r.Method, "Expected method 'PATCH', got %s", r.Method)
+		require.Empty(t, r.URL.Query())
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, `{"9b16ce22-d1bf-425d-869f-a11f8240fafb":{"state":"ignored"},"c51c2ea1-a690-48fd-8e3f-7fc79b269947":{"state":"review"}}`, string(body))
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, response)
+	}
+
+	mux.HandleFunc(endpoint, handler)
+
+	actual, err := client.PatchAPIShieldDiscoveryOperations(
+		context.Background(),
+		ZoneIdentifier(testZoneID),
+		PatchAPIShieldDiscoveryOperationsParams{
+			"9b16ce22-d1bf-425d-869f-a11f8240fafb": PatchAPIShieldDiscoveryOperation{State: "ignored"},
+			"c51c2ea1-a690-48fd-8e3f-7fc79b269947": PatchAPIShieldDiscoveryOperation{State: "review"},
+		},
+	)
+
+	expected := &PatchAPIShieldDiscoveryOperationsParams{
+		"9b16ce22-d1bf-425d-869f-a11f8240fafb": PatchAPIShieldDiscoveryOperation{State: "ignored"},
+		"c51c2ea1-a690-48fd-8e3f-7fc79b269947": PatchAPIShieldDiscoveryOperation{State: "review"},
+	}
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, actual)
+	}
+
+	assert.NoError(t, err)
+}
+
+func TestMustProvideDiscoveryOperationID(t *testing.T) {
+	setup()
+	t.Cleanup(teardown)
+
+	_, err := client.PatchAPIShieldDiscoveryOperation(context.Background(), ZoneIdentifier(testZoneID), PatchAPIShieldDiscoveryOperationParams{})
+	require.ErrorContains(t, err, "params.OperationID must be provided")
+}


### PR DESCRIPTION
This change adds support for the following API Shield related endpoints related to API Discovery:

- Retrieve discovered operations on a zone (https://developers.cloudflare.com/api/operations/api-shield-api-discovery-retrieve-discovered-operations-on-a-zone)
- Patch discovered operations (https://developers.cloudflare.com/api/operations/api-shield-api-patch-discovered-operations)
- Patch discovered operation (https://developers.cloudflare.com/api/operations/api-shield-api-patch-discovered-operation)


## Description

This change adds support for API Shield endpoints related to API Shield API Discovery. This is so they can be used from the library and will enable this feature to be added to terraform in the future.

## Has your change been tested?

* Unit tests
* Local testing


## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs. (see [API Shield API Discovery](https://developers.cloudflare.com/api/operations/api-shield-api-discovery-retrieve-discovered-operations-on-a-zone))

[1]: https://help.github.com/articles/closing-issues-using-keywords/
