### PR TITLE
Add session_duration to access policies & orgs

### DIFF
--- a/.changelog/1415.txt
+++ b/.changelog/1415.txt
@@ -1,4 +1,7 @@
 ```release-note:enhancement
 access_organization: Add support for session_duration
+```
+
+```release-note:enhancement
 access_policy: Add support for session_duration
 ```

--- a/.changelog/1415.txt
+++ b/.changelog/1415.txt
@@ -1,0 +1,4 @@
+```release-note:enhancement
+access_organization: Add support for session_duration
+access_policy: Add support for session_duration
+```

--- a/access_organization.go
+++ b/access_organization.go
@@ -20,6 +20,7 @@ type AccessOrganization struct {
 	UIReadOnlyToggleReason         string                        `json:"ui_read_only_toggle_reason,omitempty"`
 	UserSeatExpirationInactiveTime string                        `json:"user_seat_expiration_inactive_time,omitempty"`
 	AutoRedirectToIdentity         *bool                         `json:"auto_redirect_to_identity,omitempty"`
+	SessionDuration                *string                       `json:"session_duration,omitempty"`
 	CustomPages                    AccessOrganizationCustomPages `json:"custom_pages,omitempty"`
 }
 
@@ -64,6 +65,7 @@ type CreateAccessOrganizationParams struct {
 	UIReadOnlyToggleReason         string                        `json:"ui_read_only_toggle_reason,omitempty"`
 	UserSeatExpirationInactiveTime string                        `json:"user_seat_expiration_inactive_time,omitempty"`
 	AutoRedirectToIdentity         *bool                         `json:"auto_redirect_to_identity,omitempty"`
+	SessionDuration                *string                       `json:"session_duration,omitempty"`
 	CustomPages                    AccessOrganizationCustomPages `json:"custom_pages,omitempty"`
 }
 
@@ -75,6 +77,7 @@ type UpdateAccessOrganizationParams struct {
 	UIReadOnlyToggleReason         string                        `json:"ui_read_only_toggle_reason,omitempty"`
 	UserSeatExpirationInactiveTime string                        `json:"user_seat_expiration_inactive_time,omitempty"`
 	AutoRedirectToIdentity         *bool                         `json:"auto_redirect_to_identity,omitempty"`
+	SessionDuration                *string                       `json:"session_duration,omitempty"`
 	CustomPages                    AccessOrganizationCustomPages `json:"custom_pages,omitempty"`
 }
 

--- a/access_organization_test.go
+++ b/access_organization_test.go
@@ -29,6 +29,7 @@ func TestAccessOrganization(t *testing.T) {
 				"is_ui_read_only": false,
 				"user_seat_expiration_inactive_time": "720h",
 				"auto_redirect_to_identity": true,
+				"session_duration": "12h",
 				"login_design": {
 					"background_color": "#c5ed1b",
 					"logo_path": "https://example.com/logo.png",
@@ -57,6 +58,7 @@ func TestAccessOrganization(t *testing.T) {
 			FooterText:      "© Widget Corp",
 		},
 		IsUIReadOnly:                   BoolPtr(false),
+		SessionDuration:                StringPtr("12h"),
 		UserSeatExpirationInactiveTime: "720h",
 		AutoRedirectToIdentity:         BoolPtr(true),
 	}
@@ -95,6 +97,7 @@ func TestCreateAccessOrganization(t *testing.T) {
 				"name": "Widget Corps Internal Applications",
 				"auth_domain": "test.cloudflareaccess.com",
 				"is_ui_read_only": true,
+				"session_duration": "12h",
 				"login_design": {
 					"background_color": "#c5ed1b",
 					"logo_path": "https://example.com/logo.png",
@@ -122,7 +125,8 @@ func TestCreateAccessOrganization(t *testing.T) {
 			HeaderText:      "Widget Corp",
 			FooterText:      "© Widget Corp",
 		},
-		IsUIReadOnly: BoolPtr(true),
+		IsUIReadOnly:    BoolPtr(true),
+		SessionDuration: StringPtr("12h"),
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/organizations", handler)
@@ -137,7 +141,8 @@ func TestCreateAccessOrganization(t *testing.T) {
 			HeaderText:      "Widget Corp",
 			FooterText:      "© Widget Corp",
 		},
-		IsUIReadOnly: BoolPtr(true),
+		IsUIReadOnly:    BoolPtr(true),
+		SessionDuration: StringPtr("12h"),
 	})
 
 	if assert.NoError(t, err) {
@@ -156,7 +161,8 @@ func TestCreateAccessOrganization(t *testing.T) {
 			HeaderText:      "Widget Corp",
 			FooterText:      "© Widget Corp",
 		},
-		IsUIReadOnly: BoolPtr(true),
+		IsUIReadOnly:    BoolPtr(true),
+		SessionDuration: StringPtr("12h"),
 	})
 
 	if assert.NoError(t, err) {
@@ -188,7 +194,8 @@ func TestUpdateAccessOrganization(t *testing.T) {
 					"footer_text": "© Widget Corp"
 				},
 				"is_ui_read_only": false,
-				"ui_read_only_toggle_reason": "this is my reason"
+				"ui_read_only_toggle_reason": "this is my reason",
+				"session_duration": "12h"
 			}
 		}
 		`)
@@ -211,6 +218,7 @@ func TestUpdateAccessOrganization(t *testing.T) {
 		},
 		IsUIReadOnly:           BoolPtr(false),
 		UIReadOnlyToggleReason: "this is my reason",
+		SessionDuration:        StringPtr("12h"),
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/organizations", handler)
@@ -226,6 +234,7 @@ func TestUpdateAccessOrganization(t *testing.T) {
 			FooterText:      "© Widget Corp",
 		},
 		IsUIReadOnly:           BoolPtr(false),
+		SessionDuration:        StringPtr("12h"),
 		UIReadOnlyToggleReason: "this is my reason",
 	})
 
@@ -247,6 +256,7 @@ func TestUpdateAccessOrganization(t *testing.T) {
 		},
 		IsUIReadOnly:           BoolPtr(false),
 		UIReadOnlyToggleReason: "this is my reason",
+		SessionDuration:        StringPtr("12h"),
 	})
 
 	if assert.NoError(t, err) {

--- a/access_policy.go
+++ b/access_policy.go
@@ -31,6 +31,7 @@ type AccessPolicy struct {
 	Name       string     `json:"name"`
 
 	IsolationRequired            *bool                 `json:"isolation_required,omitempty"`
+	SessionDuration              *string               `json:"session_duration,omitempty"`
 	PurposeJustificationRequired *bool                 `json:"purpose_justification_required,omitempty"`
 	PurposeJustificationPrompt   *string               `json:"purpose_justification_prompt,omitempty"`
 	ApprovalRequired             *bool                 `json:"approval_required,omitempty"`
@@ -84,6 +85,7 @@ type CreateAccessPolicyParams struct {
 	Name       string `json:"name"`
 
 	IsolationRequired            *bool                 `json:"isolation_required,omitempty"`
+	SessionDuration              *string               `json:"session_duration,omitempty"`
 	PurposeJustificationRequired *bool                 `json:"purpose_justification_required,omitempty"`
 	PurposeJustificationPrompt   *string               `json:"purpose_justification_prompt,omitempty"`
 	ApprovalRequired             *bool                 `json:"approval_required,omitempty"`
@@ -111,6 +113,7 @@ type UpdateAccessPolicyParams struct {
 	Name       string `json:"name"`
 
 	IsolationRequired            *bool                 `json:"isolation_required,omitempty"`
+	SessionDuration              *string               `json:"session_duration,omitempty"`
 	PurposeJustificationRequired *bool                 `json:"purpose_justification_required,omitempty"`
 	PurposeJustificationPrompt   *string               `json:"purpose_justification_prompt,omitempty"`
 	ApprovalRequired             *bool                 `json:"approval_required,omitempty"`

--- a/access_policy_test.go
+++ b/access_policy_test.go
@@ -41,6 +41,7 @@ var (
 			map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
 		},
 		IsolationRequired:            &isolationRequired,
+		SessionDuration:              StringPtr("12h"),
 		PurposeJustificationRequired: &purposeJustificationRequired,
 		ApprovalRequired:             &approvalRequired,
 		PurposeJustificationPrompt:   &purposeJustificationPrompt,
@@ -101,6 +102,7 @@ func TestAccessPolicies(t *testing.T) {
 				"purpose_justification_required": true,
 				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 				"approval_required": true,
+				"session_duration": "12h",
 				"approval_groups": [
 				  {
 					"email_list_uuid": "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
@@ -185,6 +187,7 @@ func TestAccessPolicy(t *testing.T) {
 				"purpose_justification_required": true,
 				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 				"approval_required": true,
+				"session_duration": "12h",
 				"approval_groups": [
 					{
 						"email_list_uuid": "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
@@ -260,6 +263,7 @@ func TestCreateAccessPolicy(t *testing.T) {
 				"purpose_justification_required": true,
 				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 				"approval_required": true,
+				"session_duration": "12h",
 				"approval_groups": [
 					{
 						"email_list_uuid": "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
@@ -296,6 +300,7 @@ func TestCreateAccessPolicy(t *testing.T) {
 		Decision:                     "allow",
 		PurposeJustificationRequired: &purposeJustificationRequired,
 		PurposeJustificationPrompt:   &purposeJustificationPrompt,
+		SessionDuration:              StringPtr("12h"),
 		ApprovalGroups: []AccessApprovalGroup{
 			{
 				EmailListUuid:   "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
@@ -328,6 +333,7 @@ func TestCreateAccessPolicy(t *testing.T) {
 func TestCreateAccessPolicyAuthContextRule(t *testing.T) {
 	setup()
 	defer teardown()
+
 	expectedAccessPolicyAuthContext := AccessPolicy{
 		ID:         "699d98642c564d2e855e9661899b7252",
 		Precedence: 1,
@@ -346,6 +352,7 @@ func TestCreateAccessPolicyAuthContextRule(t *testing.T) {
 		PurposeJustificationRequired: &purposeJustificationRequired,
 		ApprovalRequired:             &approvalRequired,
 		PurposeJustificationPrompt:   &purposeJustificationPrompt,
+		SessionDuration:              StringPtr("12h"),
 		ApprovalGroups: []AccessApprovalGroup{
 			{
 				EmailListUuid:   "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
@@ -393,6 +400,7 @@ func TestCreateAccessPolicyAuthContextRule(t *testing.T) {
 				"purpose_justification_required": true,
 				"purpose_justification_prompt": "Please provide a business reason for your need to access before continuing.",
 				"approval_required": true,
+				"session_duration": "12h",
 				"approval_groups": [
 					{
 						"email_list_uuid": "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
@@ -483,6 +491,7 @@ func TestUpdateAccessPolicy(t *testing.T) {
 		PurposeJustificationRequired: &purposeJustificationRequired,
 		ApprovalRequired:             &approvalRequired,
 		PurposeJustificationPrompt:   &purposeJustificationPrompt,
+		SessionDuration:              StringPtr("12h"),
 		ApprovalGroups: []AccessApprovalGroup{
 			{
 				EmailListUuid:   "2413b6d7-bbe5-48bd-8fbb-e52069c85561",
@@ -508,6 +517,7 @@ func TestUpdateAccessPolicy(t *testing.T) {
 				"created_at": "2014-01-01T05:20:00.12345Z",
 				"updated_at": "2014-01-01T05:20:00.12345Z",
 				"name": "Allow devs",
+				"session_duration": "12h",
 				"include": [
 					{
 						"email": {


### PR DESCRIPTION
## Description
Pending documentation update
Adds session_duration to access policies & organizations.
The API already supports these, but they are undocumented

## Has your change been tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X ] My code follows the code style of this project.
- [ X] My change requires a change to the documentation.
- [ X] I have updated the documentation accordingly.
- [X ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
- [X ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
