### PR TITLE
Add support for Get/Update API Shield Schema Validation Settings

### DIFF
--- a/.changelog/1418.txt
+++ b/.changelog/1418.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+api_shield_schema: Add support for Get/Update API Shield Schema Validation Settings
+```

--- a/api_shield_schemas.go
+++ b/api_shield_schemas.go
@@ -333,3 +333,84 @@ func (api *API) UpdateAPIShieldSchema(ctx context.Context, rc *ResourceContainer
 
 	return &asResponse.Result, nil
 }
+
+// Schema Validation Settings
+
+// APIShieldSchemaValidationSettings represents zone level schema validation settings for
+// API Shield Schema Validation 2.0.
+type APIShieldSchemaValidationSettings struct {
+	// DefaultMitigationAction is the mitigation to apply when there is no operation-level
+	// mitigation action defined
+	DefaultMitigationAction string `json:"validation_default_mitigation_action" url:"-"`
+	// OverrideMitigationAction when set, will apply to all requests regardless of
+	// zone-level/operation-level setting
+	OverrideMitigationAction *string `json:"validation_override_mitigation_action" url:"-"`
+}
+
+// UpdateAPIShieldSchemaValidationSettingsParams represents the parameters to pass to update certain fields
+// on schema validation settings on the zone
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-schema-validation-patch-zone-level-settings
+type UpdateAPIShieldSchemaValidationSettingsParams struct {
+	// DefaultMitigationAction is the mitigation to apply when there is no operation-level
+	// mitigation action defined
+	//
+	// passing a `nil` value will have no effect on this setting
+	DefaultMitigationAction *string `json:"validation_default_mitigation_action" url:"-"`
+
+	// OverrideMitigationAction when set, will apply to all requests regardless of
+	// zone-level/operation-level setting
+	//
+	// passing a `nil` value will have no effect on this setting
+	OverrideMitigationAction *string `json:"validation_override_mitigation_action" url:"-"`
+}
+
+// APIShieldSchemaValidationSettingsResponse represents the response from the GET api_gateway/settings/schema_validation endpoint.
+type APIShieldSchemaValidationSettingsResponse struct {
+	Result APIShieldSchemaValidationSettings `json:"result"`
+	Response
+}
+
+// GetAPIShieldSchemaValidationSettings retrieves zone level schema validation settings
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-schema-validation-retrieve-zone-level-settings
+func (api *API) GetAPIShieldSchemaValidationSettings(ctx context.Context, rc *ResourceContainer) (*APIShieldSchemaValidationSettings, error) {
+	path := fmt.Sprintf("/zones/%s/api_gateway/settings/schema_validation", rc.Identifier)
+
+	uri := buildURI(path, nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var asResponse APIShieldSchemaValidationSettingsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return &asResponse.Result, nil
+}
+
+// UpdateAPIShieldSchemaValidationSettings updates certain fields on zone level schema validation settings
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-schema-validation-patch-zone-level-settings
+func (api *API) UpdateAPIShieldSchemaValidationSettings(ctx context.Context, rc *ResourceContainer, params UpdateAPIShieldSchemaValidationSettingsParams) (*APIShieldSchemaValidationSettings, error) {
+	path := fmt.Sprintf("/zones/%s/api_gateway/settings/schema_validation", rc.Identifier)
+
+	uri := buildURI(path, params)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var asResponse APIShieldSchemaValidationSettingsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return &asResponse.Result, nil
+}


### PR DESCRIPTION
This change adds support for the following API Shield related endpoints related to API Shield Schema Validation Settings:

- Retrieve API Shield Schema Validation Settings https://developers.cloudflare.com/api/operations/api-shield-schema-validation-retrieve-zone-level-settings
- Update All API Shield Schema Validation Settings https://developers.cloudflare.com/api/operations/api-shield-schema-validation-update-zone-level-settings
- Update API Shield Schema Validation Settings https://developers.cloudflare.com/api/operations/api-shield-schema-validation-patch-zone-level-settings


## Description


## Has your change been tested?

* Unit tests
* Local testing

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
