### PR TITLE
Add support for Get/Update API Shield Operation Schema Validation settings

### DIFF
--- a/.changelog/1422.txt
+++ b/.changelog/1422.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+api_shield_schema: Add support for Get/Update API Shield Operation Schema Validation Settings
+```

--- a/api_shield_schemas.go
+++ b/api_shield_schemas.go
@@ -414,3 +414,92 @@ func (api *API) UpdateAPIShieldSchemaValidationSettings(ctx context.Context, rc 
 
 	return &asResponse.Result, nil
 }
+
+// APIShieldOperationSchemaValidationSettings represents operation level schema validation settings for
+// API Shield Schema Validation 2.0.
+type APIShieldOperationSchemaValidationSettings struct {
+	// MitigationAction is the mitigation to apply to the operation
+	MitigationAction *string `json:"mitigation_action" url:"-"`
+}
+
+// GetAPIShieldOperationSchemaValidationSettingsParams represents the parameters to pass to retrieve
+// the schema validation settings set on the operation.
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-schema-validation-retrieve-operation-level-settings
+type GetAPIShieldOperationSchemaValidationSettingsParams struct {
+	// The Operation ID to apply the mitigation action to
+	OperationID string `url:"-"`
+}
+
+// UpdateAPIShieldOperationSchemaValidationSettings maps operation IDs to APIShieldOperationSchemaValidationSettings
+//
+// # This can be used to bulk update operations in one call
+//
+// Example:
+//
+//	UpdateAPIShieldOperationSchemaValidationSettings{
+//			"99522293-a505-45e5-bbad-bbc339f5dc40": APIShieldOperationSchemaValidationSettings{ MitigationAction: nil },
+//	}
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-schema-validation-update-multiple-operation-level-settings
+type UpdateAPIShieldOperationSchemaValidationSettings map[string]APIShieldOperationSchemaValidationSettings
+
+// APIShieldOperationSchemaValidationSettingsResponse represents the response from the GET api_gateway/operation/{operationID}/schema_validation endpoint.
+type APIShieldOperationSchemaValidationSettingsResponse struct {
+	Result APIShieldOperationSchemaValidationSettings `json:"result"`
+	Response
+}
+
+// UpdateAPIShieldOperationSchemaValidationSettingsResponse represents the response from the PATCH api_gateway/operations/schema_validation endpoint.
+type UpdateAPIShieldOperationSchemaValidationSettingsResponse struct {
+	Result UpdateAPIShieldOperationSchemaValidationSettings `json:"result"`
+	Response
+}
+
+// GetAPIShieldOperationSchemaValidationSettings retrieves operation level schema validation settings
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-schema-validation-retrieve-operation-level-settings
+func (api *API) GetAPIShieldOperationSchemaValidationSettings(ctx context.Context, rc *ResourceContainer, params GetAPIShieldOperationSchemaValidationSettingsParams) (*APIShieldOperationSchemaValidationSettings, error) {
+	if params.OperationID == "" {
+		return nil, fmt.Errorf("operation ID must be provided")
+	}
+
+	path := fmt.Sprintf("/zones/%s/api_gateway/operations/%s/schema_validation", rc.Identifier, params.OperationID)
+
+	uri := buildURI(path, nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var asResponse APIShieldOperationSchemaValidationSettingsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return &asResponse.Result, nil
+}
+
+// UpdateAPIShieldOperationSchemaValidationSettings update multiple operation level schema validation settings
+//
+// API documentation: https://developers.cloudflare.com/api/operations/api-shield-schema-validation-update-multiple-operation-level-settings
+func (api *API) UpdateAPIShieldOperationSchemaValidationSettings(ctx context.Context, rc *ResourceContainer, params UpdateAPIShieldOperationSchemaValidationSettings) (*UpdateAPIShieldOperationSchemaValidationSettings, error) {
+	path := fmt.Sprintf("/zones/%s/api_gateway/operations/schema_validation", rc.Identifier)
+
+	uri := buildURI(path, nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
+	if err != nil {
+		return nil, err
+	}
+
+	var asResponse UpdateAPIShieldOperationSchemaValidationSettingsResponse
+	err = json.Unmarshal(res, &asResponse)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return &asResponse.Result, nil
+}


### PR DESCRIPTION
Adds support for the following endpoints

- Retrieve operation level schema validation settings https://developers.cloudflare.com/api/operations/api-shield-schema-validation-retrieve-operation-level-settings
- Update multiple operation level schema validation settings https://developers.cloudflare.com/api/operations/api-shield-schema-validation-update-multiple-operation-level-settings

## Description

## Has your change been tested?

- Unit tests
- Local testing

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
