### PR TITLE
Add Browser Isolation Non-identity onramp support

### DIFF
--- a/.changelog/1424.txt
+++ b/.changelog/1424.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
 teams: Add `non_identity_enabled` boolean in browser isolation settings
 ```
+
+```release-note:breaking-change
+teams: `BrowserIsolation.UrlBrowserIsolationEnabled` has changed from `bool` to `*bool` to meet the library conventions
+```

--- a/.changelog/1424.txt
+++ b/.changelog/1424.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams: Add `non_identity_enabled` boolean in browser isolation settings
+```

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -47,8 +47,8 @@ type TeamsAccountSettings struct {
 }
 
 type BrowserIsolation struct {
-	UrlBrowserIsolationEnabled bool `json:"url_browser_isolation_enabled"`
-	NonIdentityEnabled         bool `json:"non_identity_enabled"`
+	UrlBrowserIsolationEnabled *bool `json:"url_browser_isolation_enabled,omitempty"`
+	NonIdentityEnabled         *bool `json:"non_identity_enabled,omitempty"`
 }
 
 type TeamsAntivirus struct {

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -48,6 +48,7 @@ type TeamsAccountSettings struct {
 
 type BrowserIsolation struct {
 	UrlBrowserIsolationEnabled bool `json:"url_browser_isolation_enabled"`
+	NonIdentityEnabled         bool `json:"non_identity_enabled"`
 }
 
 type TeamsAntivirus struct {

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -78,6 +78,10 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 						"logo_path": "https://logos.com/a.png",
 						"background_color": "#ff0000",
 						"suppress_footer": true
+					},
+					"browser_isolation": {
+						"url_browser_isolation_enabled": true,
+						"non_identity_enabled": true
 					}
 				}
 			}
@@ -107,6 +111,10 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 				MailtoAddress:   "admin@example.com",
 				MailtoSubject:   "Blocked User Inquiry",
 				SuppressFooter:  BoolPtr(true),
+			},
+			BrowserIsolation: &BrowserIsolation{
+				UrlBrowserIsolationEnabled: true,
+				NonIdentityEnabled:         true,
 			},
 		})
 	}

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -82,7 +82,7 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 					"browser_isolation": {
 						"url_browser_isolation_enabled": true,
 						"non_identity_enabled": true
-          }
+          				},
 					"body_scanning": {
 						"inspection_mode": "deep"
 					}

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -113,8 +113,8 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 				SuppressFooter:  BoolPtr(true),
 			},
 			BrowserIsolation: &BrowserIsolation{
-				UrlBrowserIsolationEnabled: true,
-				NonIdentityEnabled:         true,
+				UrlBrowserIsolationEnabled: BoolPtr(true),
+				NonIdentityEnabled:         BoolPtr(true),
 			},
 		})
 	}


### PR DESCRIPTION
<!-- 
Non-identity onramp support has existed for a while in the dashboard but hasn't been made available through the SDK and terraform provider yet.
-->

## Description

Add a `non_identity_enabled` JSON field to the Browser Isolation settings structure in the Zero trust account.

## Has your change been tested?

The unit test was updated to reflect the new fields.

## Screenshots (if appropriate):

This is the corresponding dashboard setting:
![image](https://github.com/cloudflare/cloudflare-go/assets/4979572/c11397e9-3116-4264-a77f-17422e5f260d)


## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. NOTE: Feature already documented
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs. NOTE: OpenAPI source updated, awaiting roll out.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
