### PR TITLE
Flarectl add subcommands certs

### DIFF
--- a/cmd/flarectl/certs.go
+++ b/cmd/flarectl/certs.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/cloudflare/cloudflare-go"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+func certificatePackCreate(c *cli.Context) error {
+	zoneName := c.String("zone")
+	if zoneName == "" {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: the required flag \"zone\" was empty or not provided")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	hosts := c.String("hosts")
+	if hosts == "" {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: the required flag \"hosts\" was empty or not provided")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	validationMethod := c.String("validation")
+	if validationMethod != "txt" && validationMethod != "http" && validationMethod != "email" {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: invalid validation method")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	validityDays := c.Int("validity-days")
+
+	if validityDays != 14 && validityDays != 30 && validityDays != 90 && validityDays != 365 {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: invalid validity days")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	cloudflareBranding := c.String("authority")
+	if cloudflareBranding != "lets_encrypt" && cloudflareBranding != "google" {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: invalid Certificate Authority")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	certificatePackRequest := cloudflare.CertificatePackRequest{
+		Type:                 "advanced",
+		Hosts:                strings.Split(hosts, ","),
+		ValidationMethod:     validationMethod,
+		ValidityDays:         validityDays,
+		CloudflareBranding:   c.Bool("cloudflare-branding"),
+		CertificateAuthority: cloudflareBranding,
+	}
+
+	zoneID, err := api.ZoneIDByName(zoneName)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	record, err := api.CreateCertificatePack(context.Background(), zoneID, certificatePackRequest)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	output := make([][]string, 0, 1)
+	expiresOn := ""
+	if len(record.Certificates) > 0 {
+		expiresOn = record.Certificates[0].ExpiresOn.Format("2006-01-02")
+	}
+	output = append(output, []string{
+		record.ID,
+		record.Type,
+		record.Status,
+		record.ValidationMethod,
+		fmt.Sprintf("%d", record.ValidityDays),
+		record.CertificateAuthority,
+		expiresOn,
+		strings.Join(record.Hosts, " "),
+	})
+	writeTable(c, output, "ID", "Type", "status", "validation_method", "validity_days", "certificate_authority", "expires_on", "hosts")
+	return nil
+}
+
+func certificatePackDelete(c *cli.Context) error {
+	zoneName := c.String("zone")
+	if zoneName == "" {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: the required flag \"zone\" was empty or not provided")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	certificatePackId := c.String("id")
+	if certificatePackId == "" {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: the required flag \"id\" was empty or not provided")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+
+	zoneID, err := api.ZoneIDByName(zoneName)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	err = api.DeleteCertificatePack(context.Background(), zoneID, certificatePackId)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	return nil
+}
+
+func certificatePacksList(c *cli.Context) error {
+	zoneName := c.String("zone")
+	if zoneName == "" {
+		cli.ShowSubcommandHelp(c)
+		err := errors.New("err: the required flag \"zone\" was empty or not provided")
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	zoneID, err := api.ZoneIDByName(zoneName)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	records, err := api.ListCertificatePacks(context.Background(), zoneID)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	var output [][]string
+	for _, r := range records {
+		if c.String("id") != "" && r.ID != c.String("id") {
+			continue
+		}
+		expiresOn := ""
+		if len(r.Certificates) > 0 {
+			expiresOn = r.Certificates[0].ExpiresOn.Format("2006-01-02")
+		}
+		output = append(output, []string{
+			r.ID,
+			r.Type,
+			r.Status,
+			r.ValidationMethod,
+			fmt.Sprintf("%d", r.ValidityDays),
+			r.CertificateAuthority,
+			expiresOn,
+			strings.Join(r.Hosts, " "),
+		})
+	}
+	writeTable(c, output, "ID", "Type", "status", "validation_method", "validity_days", "certificate_authority", "expires_on", "hosts")
+	return nil
+}

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -228,6 +228,16 @@ func main() {
 					Aliases: []string{"c"},
 					Action:  zoneCerts,
 					Usage:   "Custom SSL certificates for a zone",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+						&cli.StringFlag{
+							Name:  "id",
+							Usage: "certificate pack ID",
+						},
+					},
 				},
 				{
 					Name:    "keyless",
@@ -249,7 +259,81 @@ func main() {
 				},
 			},
 		},
-
+		{
+			Name:    "certs",
+			Aliases: []string{"c"},
+			Usage:   "Certificate Packs",
+			Before:  initializeAPI,
+			Subcommands: []*cli.Command{
+				{
+					Name:    "list",
+					Aliases: []string{"l"},
+					Action:  certificatePacksList,
+					Usage:   "List Certificate Packs for a zone",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "id",
+							Usage: "certificate pack ID",
+						},
+						&cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+					},
+				},
+				{
+					Name:    "order",
+					Aliases: []string{"o"},
+					Action:  certificatePackCreate,
+					Usage:   "Order Advanced Certificate Manager Certificate Pack",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+						&cli.StringFlag{
+							Name:  "hosts",
+							Usage: "Comma separated list of valid host names for the certificate packs. Must contain the zone apex, may not contain more than 50 hosts, and may not be empty",
+						},
+						&cli.StringFlag{
+							Name:  "validation",
+							Usage: "validation method: txt, http or email",
+							Value: "txt",
+						},
+						&cli.IntFlag{
+							Name:  "validity-days",
+							Usage: "14, 30, 90 or 365",
+							Value: 30,
+						},
+						&cli.StringFlag{
+							Name:  "authority",
+							Usage: "Certificate Authority selected for the order: google or lets_encrypt",
+							Value: "lets_encrypt",
+						},
+						&cli.BoolFlag{
+							Name:  "cloudflare-branding",
+							Usage: "Whether or not to add Cloudflare Branding for the order. This will add sni.cloudflaressl.com as the Common Name if set true.",
+							Value: false,
+						},
+					},
+				}, {
+					Name:    "delete",
+					Aliases: []string{"d"},
+					Action:  certificatePackDelete,
+					Usage:   "Delete Advanced Certificate Manager Certificate Pack",
+					Flags: []cli.Flag{
+						&cli.StringFlag{
+							Name:  "zone",
+							Usage: "zone name",
+						},
+						&cli.StringFlag{
+							Name:  "id",
+							Usage: "Certificate Pack id",
+						},
+					},
+				},
+			},
+		},
 		{
 			Name:    "dns",
 			Aliases: []string{"d"},

--- a/cmd/flarectl/zone.go
+++ b/cmd/flarectl/zone.go
@@ -11,8 +11,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func zoneCerts(*cli.Context) error {
-	return nil
+func zoneCerts(c *cli.Context) error {
+	return certificatePacksList(c)
 }
 
 func zoneKeyless(*cli.Context) error {


### PR DESCRIPTION
Add flarectl sub command: certs, for support creating, list, and delete SSL certificate


## Description
Add: 
  - flarectl certs list
  - flarectl certs order
  - flarectl certs delete

help info:
flarectl certs      
NAME:
   flarectl certs - Certificate Packs

USAGE:
   flarectl certs command [command options] [arguments...]

COMMANDS:
   list, l    List Certificate Packs for a zone
   order, o   Order Advanced Certificate Manager Certificate Pack
   delete, d  Delete Advanced Certificate Manager Certificate Pack
   help, h    Shows a list of commands or help for one command

OPTIONS:
   --help, -h  show help

## Has your change been tested?

yes, I've tested

## Screenshots (if appropriate):
![image](https://github.com/cloudflare/cloudflare-go/assets/18598252/eeeeb516-f2b1-4a02-93d2-302593bdef6d)


## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
