### PR TITLE
Add support for custom hostname status filters

### DIFF
--- a/.changelog/1435.txt
+++ b/.changelog/1435.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+custom_hostname: Add support for `hostname_status` and `ssl_status` filters in CustomHostnames().
+```

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -214,7 +214,7 @@ func (api *API) CreateCustomHostname(ctx context.Context, zoneID string, ch Cust
 }
 
 // CustomHostnames fetches custom hostnames for the given zone,
-// by applying filter.Hostname if not empty and scoping the result to page'th 50 items.
+// by applying filter and scoping the result to page'th 50 items.
 //
 // The returned ResultInfo can be used to implement pagination.
 //
@@ -225,6 +225,15 @@ func (api *API) CustomHostnames(ctx context.Context, zoneID string, page int, fi
 	v.Set("page", strconv.Itoa(page))
 	if filter.Hostname != "" {
 		v.Set("hostname", filter.Hostname)
+	} else {
+		if filter.Status != "" {
+			v.Set("hostname_status", string(filter.Status))
+		}
+		if ssl := filter.SSL; ssl != nil {
+			if ssl.Status != "" {
+				v.Set("ssl_status", ssl.Status)
+			}
+		}
 	}
 
 	uri := fmt.Sprintf("/zones/%s/custom_hostnames?%s", zoneID, v.Encode())


### PR DESCRIPTION
## Description

Added the following filters for GET custom hostnames:

- `hostname_status`
- `ssl_status`

These filters can be used to Identify custom hostnames in certain error states. They are **not** [publicly documented](https://developers.cloudflare.com/api/operations/custom-hostname-for-a-zone-list-custom-hostnames).

## Has your change been tested?

Added basic unit tests.

## Screenshots
<img width="1007" alt="image" src="https://github.com/cloudflare/cloudflare-go/assets/48730987/416e55f7-a3c0-4a05-82fd-642def22522b">


## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
