### PR TITLE
GATE-4979: Add support for resolver policies

### DIFF
--- a/.changelog/1436.txt
+++ b/.changelog/1436.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams-rules: Add support for resolver policies
+```

--- a/.changelog/1436.txt
+++ b/.changelog/1436.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-teams-rules: Add support for resolver policies
+teams_rules: Add support for resolver policies
 ```

--- a/teams_rules.go
+++ b/teams_rules.go
@@ -57,6 +57,12 @@ type TeamsRuleSettings struct {
 
 	// Action taken when an untrusted origin certificate error occurs in a http allow rule
 	UntrustedCertSettings *UntrustedCertSettings `json:"untrusted_cert"`
+
+	// Specifies that a resolver policy should use Cloudflare's DNS Resolver.
+	ResolveDnsThroughCloudflare *bool `json:"resolve_dns_through_cloudflare,omitempty"`
+
+	// Resolver policy settings.
+	DnsResolverSettings *TeamsDnsResolverSettings `json:"dns_resolvers,omitempty"`
 }
 
 type TeamsGatewayUntrustedCertAction string
@@ -100,6 +106,28 @@ type TeamsCheckSessionSettings struct {
 	Enforce  bool     `json:"enforce"`
 	Duration Duration `json:"duration"`
 }
+
+type (
+	TeamsDnsResolverSettings struct {
+		V4Resolvers []TeamsDnsResolverAddressV4 `json:"ipv4,omitempty"`
+		V6Resolvers []TeamsDnsResolverAddressV6 `json:"ipv6,omitempty"`
+	}
+
+	TeamsDnsResolverAddressV4 struct {
+		TeamsDnsResolverAddress
+	}
+
+	TeamsDnsResolverAddressV6 struct {
+		TeamsDnsResolverAddress
+	}
+
+	TeamsDnsResolverAddress struct {
+		IP                         string `json:"ip"`
+		Port                       *int   `json:"port,omitempty"`
+		VnetID                     string `json:"vnet_id,omitempty"`
+		RouteThroughPrivateNetwork *bool  `json:"route_through_private_network,omitempty"`
+	}
+)
 
 type TeamsDlpPayloadLogSettings struct {
 	Enabled bool `json:"enabled"`

--- a/teams_rules_test.go
+++ b/teams_rules_test.go
@@ -53,6 +53,19 @@ func TestTeamsRules(t *testing.T) {
                     "insecure_disable_dnssec_validation": false,
 					"untrusted_cert": {
 						"action": "error"
+					},
+					"dns_resolvers": {
+						"ipv4": [
+							{"ip": "10.0.0.2", "port": 5053},
+							{
+								"ip": "192.168.0.2",
+								"vnet_id": "16fd7a32-11f0-4687-a0bb-7031d241e184",
+								"route_through_private_network": true
+							}
+						],
+						"ipv6": [
+							{"ip": "2460::1"}
+						]
 					}
 				  }
 				},
@@ -84,7 +97,8 @@ func TestTeamsRules(t *testing.T) {
                     "insecure_disable_dnssec_validation": true,
 					"untrusted_cert": {
 						"action": "pass_through"
-					}
+					},
+					"resolve_dns_through_cloudflare": true
 				  }
 				}
 			]
@@ -94,6 +108,8 @@ func TestTeamsRules(t *testing.T) {
 
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
+	dnsPort := 5053
+	trueBool := true
 
 	want := []TeamsRule{{
 		ID:            "7559a944-3dd7-41bf-b183-360a814a8c36",
@@ -122,6 +138,30 @@ func TestTeamsRules(t *testing.T) {
 			InsecureDisableDNSSECValidation: false,
 			UntrustedCertSettings: &UntrustedCertSettings{
 				Action: UntrustedCertError,
+			},
+			DnsResolverSettings: &TeamsDnsResolverSettings{
+				V4Resolvers: []TeamsDnsResolverAddressV4{
+					{
+						TeamsDnsResolverAddress{
+							IP:   "10.0.0.2",
+							Port: &dnsPort,
+						},
+					},
+					{
+						TeamsDnsResolverAddress{
+							IP:                         "192.168.0.2",
+							VnetID:                     "16fd7a32-11f0-4687-a0bb-7031d241e184",
+							RouteThroughPrivateNetwork: &trueBool,
+						},
+					},
+				},
+				V6Resolvers: []TeamsDnsResolverAddressV6{
+					{
+						TeamsDnsResolverAddress{
+							IP: "2460::1",
+						},
+					},
+				},
 			},
 		},
 		CreatedAt: &createdAt,
@@ -154,6 +194,7 @@ func TestTeamsRules(t *testing.T) {
 				UntrustedCertSettings: &UntrustedCertSettings{
 					Action: UntrustedCertPassthrough,
 				},
+				ResolveDnsThroughCloudflare: &trueBool,
 			},
 			CreatedAt: &createdAt,
 			UpdatedAt: &updatedAt,

--- a/teams_rules_test.go
+++ b/teams_rules_test.go
@@ -108,8 +108,6 @@ func TestTeamsRules(t *testing.T) {
 
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
-	dnsPort := 5053
-	trueBool := true
 
 	want := []TeamsRule{{
 		ID:            "7559a944-3dd7-41bf-b183-360a814a8c36",
@@ -144,14 +142,14 @@ func TestTeamsRules(t *testing.T) {
 					{
 						TeamsDnsResolverAddress{
 							IP:   "10.0.0.2",
-							Port: &dnsPort,
+							Port: IntPtr(5053),
 						},
 					},
 					{
 						TeamsDnsResolverAddress{
 							IP:                         "192.168.0.2",
 							VnetID:                     "16fd7a32-11f0-4687-a0bb-7031d241e184",
-							RouteThroughPrivateNetwork: &trueBool,
+							RouteThroughPrivateNetwork: BoolPtr(true),
 						},
 					},
 				},
@@ -194,7 +192,7 @@ func TestTeamsRules(t *testing.T) {
 				UntrustedCertSettings: &UntrustedCertSettings{
 					Action: UntrustedCertPassthrough,
 				},
-				ResolveDnsThroughCloudflare: &trueBool,
+				ResolveDnsThroughCloudflare: BoolPtr(true),
 			},
 			CreatedAt: &createdAt,
 			UpdatedAt: &updatedAt,


### PR DESCRIPTION
## Description

Resolver policies allow a Zero Trust customer to configure which upstream DNS Resolver to use when criteria in a a rule are matched.

This PR provides this functionality to Golang API Clients.

## Has your change been tested?

Additional serialization tests have been added

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
