### PR TITLE
Add Healthy field to Load Balancer Pool struct

### DIFF
--- a/.changelog/1442.txt
+++ b/.changelog/1442.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+load_balancing: add healthy field to LoadBalancerPool
+```

--- a/load_balancing.go
+++ b/load_balancing.go
@@ -26,6 +26,7 @@ type LoadBalancerPool struct {
 	Longitude         *float32                    `json:"longitude,omitempty"`
 	LoadShedding      *LoadBalancerLoadShedding   `json:"load_shedding,omitempty"`
 	OriginSteering    *LoadBalancerOriginSteering `json:"origin_steering,omitempty"`
+	Healthy           *bool                       `json:"healthy,omitempty"`
 
 	// CheckRegions defines the geographic region(s) from where to run health-checks from - e.g. "WNAM", "WEU", "SAF", "SAM".
 	// Providing a null/empty value means "all regions", which may not be available to all plan types.

--- a/load_balancing_test.go
+++ b/load_balancing_test.go
@@ -96,7 +96,8 @@ func TestCreateLoadBalancerPool(t *testing.T) {
               "notification_email": "someone@example.com",
               "check_regions": [
                 "WEU"
-              ]
+              ],
+			  "healthy": true
             }
         }`)
 	}
@@ -143,6 +144,7 @@ func TestCreateLoadBalancerPool(t *testing.T) {
 		CheckRegions: []string{
 			"WEU",
 		},
+		Healthy: BoolPtr(true),
 	}
 	request := LoadBalancerPool{
 		Description: "Primary data center - Provider XYZ",


### PR DESCRIPTION
## Description

Add support to LoadBalancerPool struct by adding `healthy` field. In api response to the pool endpoints I see that healthy field is available but not in the cloudflare-go library. 

## Has your change been tested?

Added unit test

## Screenshots (if appropriate):

## Types of changes

Add field to struct

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
