### PR TITLE
updating binding form id

### DIFF
--- a/.changelog/1450.txt
+++ b/.changelog/1450.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+worker_bindings: Fixing form element name for d1 binding
+```

--- a/workers_bindings.go
+++ b/workers_bindings.go
@@ -428,7 +428,7 @@ func (b WorkerD1DatabaseBinding) serialize(bindingName string) (workerBindingMet
 	return workerBindingMeta{
 		"name":        bindingName,
 		"type":        b.Type(),
-		"database_id": b.DatabaseID,
+		"id": b.DatabaseID,
 	}, nil, nil
 }
 


### PR DESCRIPTION
Changing name of form binding parameter

## Description

Was using wrong form parameter name for D1 binding id
## Has your change been tested?

Change tested with changes to terraform-cloudflare-provider

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
