### PR TITLE
feat: added gateway rule notification settings

### DIFF
--- a/.changelog/1463.txt
+++ b/.changelog/1463.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams_rules: Added support for notification settings in a gateway rule
+```

--- a/teams_rules.go
+++ b/teams_rules.go
@@ -63,6 +63,8 @@ type TeamsRuleSettings struct {
 
 	// Resolver policy settings.
 	DnsResolverSettings *TeamsDnsResolverSettings `json:"dns_resolvers,omitempty"`
+
+	NotificationSettings *TeamsNotificationSettings `json:"notification_settings"`
 }
 
 type TeamsGatewayUntrustedCertAction string
@@ -75,6 +77,12 @@ const (
 
 type UntrustedCertSettings struct {
 	Action TeamsGatewayUntrustedCertAction `json:"action"`
+}
+
+type TeamsNotificationSettings struct {
+	Enabled    *bool  `json:"enabled,omitempty"`
+	Message    string `json:"msg"`
+	SupportURL string `json:"support_url"`
 }
 
 type AuditSSHRuleSettings struct {

--- a/teams_rules_test.go
+++ b/teams_rules_test.go
@@ -66,6 +66,11 @@ func TestTeamsRules(t *testing.T) {
 						"ipv6": [
 							{"ip": "2460::1"}
 						]
+					},
+					"notification_settings": {
+						"enabled": true,
+						"msg": "message",
+						"support_url": "https://hello.com"
 					}
 				  }
 				},
@@ -109,6 +114,7 @@ func TestTeamsRules(t *testing.T) {
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
+	True := true
 	want := []TeamsRule{{
 		ID:            "7559a944-3dd7-41bf-b183-360a814a8c36",
 		Name:          "rule1",
@@ -160,6 +166,11 @@ func TestTeamsRules(t *testing.T) {
 						},
 					},
 				},
+			},
+			NotificationSettings: &TeamsNotificationSettings{
+				Enabled:    &True,
+				Message:    "message",
+				SupportURL: "https://hello.com",
 			},
 		},
 		CreatedAt: &createdAt,

--- a/teams_rules_test.go
+++ b/teams_rules_test.go
@@ -114,7 +114,6 @@ func TestTeamsRules(t *testing.T) {
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
-	True := true
 	want := []TeamsRule{{
 		ID:            "7559a944-3dd7-41bf-b183-360a814a8c36",
 		Name:          "rule1",
@@ -168,7 +167,7 @@ func TestTeamsRules(t *testing.T) {
 				},
 			},
 			NotificationSettings: &TeamsNotificationSettings{
-				Enabled:    &True,
+				Enabled:    BoolPtr(true),
 				Message:    "message",
 				SupportURL: "https://hello.com",
 			},


### PR DESCRIPTION
New notification settings are added to the gateway rules as optional settings. This PR adds support for them in the library.

API DOC change at https://developers.cloudflare.com/api/operations/zero-trust-gateway-rules-create-zero-trust-gateway-rule


## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
