### PR TITLE
Adding Access client secret and ID to device posture integration

### DIFF
--- a/.changelog/1464.txt
+++ b/.changelog/1464.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+device_posture_rules: add support for Access client fields in device posture integrations
+```

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -17,7 +17,7 @@ type DevicePostureIntegrationConfig struct {
 	ApiUrl             string `json:"api_url,omitempty"`
 	ClientKey          string `json:"client_key,omitempty"`
 	CustomerID         string `json:"customer_id,omitempty"`
-	AccessClientId     string `json:"access_client_id,omitempty"`
+	AccessClientID     string `json:"access_client_id,omitempty"`
 	AccessClientSecret string `json:"access_client_secret,omitempty"`
 }
 

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -11,12 +11,14 @@ import (
 // DevicePostureIntegrationConfig contains authentication information
 // for a device posture integration.
 type DevicePostureIntegrationConfig struct {
-	ClientID     string `json:"client_id,omitempty"`
-	ClientSecret string `json:"client_secret,omitempty"`
-	AuthUrl      string `json:"auth_url,omitempty"`
-	ApiUrl       string `json:"api_url,omitempty"`
-	ClientKey    string `json:"client_key,omitempty"`
-	CustomerID   string `json:"customer_id,omitempty"`
+	ClientID           string `json:"client_id,omitempty"`
+	ClientSecret       string `json:"client_secret,omitempty"`
+	AuthUrl            string `json:"auth_url,omitempty"`
+	ApiUrl             string `json:"api_url,omitempty"`
+	ClientKey          string `json:"client_key,omitempty"`
+	CustomerID         string `json:"customer_id,omitempty"`
+	AccessClientId     string `json:"access_client_id,omitempty"`
+	AccessClientSecret string `json:"access_client_secret,omitempty"`
 }
 
 // DevicePostureIntegration represents a device posture integration.

--- a/device_posture_rule_test.go
+++ b/device_posture_rule_test.go
@@ -263,7 +263,7 @@ func TestDevicePostureIntegrationTaniumCreate(t *testing.T) {
 		Config: DevicePostureIntegrationConfig{
 			ApiUrl:             "https://api_url.example.com",
 			ClientSecret:       "test_client_secret",
-			AccessClientId:     "test_access_client_id",
+			AccessClientID:     "test_access_client_id",
 			AccessClientSecret: "test_access_client_secret",
 		},
 	}

--- a/device_posture_rule_test.go
+++ b/device_posture_rule_test.go
@@ -228,6 +228,55 @@ func TestDevicePostureIntegrationCreate(t *testing.T) {
 	}
 }
 
+func TestDevicePostureIntegrationTaniumCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	id := "480f4f69-1a28-4fdd-9240-1ed29f0ac1db"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "%s",
+				"interval": "1h",
+				"type": "tanium_s2s",
+				"name": "My Tanium integration",
+				"config": {
+					"api_url":              "https://api_url.example.com",
+					"client_secret":        "test_client_secret",
+					"access_client_id":     "test_access_client_id",
+					"access_client_secret": "test_access_client_secret"
+				}
+			}
+		}`, id)
+	}
+
+	want := DevicePostureIntegration{
+		IntegrationID: id,
+		Name:          "My Tanium integration",
+		Type:          "tanium_s2s",
+		Interval:      "1h",
+		Config: DevicePostureIntegrationConfig{
+			ApiUrl:             "https://api_url.example.com",
+			ClientSecret:       "test_client_secret",
+			AccessClientId:     "test_access_client_id",
+			AccessClientSecret: "test_access_client_secret",
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/devices/posture/integration", handler)
+
+	actual, err := client.CreateDevicePostureIntegration(context.Background(), testAccountID, want)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
 func TestDevicePostureIntegrationDelete(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adding the `access_client_secret` and `access_client_id` fields for device posture integrations. 

## Description

These are new credentials that an admin can supply for their posture integration. 

## Has your change been tested?

Yes, added a unit test here and manually tested. These fields have been available in the API and ZT dashboard for the past week.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. 
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
