### PR TITLE
bump minimum Go version to 1.19

### DIFF
--- a/.changelog/1473.txt
+++ b/.changelog/1473.txt
@@ -1,0 +1,3 @@
+```release-note:internal
+cloudflare: bump minimum Go version to 1.19
+```

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.18.3
+FROM golang:1.19

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/cloudflare-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/goccy/go-json v0.10.2

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/cloudflare-go/internal/tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/breml/bidichk v0.2.3
@@ -19,6 +19,7 @@ require (
 	github.com/uudashr/gopkgs/v2 v2.1.2
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
+	golang.org/x/tools v0.13.0
 	golang.org/x/tools/gopls v0.9.4
 )
 
@@ -232,7 +233,6 @@ require (
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
-	golang.org/x/tools v0.13.0 // indirect
 	golang.org/x/vuln v0.0.0-20220725105440-4151a5aca1df // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -18,7 +18,7 @@ package tools
 //go:generate go install github.com/uudashr/gopkgs/v2/cmd/gopkgs
 //go:generate go install golang.org/x/lint/golint
 //go:generate go install golang.org/x/oauth2
-//go:generate go install golang.org/x/tools/gopls@latest
+//go:generate go install golang.org/x/tools/gopls
 //go:generate go install golang.org/x/tools/cmd/goimports@latest
 
 import (
@@ -36,7 +36,7 @@ import (
 	_ "github.com/securego/gosec/v2/cmd/gosec"
 	_ "github.com/uudashr/gopkgs/v2/cmd/gopkgs"
 	_ "golang.org/x/lint/golint"
-	_ "golang.org/x/tools/cmd/goimports@latest"
+	_ "golang.org/x/tools/cmd/goimports"
 	_ "golang.org/x/tools/gopls"
 
 	// used for changelog-check tooling


### PR DESCRIPTION
Following the Go version support policy, we're bumping the minimum to 1.19