### PR TITLE
flarectl: fix duplicate alias in zone subcommand

### DIFF
--- a/.changelog/1484.txt
+++ b/.changelog/1484.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+flarectl: alias zone certs to "ct" instead of duplicating the "c" alias
+```

--- a/cmd/flarectl/flarectl.go
+++ b/cmd/flarectl/flarectl.go
@@ -225,7 +225,7 @@ func main() {
 				},
 				{
 					Name:    "certs",
-					Aliases: []string{"c"},
+					Aliases: []string{"ct"},
 					Action:  zoneCerts,
 					Usage:   "Custom SSL certificates for a zone",
 				},


### PR DESCRIPTION
Fixes: #1465 

## Description
check and certs were both aliased to "c". Changed certs alias from "c" to "ct".

This would've been way more easier to debug if a log were introduced before os.Exit(1). I'd be happy to add it here but I'm unsure if not logging is the intended behavior.

https://github.com/cloudflare/cloudflare-go/blob/c3ac69e2e73752b34b57aeba74e6a3fbb9cbc600/cmd/flarectl/flarectl.go#L715-L718

Just checked v0.82.0 where the zone command worked and `zone c` use the create command instead of the certs command. It looks like the `c` alias was changed from `certs` to `create` since the create command was added (d0f7110d28f7c9f322c104b64a432923074216c5 )


## Has your change been tested?
Yes, `flarectl zone` now works

## Screenshots (if appropriate):
Not appropriate

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
