### PR TITLE
GATE-5397: Add support for extended email matching setting

### DIFF
--- a/.changelog/1486.txt
+++ b/.changelog/1486.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams_accounts: add support for extended email matching
+```

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -5,7 +5,7 @@ making changes the Go SDK.
 
 ## Methods
 
-- All methods should take a maxium of 3 parameter. See examples in [experimental](./experimental.md)
+- All methods should take a maximum of 3 parameter. See examples in [experimental](./experimental.md)
 - The first parameter is always `context.Context`.
 - The second is a `*ResourceContainer`.
 - The final is a struct of available parameters for the method. 

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -37,14 +37,15 @@ type TeamsConfiguration struct {
 }
 
 type TeamsAccountSettings struct {
-	Antivirus         *TeamsAntivirus         `json:"antivirus,omitempty"`
-	TLSDecrypt        *TeamsTLSDecrypt        `json:"tls_decrypt,omitempty"`
-	ActivityLog       *TeamsActivityLog       `json:"activity_log,omitempty"`
-	BlockPage         *TeamsBlockPage         `json:"block_page,omitempty"`
-	BrowserIsolation  *BrowserIsolation       `json:"browser_isolation,omitempty"`
-	FIPS              *TeamsFIPS              `json:"fips,omitempty"`
-	ProtocolDetection *TeamsProtocolDetection `json:"protocol_detection,omitempty"`
-	BodyScanning      *TeamsBodyScanning      `json:"body_scanning,omitempty"`
+	Antivirus             *TeamsAntivirus             `json:"antivirus,omitempty"`
+	TLSDecrypt            *TeamsTLSDecrypt            `json:"tls_decrypt,omitempty"`
+	ActivityLog           *TeamsActivityLog           `json:"activity_log,omitempty"`
+	BlockPage             *TeamsBlockPage             `json:"block_page,omitempty"`
+	BrowserIsolation      *BrowserIsolation           `json:"browser_isolation,omitempty"`
+	FIPS                  *TeamsFIPS                  `json:"fips,omitempty"`
+	ProtocolDetection     *TeamsProtocolDetection     `json:"protocol_detection,omitempty"`
+	BodyScanning          *TeamsBodyScanning          `json:"body_scanning,omitempty"`
+	ExtendedEmailMatching *TeamsExtendedEmailMatching `json:"extended_email_matching,omitempty"`
 }
 
 type BrowserIsolation struct {
@@ -95,6 +96,10 @@ const (
 
 type TeamsBodyScanning struct {
 	InspectionMode TeamsInspectionMode `json:"inspection_mode,omitempty"`
+}
+
+type TeamsExtendedEmailMatching struct {
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 type TeamsRuleType = string

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -85,6 +85,9 @@ func TestTeamsAccountConfiguration(t *testing.T) {
           				},
 					"body_scanning": {
 						"inspection_mode": "deep"
+					},
+					"extended_email_matching": {
+						"enabled": true
 					}
 				}
 			}
@@ -120,6 +123,9 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 				UrlBrowserIsolationEnabled: BoolPtr(true),
 				NonIdentityEnabled:         BoolPtr(true),
 			},
+			ExtendedEmailMatching: &TeamsExtendedEmailMatching{
+				Enabled: BoolPtr(true),
+			},
 		})
 	}
 }
@@ -148,6 +154,9 @@ func TestTeamsAccountUpdateConfiguration(t *testing.T) {
 					},
 					"protocol_detection": {
 						"enabled": true
+					},
+					"extended_email_matching": {
+						"enabled": true
 					}
 				}
 			}
@@ -160,6 +169,9 @@ func TestTeamsAccountUpdateConfiguration(t *testing.T) {
 		ActivityLog:       &TeamsActivityLog{Enabled: true},
 		TLSDecrypt:        &TeamsTLSDecrypt{Enabled: true},
 		ProtocolDetection: &TeamsProtocolDetection{Enabled: true},
+		ExtendedEmailMatching: &TeamsExtendedEmailMatching{
+			Enabled: BoolPtr(true),
+		},
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/configuration", handler)


### PR DESCRIPTION
## Description
This change introduces support for enabling/disabling extended e-mail matching

## Has your change been tested?
Tested manually and by adjusting unit tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
