### PR TITLE
ZRZ-1097 deprecate neoEvents array on Zaraz config tools

### DIFF
--- a/.changelog/1490.txt
+++ b/.changelog/1490.txt
@@ -1,0 +1,3 @@
+```release-note:note
+zaraz: replace deprecated neoEvents with Actions on Zaraz Config tools schema
+```

--- a/zaraz.go
+++ b/zaraz.go
@@ -44,7 +44,7 @@ type ZarazConfigSettings struct {
 	ContextEnricher     ZarazWorker `json:"contextEnricher,omitempty"`
 }
 
-// DEPRECATED - to be removed pending migration of existing configs.
+// Deprecated: To be removed pending migration of existing configs.
 type ZarazNeoEvent struct {
 	BlockingTriggers []string       `json:"blockingTriggers"`
 	FiringTriggers   []string       `json:"firingTriggers"`

--- a/zaraz.go
+++ b/zaraz.go
@@ -44,7 +44,15 @@ type ZarazConfigSettings struct {
 	ContextEnricher     ZarazWorker `json:"contextEnricher,omitempty"`
 }
 
+// DEPRECATED - to be removed pending migration of existing configs.
 type ZarazNeoEvent struct {
+	BlockingTriggers []string       `json:"blockingTriggers"`
+	FiringTriggers   []string       `json:"firingTriggers"`
+	Data             map[string]any `json:"data"`
+	ActionType       string         `json:"actionType,omitempty"`
+}
+
+type ZarazAction struct {
 	BlockingTriggers []string       `json:"blockingTriggers"`
 	FiringTriggers   []string       `json:"firingTriggers"`
 	Data             map[string]any `json:"data"`
@@ -60,18 +68,19 @@ const (
 )
 
 type ZarazTool struct {
-	BlockingTriggers []string        `json:"blockingTriggers"`
-	Enabled          *bool           `json:"enabled"`
-	DefaultFields    map[string]any  `json:"defaultFields"`
-	Name             string          `json:"name"`
-	NeoEvents        []ZarazNeoEvent `json:"neoEvents"`
-	Type             ZarazToolType   `json:"type"`
-	DefaultPurpose   string          `json:"defaultPurpose,omitempty"`
-	Library          string          `json:"library,omitempty"`
-	Component        string          `json:"component,omitempty"`
-	Permissions      []string        `json:"permissions,omitempty"`
-	Settings         map[string]any  `json:"settings,omitempty"`
-	Worker           ZarazWorker     `json:"worker,omitempty"`
+	BlockingTriggers []string               `json:"blockingTriggers"`
+	Enabled          *bool                  `json:"enabled"`
+	DefaultFields    map[string]any         `json:"defaultFields"`
+	Name             string                 `json:"name"`
+	NeoEvents        []ZarazNeoEvent        `json:"neoEvents"`
+	Actions          map[string]ZarazAction `json:"actions"`
+	Type             ZarazToolType          `json:"type"`
+	DefaultPurpose   string                 `json:"defaultPurpose,omitempty"`
+	Library          string                 `json:"library,omitempty"`
+	Component        string                 `json:"component,omitempty"`
+	Permissions      []string               `json:"permissions"`
+	Settings         map[string]any         `json:"settings"`
+	Worker           ZarazWorker            `json:"worker,omitempty"`
 }
 
 type ZarazTriggerSystem string

--- a/zaraz_test.go
+++ b/zaraz_test.go
@@ -30,8 +30,8 @@ var expectedConfig ZarazConfig = ZarazConfig{
 			Enabled:          &trueValue,
 			DefaultFields:    map[string]any{},
 			Name:             "Custom HTML",
-			NeoEvents: []ZarazNeoEvent{
-				{
+			Actions: map[string]ZarazAction{
+				"7ccae28d-5e00-4f0b-a491-519ecde998c8": {
 					ActionType:       "event",
 					BlockingTriggers: []string{},
 					Data: map[string]any{
@@ -179,19 +179,19 @@ func TestGetZarazConfig(t *testing.T) {
 					  "trigger": "pageload"
 					},
 					"name": "Custom HTML",
-					"neoEvents": [
-					  {
-						"actionType": "event",
-						"blockingTriggers": [],
-						"data": {
-						  "__zaraz_setting_name": "pageview1",
-						  "htmlCode": "<script>console.log('pageview')</script>"
-						},
-						"firingTriggers": [
-						  "Pageview"
-						]
+					"actions": {
+					  "7ccae28d-5e00-4f0b-a491-519ecde998c8": {
+							"actionType": "event",
+							"blockingTriggers": [],
+							"data": {
+								"__zaraz_setting_name": "pageview1",
+								"htmlCode": "<script>console.log('pageview')</script>"
+							},
+							"firingTriggers": [
+								"Pageview"
+							]
 					  }
-					],
+					},
 					"permissions": [
 					  "execute_unsafe_scripts"
 					],
@@ -340,19 +340,19 @@ func TestUpdateZarazConfig(t *testing.T) {
 					  "trigger": "pageload"
 					},
 					"name": "Custom HTML",
-					"neoEvents": [
-					  {
-						"actionType": "event",
-						"blockingTriggers": [],
-						"data": {
-						  "__zaraz_setting_name": "pageview1",
-						  "htmlCode": "<script>console.log('pageview')</script>"
-						},
-						"firingTriggers": [
-						  "Pageview"
-						]
+					"actions": {
+					  "7ccae28d-5e00-4f0b-a491-519ecde998c8": {
+							"actionType": "event",
+							"blockingTriggers": [],
+							"data": {
+								"__zaraz_setting_name": "pageview1",
+								"htmlCode": "<script>console.log('pageview')</script>"
+							},
+							"firingTriggers": [
+								"Pageview"
+							]
 					  }
-					],
+					},
 					"permissions": [
 					  "execute_unsafe_scripts"
 					],
@@ -435,8 +435,263 @@ func TestUpdateZarazConfig(t *testing.T) {
 				Enabled:          &trueValue,
 				DefaultFields:    map[string]any{},
 				Name:             "Custom HTML",
-				NeoEvents: []ZarazNeoEvent{
-					{
+				Actions: map[string]ZarazAction{
+					"7ccae28d-5e00-4f0b-a491-519ecde998c8": {
+						ActionType:       "event",
+						BlockingTriggers: []string{},
+						Data: map[string]any{
+							"__zaraz_setting_name": "pageview1",
+							"htmlCode":             "<script>console.log('pageview')</script>",
+						},
+						FiringTriggers: []string{"Pageview"},
+					},
+				},
+				Type:           ZarazToolComponent,
+				DefaultPurpose: "rJJC",
+				Component:      "html",
+				Permissions:    []string{"execute_unsafe_scripts"},
+				Settings:       map[string]any{},
+			},
+		},
+		Triggers: map[string]ZarazTrigger{
+			"Pageview": {
+				Name:         "Pageview",
+				Description:  "All page loads",
+				LoadRules:    []ZarazTriggerRule{{Match: "{{ client.__zarazTrack }}", Op: "EQUALS", Value: "Pageview"}},
+				ExcludeRules: []ZarazTriggerRule{},
+				ClientRules:  []any{},
+				System:       ZarazPageload,
+			},
+			"TFOl": {
+				Name:         "test",
+				Description:  "",
+				LoadRules:    []ZarazTriggerRule{{Id: "Kqsc", Match: "test", Op: "CONTAINS", Value: "test"}, {Id: "EDnV", Action: ZarazClickListener, Settings: ZarazRuleSettings{Selector: "test", Type: ZarazCSS}}},
+				ExcludeRules: []ZarazTriggerRule{},
+			},
+		},
+		Variables: map[string]ZarazVariable{
+			"jwIx": {
+				Name:  "test",
+				Type:  ZarazVarString,
+				Value: "sss",
+			},
+			"pAuL": {
+				Name: "test-worker-var",
+				Type: ZarazVarWorker,
+				Value: map[string]interface{}{
+					"escapedWorkerName": "worker-var-example",
+					"mutableId":         "m.zpt3q__WyW-61WM2qwgGoBl4Nxg-sfBsaMhu9NayjwU",
+					"workerTag":         "68aba570db9d4ec5b159624e2f7ad8bf",
+				},
+			},
+		},
+		Consent: ZarazConsent{
+			Enabled: &trueValue,
+			ButtonTextTranslations: ZarazButtonTextTranslations{
+				AcceptAll:        map[string]string{"en": "Accept ALL"},
+				ConfirmMyChoices: map[string]string{"en": "YES!"},
+				RejectAll:        map[string]string{"en": "Reject ALL"},
+			},
+			CompanyEmail:                          "email@example.com",
+			ConsentModalIntroHTMLWithTranslations: map[string]string{"en": "Lorem ipsum dolar set Amet?"},
+			CookieName:                            "zaraz-consent",
+			CustomCSS:                             ".test {\n    color: red;\n}",
+			CustomIntroDisclaimerDismissed:        &trueValue,
+			DefaultLanguage:                       "en",
+			HideModal:                             &falseValue,
+			PurposesWithTranslations: map[string]ZarazPurposeWithTranslations{
+				"rJJC": {
+					Description: map[string]string{"en": "Blah blah"},
+					Name:        map[string]string{"en": "Analytics"},
+					Order:       0,
+				},
+			},
+		},
+	}
+	payload.DebugKey = "butter" // Updating config
+	modifiedConfig := expectedConfig
+	modifiedConfig.DebugKey = "butter" // Updating config
+	expected := ZarazConfigResponse{
+		Result: modifiedConfig,
+	}
+
+	actual, err := client.UpdateZarazConfig(context.Background(), ZoneIdentifier(testZoneID), payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected.Result, actual.Result)
+}
+
+func TestUpdateDeprecatedZarazConfig(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"errors": [],
+			"messages": [],
+			"success": true,
+			"result": {
+				"consent": {
+				  "buttonTextTranslations": {
+					"accept_all": {
+					  "en": "Accept ALL"
+					},
+					"confirm_my_choices": {
+					  "en": "YES!"
+					},
+					"reject_all": {
+					  "en": "Reject ALL"
+					}
+				  },
+				  "companyEmail": "email@example.com",
+				  "consentModalIntroHTMLWithTranslations": {
+					"en": "Lorem ipsum dolar set Amet?"
+				  },
+				  "cookieName": "zaraz-consent",
+				  "customCSS": ".test {\n    color: red;\n}",
+				  "customIntroDisclaimerDismissed": true,
+				  "defaultLanguage": "en",
+				  "enabled": true,
+				  "hideModal": false,
+				  "purposesWithTranslations": {
+					"rJJC": {
+					  "description": {
+						"en": "Blah blah"
+					  },
+					  "name": {
+						"en": "Analytics"
+					  },
+					  "order": 0
+					}
+				  }
+				},
+				"dataLayer": true,
+				"debugKey": "butter",
+				"dlp": [],
+				"historyChange": true,
+				"invalidKey": "cheese",
+				"settings": {
+				  "autoInjectScript": true
+				},
+				"tools": {
+				  "PBQr": {
+					"blockingTriggers": [],
+					"component": "html",
+					"defaultFields": {},
+					"defaultPurpose": "rJJC",
+					"enabled": true,
+					"mode": {
+					  "cloud": false,
+					  "ignoreSPA": true,
+					  "light": false,
+					  "sample": false,
+					  "segment": {
+						"end": 100,
+						"start": 0
+					  },
+					  "trigger": "pageload"
+					},
+					"name": "Custom HTML",
+					"actions": {
+					  "7ccae28d-5e00-4f0b-a491-519ecde998c8": {
+							"actionType": "event",
+							"blockingTriggers": [],
+							"data": {
+								"__zaraz_setting_name": "pageview1",
+								"htmlCode": "<script>console.log('pageview')</script>"
+							},
+							"firingTriggers": [
+								"Pageview"
+							]
+					  }
+					},
+					"permissions": [
+					  "execute_unsafe_scripts"
+					],
+					"settings": {},
+					"type": "component"
+				  }
+				},
+				"triggers": {
+				  "Pageview": {
+					"clientRules": [],
+					"description": "All page loads",
+					"excludeRules": [],
+					"loadRules": [
+					  {
+						"match": "{{ client.__zarazTrack }}",
+						"op": "EQUALS",
+						"value": "Pageview"
+					  }
+					],
+					"name": "Pageview",
+					"system": "pageload"
+				  },
+				  "TFOl": {
+					"description": "",
+					"excludeRules": [],
+					"loadRules": [
+					  {
+						"id": "Kqsc",
+						"match": "test",
+						"op": "CONTAINS",
+						"value": "test"
+					  },
+					  {
+						"action": "clickListener",
+						"id": "EDnV",
+						"settings": {
+						  "selector": "test",
+						  "type": "css",
+						  "waitForTags": 0
+						}
+					  }
+					],
+					"name": "test"
+				  }
+				},
+				"variables": {
+				  "jwIx": {
+					"name": "test",
+					"type": "string",
+					"value": "sss"
+				  },
+				  "pAuL": {
+					"name": "test-worker-var",
+					"type": "worker",
+					"value": {
+					  "escapedWorkerName": "worker-var-example",
+					  "mutableId": "m.zpt3q__WyW-61WM2qwgGoBl4Nxg-sfBsaMhu9NayjwU",
+					  "workerTag": "68aba570db9d4ec5b159624e2f7ad8bf"
+					}
+				  }
+				},
+				"zarazVersion": 44
+			  }
+		}`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/settings/zaraz/v2/config", handler)
+	payload := UpdateZarazConfigParams{
+		DebugKey:      "cheese",
+		ZarazVersion:  44,
+		DataLayer:     &trueValue,
+		Dlp:           []any{},
+		HistoryChange: &trueValue,
+		Settings: ZarazConfigSettings{
+			AutoInjectScript: &trueValue,
+		},
+		Tools: map[string]ZarazTool{
+			"PBQr": {
+				BlockingTriggers: []string{},
+				Enabled:          &trueValue,
+				DefaultFields:    map[string]any{},
+				Name:             "Custom HTML",
+				Actions: map[string]ZarazAction{
+					"7ccae28d-5e00-4f0b-a491-519ecde998c8": {
 						ActionType:       "event",
 						BlockingTriggers: []string{},
 						Data: map[string]any{


### PR DESCRIPTION
Per new Zaraz api & docs, `neoEvents` array is being replaced with the more semantic `Actions` object on configured Zaraz tools.

All existing Zaraz configs will be automatically migrated to the new schema; similarly, any new config imports / updates containing deprecated neoEvents will be migrated before saving. I.e. old config schema in --> newer config schema out.

## Has your change been tested? ✅

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
