### PR TITLE
Add CRUD support for Images Variants

### DIFF
--- a/.changelog/1494.txt
+++ b/.changelog/1494.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+images_variants: Add support for Images Variants CRUD operations
+```

--- a/images_variants.go
+++ b/images_variants.go
@@ -54,24 +54,24 @@ type ImagesVariantResponse struct {
 // Lists existing variants.
 //
 // API Reference: https://developers.cloudflare.com/api/operations/cloudflare-images-variants-list-variants
-func (api *API) ListImagesVariants(ctx context.Context, rc *ResourceContainer, params ListImageVariantsParams) (map[string]ImagesVariant, error) {
+func (api *API) ListImagesVariants(ctx context.Context, rc *ResourceContainer, params ListImageVariantsParams) (ListImageVariantsResult, error) {
 	if rc.Identifier == "" {
-		return map[string]ImagesVariant{}, ErrMissingAccountID
+		return ListImageVariantsResult{}, ErrMissingAccountID
 	}
 
 	baseURL := fmt.Sprintf("/accounts/%s/images/v1/variants", rc.Identifier)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, baseURL, nil)
 	if err != nil {
-		return map[string]ImagesVariant{}, err
+		return ListImageVariantsResult{}, err
 	}
 
 	var listImageVariantsResponse ListImagesVariantsResponse
 	err = json.Unmarshal(res, &listImageVariantsResponse)
 	if err != nil {
-		return map[string]ImagesVariant{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return ListImageVariantsResult{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return listImageVariantsResponse.Result.ImagesVariants, nil
+	return listImageVariantsResponse.Result, nil
 }
 
 // Fetch details for a single variant.

--- a/images_variants.go
+++ b/images_variants.go
@@ -1,0 +1,161 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/goccy/go-json"
+)
+
+type ImagesVariant struct {
+	ID                     string                `json:"id,omitempty"`
+	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
+	Options                ImagesVariantsOptions `json:"options,omitempty"`
+}
+
+type ImagesVariantsOptions struct {
+	Fit      string `json:"fit,omitempty"`
+	Height   int    `json:"height,omitempty"`
+	Metadata string `json:"metadata,omitempty"`
+	Width    int    `json:"width,omitempty"`
+}
+
+type ListImageVariantsParams struct{}
+
+type ListImagesVariantsResponse struct {
+	Result ListImageVariantsResult `json:"result,omitempty"`
+	Response
+}
+
+type ListImageVariantsResult struct {
+	ImagesVariants map[string]ImagesVariant `json:"variants,omitempty"`
+}
+
+type CreateImagesVariantParams struct {
+	ImagesVariant
+}
+
+type UpdateImagesVariantParams struct {
+	ID                     string                `json:"-"`
+	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
+	Options                ImagesVariantsOptions `json:"options,omitempty"`
+}
+
+type ImagesVariantResult struct {
+	Variant ImagesVariant `json:"variant,omitempty"`
+}
+
+type ImagesVariantResponse struct {
+	Result ImagesVariantResult `json:"result,omitempty"`
+	Response
+}
+
+// Lists existing variants.
+//
+// API Reference: https://developers.cloudflare.com/api/operations/cloudflare-images-variants-list-variants
+func (api *API) ListImagesVariants(ctx context.Context, rc *ResourceContainer, params ListImageVariantsParams) (map[string]ImagesVariant, error) {
+	if rc.Identifier == "" {
+		return map[string]ImagesVariant{}, ErrMissingAccountID
+	}
+
+	baseURL := fmt.Sprintf("/accounts/%s/images/v1/variants", rc.Identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, baseURL, nil)
+	if err != nil {
+		return map[string]ImagesVariant{}, err
+	}
+
+	var listImageVariantsResponse ListImagesVariantsResponse
+	err = json.Unmarshal(res, &listImageVariantsResponse)
+	if err != nil {
+		return map[string]ImagesVariant{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return listImageVariantsResponse.Result.ImagesVariants, nil
+}
+
+// Fetch details for a single variant.
+//
+// API Reference: https://developers.cloudflare.com/api/operations/cloudflare-images-variants-variant-details
+func (api *API) GetImagesVariantDetails(ctx context.Context, rc *ResourceContainer, variantID string) (ImagesVariant, error) {
+	if rc.Identifier == "" {
+		return ImagesVariant{}, ErrMissingAccountID
+	}
+
+	baseURL := fmt.Sprintf("/accounts/%s/images/v1/variants/%s", rc.Identifier, variantID)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, baseURL, nil)
+	if err != nil {
+		return ImagesVariant{}, err
+	}
+
+	var imagesVariantDetailResponse ImagesVariantResponse
+	err = json.Unmarshal(res, &imagesVariantDetailResponse)
+	if err != nil {
+		return ImagesVariant{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return imagesVariantDetailResponse.Result.Variant, nil
+}
+
+// Specify variants that allow you to resize images for different use cases.
+//
+// API Reference: https://developers.cloudflare.com/api/operations/cloudflare-images-variants-create-a-variant
+func (api *API) CreateImagesVariant(ctx context.Context, rc *ResourceContainer, params CreateImagesVariantParams) (ImagesVariant, error) {
+	if rc.Identifier == "" {
+		return ImagesVariant{}, ErrMissingAccountID
+	}
+
+	baseURL := fmt.Sprintf("/accounts/%s/images/v1/variants", rc.Identifier)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, baseURL, params.ImagesVariant)
+	if err != nil {
+		return ImagesVariant{}, err
+	}
+
+	var createImagesVariantResponse ImagesVariantResponse
+	err = json.Unmarshal(res, &createImagesVariantResponse)
+	if err != nil {
+		return ImagesVariant{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return createImagesVariantResponse.Result.Variant, nil
+}
+
+// Deleting a variant purges the cache for all images associated with the variant.
+//
+// API Reference: https://developers.cloudflare.com/api/operations/cloudflare-images-variants-variant-details
+func (api *API) DeleteImagesVariant(ctx context.Context, rc *ResourceContainer, variantID string) error {
+	if rc.Identifier == "" {
+		return ErrMissingAccountID
+	}
+
+	baseURL := fmt.Sprintf("/accounts/%s/images/v1/variants/%s", rc.Identifier, variantID)
+	_, err := api.makeRequestContext(ctx, http.MethodDelete, baseURL, nil)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errMakeRequestError, err)
+	}
+
+	return nil
+}
+
+// Updating a variant purges the cache for all images associated with the variant.
+//
+// API Reference: https://developers.cloudflare.com/api/operations/cloudflare-images-variants-variant-details
+func (api *API) UpdateImagesVariant(ctx context.Context, rc *ResourceContainer, params UpdateImagesVariantParams) (ImagesVariant, error) {
+	if rc.Identifier == "" {
+		return ImagesVariant{}, ErrMissingAccountID
+	}
+
+	baseURL := fmt.Sprintf("/accounts/%s/images/v1/variants/%s", rc.Identifier, params.ID)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, baseURL, params)
+	if err != nil {
+		return ImagesVariant{}, err
+	}
+
+	var imagesVariantDetailResponse ImagesVariantResponse
+	err = json.Unmarshal(res, &imagesVariantDetailResponse)
+	if err != nil {
+		return ImagesVariant{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return imagesVariantDetailResponse.Result.Variant, nil
+}

--- a/images_variants.go
+++ b/images_variants.go
@@ -10,7 +10,7 @@ import (
 
 type ImagesVariant struct {
 	ID                     string                `json:"id,omitempty"`
-	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
+	NeverRequireSignedURLs *bool                 `json:"neverRequireSignedURLs,omitempty"`
 	Options                ImagesVariantsOptions `json:"options,omitempty"`
 }
 
@@ -38,7 +38,7 @@ type CreateImagesVariantParams struct {
 
 type UpdateImagesVariantParams struct {
 	ID                     string                `json:"-"`
-	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
+	NeverRequireSignedURLs *bool                 `json:"neverRequireSignedURLs,omitempty"`
 	Options                ImagesVariantsOptions `json:"options,omitempty"`
 }
 

--- a/images_variants.go
+++ b/images_variants.go
@@ -33,7 +33,9 @@ type ListImageVariantsResult struct {
 }
 
 type CreateImagesVariantParams struct {
-	ImagesVariant
+	ID                     string                `json:"id"`
+	NeverRequireSignedURLs *bool                 `json:"neverRequireSignedURLs,omitempty"`
+	Options                ImagesVariantsOptions `json:"options"`
 }
 
 type UpdateImagesVariantParams struct {
@@ -77,7 +79,7 @@ func (api *API) ListImagesVariants(ctx context.Context, rc *ResourceContainer, p
 // Fetch details for a single variant.
 //
 // API Reference: https://developers.cloudflare.com/api/operations/cloudflare-images-variants-variant-details
-func (api *API) GetImagesVariantDetails(ctx context.Context, rc *ResourceContainer, variantID string) (ImagesVariant, error) {
+func (api *API) GetImagesVariant(ctx context.Context, rc *ResourceContainer, variantID string) (ImagesVariant, error) {
 	if rc.Identifier == "" {
 		return ImagesVariant{}, ErrMissingAccountID
 	}
@@ -106,7 +108,7 @@ func (api *API) CreateImagesVariant(ctx context.Context, rc *ResourceContainer, 
 	}
 
 	baseURL := fmt.Sprintf("/accounts/%s/images/v1/variants", rc.Identifier)
-	res, err := api.makeRequestContext(ctx, http.MethodPost, baseURL, params.ImagesVariant)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, baseURL, params)
 	if err != nil {
 		return ImagesVariant{}, err
 	}

--- a/images_variants.go
+++ b/images_variants.go
@@ -33,9 +33,9 @@ type ListImageVariantsResult struct {
 }
 
 type CreateImagesVariantParams struct {
-	ID                     string                `json:"id"`
+	ID                     string                `json:"id,omitempty"`
 	NeverRequireSignedURLs *bool                 `json:"neverRequireSignedURLs,omitempty"`
-	Options                ImagesVariantsOptions `json:"options"`
+	Options                ImagesVariantsOptions `json:"options,omitempty"`
 }
 
 type UpdateImagesVariantParams struct {

--- a/images_variants.go
+++ b/images_variants.go
@@ -10,7 +10,7 @@ import (
 
 type ImagesVariant struct {
 	ID                     string                `json:"id,omitempty"`
-	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
+	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs"`
 	Options                ImagesVariantsOptions `json:"options,omitempty"`
 }
 
@@ -38,7 +38,7 @@ type CreateImagesVariantParams struct {
 
 type UpdateImagesVariantParams struct {
 	ID                     string                `json:"-"`
-	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
+	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs"`
 	Options                ImagesVariantsOptions `json:"options,omitempty"`
 }
 

--- a/images_variants.go
+++ b/images_variants.go
@@ -10,7 +10,7 @@ import (
 
 type ImagesVariant struct {
 	ID                     string                `json:"id,omitempty"`
-	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs"`
+	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
 	Options                ImagesVariantsOptions `json:"options,omitempty"`
 }
 
@@ -38,7 +38,7 @@ type CreateImagesVariantParams struct {
 
 type UpdateImagesVariantParams struct {
 	ID                     string                `json:"-"`
-	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs"`
+	NeverRequireSignedURLs bool                  `json:"neverRequireSignedURLs,omitempty"`
 	Options                ImagesVariantsOptions `json:"options,omitempty"`
 }
 

--- a/images_variants_test.go
+++ b/images_variants_test.go
@@ -25,15 +25,17 @@ func TestImageVariants_ListVariants(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1/variants", handler)
 
-	want := map[string]ImagesVariant{
-		"hero": {
-			ID:                     "hero",
-			NeverRequireSignedURLs: true,
-			Options: ImagesVariantsOptions{
-				Fit:      "scale-down",
-				Height:   768,
-				Width:    1366,
-				Metadata: "none",
+	want := ListImageVariantsResult{
+		ImagesVariants: map[string]ImagesVariant{
+			"hero": {
+				ID:                     "hero",
+				NeverRequireSignedURLs: true,
+				Options: ImagesVariantsOptions{
+					Fit:      "scale-down",
+					Height:   768,
+					Width:    1366,
+					Metadata: "none",
+				},
 			},
 		},
 	}
@@ -153,12 +155,34 @@ func TestImagesVariants_UpdateVariant(t *testing.T) {
 	}
 
 	got, err := client.UpdateImagesVariant(context.Background(), AccountIdentifier(testAccountID), UpdateImagesVariantParams{
-		ID:                     want.ID,
-		NeverRequireSignedURLs: want.NeverRequireSignedURLs,
-		Options:                want.Options,
+		ID:                     "hero",
+		NeverRequireSignedURLs: true,
+		Options: ImagesVariantsOptions{
+			Fit:      "scale-down",
+			Height:   768,
+			Width:    1366,
+			Metadata: "none",
+		},
 	})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, got)
 	}
+}
+
+func TestImageVariants_MissingAccountId(t *testing.T) {
+	_, err := client.ListImagesVariants(context.Background(), AccountIdentifier(""), ListImageVariantsParams{})
+	assert.Equal(t, ErrMissingAccountID, err)
+
+	_, err = client.GetImagesVariantDetails(context.Background(), AccountIdentifier(""), testImagesVariantID)
+	assert.Equal(t, ErrMissingAccountID, err)
+
+	_, err = client.CreateImagesVariant(context.Background(), AccountIdentifier(""), CreateImagesVariantParams{})
+	assert.Equal(t, ErrMissingAccountID, err)
+
+	err = client.DeleteImagesVariant(context.Background(), AccountIdentifier(""), testImagesVariantID)
+	assert.Equal(t, ErrMissingAccountID, err)
+
+	_, err = client.UpdateImagesVariant(context.Background(), AccountIdentifier(""), UpdateImagesVariantParams{})
+	assert.Equal(t, ErrMissingAccountID, err)
 }

--- a/images_variants_test.go
+++ b/images_variants_test.go
@@ -13,7 +13,7 @@ const (
 	testImagesVariantID = "hero"
 )
 
-func TestImageVariants_ListVariants(t *testing.T) {
+func TestImageVariants_List(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -98,7 +98,7 @@ func TestImagesVariants_Get(t *testing.T) {
 	}
 }
 
-func TestImagesVariants_CreateVariant(t *testing.T) {
+func TestImagesVariants_Create(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -137,7 +137,7 @@ func TestImagesVariants_CreateVariant(t *testing.T) {
 	}
 }
 
-func TestImagesVariants_UpdateVariant(t *testing.T) {
+func TestImagesVariants_Update(t *testing.T) {
 	setup()
 	defer teardown()
 

--- a/images_variants_test.go
+++ b/images_variants_test.go
@@ -1,0 +1,164 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testImagesVariantID = "hero"
+)
+
+func TestImageVariants_ListVariants(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, loadFixture("images_variants", "single_list"))
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/images/v1/variants", handler)
+
+	want := map[string]ImagesVariant{
+		"hero": {
+			ID:                     "hero",
+			NeverRequireSignedURLs: true,
+			Options: ImagesVariantsOptions{
+				Fit:      "scale-down",
+				Height:   768,
+				Width:    1366,
+				Metadata: "none",
+			},
+		},
+	}
+
+	got, err := client.ListImagesVariants(context.Background(), AccountIdentifier(testAccountID), ListImageVariantsParams{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestImageVariants_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method '%s', got %s", http.MethodDelete, r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {}
+		}`)
+	}
+
+	url := fmt.Sprintf("/accounts/%s/images/v1/variants/%s", testAccountID, testImagesVariantID)
+	mux.HandleFunc(url, handler)
+
+	err := client.DeleteImagesVariant(context.Background(), AccountIdentifier(testAccountID), testImagesVariantID)
+	assert.NoError(t, err)
+}
+
+func TestImagesVariants_GetDetails(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method '%s', got %s", http.MethodGet, r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, loadFixture("images_variants", "single_full"))
+	}
+
+	url := fmt.Sprintf("/accounts/%s/images/v1/variants/%s", testAccountID, testImagesVariantID)
+	mux.HandleFunc(url, handler)
+
+	want := ImagesVariant{
+		ID:                     "hero",
+		NeverRequireSignedURLs: true,
+		Options: ImagesVariantsOptions{
+			Fit:      "scale-down",
+			Height:   768,
+			Width:    1366,
+			Metadata: "none",
+		},
+	}
+
+	got, err := client.GetImagesVariantDetails(context.Background(), AccountIdentifier(testAccountID), testImagesVariantID)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestImagesVariants_CreateVariant(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method '%s', got %s", http.MethodPost, r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, loadFixture("images_variants", "single_full"))
+	}
+
+	url := fmt.Sprintf("/accounts/%s/images/v1/variants", testAccountID)
+	mux.HandleFunc(url, handler)
+
+	want := ImagesVariant{
+		ID:                     "hero",
+		NeverRequireSignedURLs: true,
+		Options: ImagesVariantsOptions{
+			Fit:      "scale-down",
+			Height:   768,
+			Width:    1366,
+			Metadata: "none",
+		},
+	}
+
+	got, err := client.CreateImagesVariant(context.Background(), AccountIdentifier(testAccountID), CreateImagesVariantParams{
+		ImagesVariant: want,
+	})
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestImagesVariants_UpdateVariant(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method, "Expected method '%s', got %s", http.MethodPatch, r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, loadFixture("images_variants", "single_full"))
+	}
+
+	url := fmt.Sprintf("/accounts/%s/images/v1/variants/%s", testAccountID, testImagesVariantID)
+	mux.HandleFunc(url, handler)
+
+	want := ImagesVariant{
+		ID:                     "hero",
+		NeverRequireSignedURLs: true,
+		Options: ImagesVariantsOptions{
+			Fit:      "scale-down",
+			Height:   768,
+			Width:    1366,
+			Metadata: "none",
+		},
+	}
+
+	got, err := client.UpdateImagesVariant(context.Background(), AccountIdentifier(testAccountID), UpdateImagesVariantParams{
+		ID:                     want.ID,
+		NeverRequireSignedURLs: want.NeverRequireSignedURLs,
+		Options:                want.Options,
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, got)
+	}
+}

--- a/images_variants_test.go
+++ b/images_variants_test.go
@@ -29,7 +29,7 @@ func TestImageVariants_ListVariants(t *testing.T) {
 		ImagesVariants: map[string]ImagesVariant{
 			"hero": {
 				ID:                     "hero",
-				NeverRequireSignedURLs: true,
+				NeverRequireSignedURLs: BoolPtr(true),
 				Options: ImagesVariantsOptions{
 					Fit:      "scale-down",
 					Height:   768,
@@ -83,7 +83,7 @@ func TestImagesVariants_GetDetails(t *testing.T) {
 
 	want := ImagesVariant{
 		ID:                     "hero",
-		NeverRequireSignedURLs: true,
+		NeverRequireSignedURLs: BoolPtr(true),
 		Options: ImagesVariantsOptions{
 			Fit:      "scale-down",
 			Height:   768,
@@ -113,7 +113,7 @@ func TestImagesVariants_CreateVariant(t *testing.T) {
 
 	want := ImagesVariant{
 		ID:                     "hero",
-		NeverRequireSignedURLs: true,
+		NeverRequireSignedURLs: BoolPtr(true),
 		Options: ImagesVariantsOptions{
 			Fit:      "scale-down",
 			Height:   768,
@@ -145,7 +145,7 @@ func TestImagesVariants_UpdateVariant(t *testing.T) {
 
 	want := ImagesVariant{
 		ID:                     "hero",
-		NeverRequireSignedURLs: true,
+		NeverRequireSignedURLs: BoolPtr(true),
 		Options: ImagesVariantsOptions{
 			Fit:      "scale-down",
 			Height:   768,
@@ -156,7 +156,7 @@ func TestImagesVariants_UpdateVariant(t *testing.T) {
 
 	got, err := client.UpdateImagesVariant(context.Background(), AccountIdentifier(testAccountID), UpdateImagesVariantParams{
 		ID:                     "hero",
-		NeverRequireSignedURLs: true,
+		NeverRequireSignedURLs: BoolPtr(true),
 		Options: ImagesVariantsOptions{
 			Fit:      "scale-down",
 			Height:   768,

--- a/images_variants_test.go
+++ b/images_variants_test.go
@@ -68,7 +68,7 @@ func TestImageVariants_Delete(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestImagesVariants_GetDetails(t *testing.T) {
+func TestImagesVariants_Get(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -92,7 +92,7 @@ func TestImagesVariants_GetDetails(t *testing.T) {
 		},
 	}
 
-	got, err := client.GetImagesVariantDetails(context.Background(), AccountIdentifier(testAccountID), testImagesVariantID)
+	got, err := client.GetImagesVariant(context.Background(), AccountIdentifier(testAccountID), testImagesVariantID)
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, got)
 	}
@@ -123,7 +123,14 @@ func TestImagesVariants_CreateVariant(t *testing.T) {
 	}
 
 	got, err := client.CreateImagesVariant(context.Background(), AccountIdentifier(testAccountID), CreateImagesVariantParams{
-		ImagesVariant: want,
+		ID:                     testImagesVariantID,
+		NeverRequireSignedURLs: BoolPtr(true),
+		Options: ImagesVariantsOptions{
+			Fit:      "scale-down",
+			Height:   768,
+			Width:    1366,
+			Metadata: "none",
+		},
 	})
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, got)
@@ -174,7 +181,7 @@ func TestImageVariants_MissingAccountId(t *testing.T) {
 	_, err := client.ListImagesVariants(context.Background(), AccountIdentifier(""), ListImageVariantsParams{})
 	assert.Equal(t, ErrMissingAccountID, err)
 
-	_, err = client.GetImagesVariantDetails(context.Background(), AccountIdentifier(""), testImagesVariantID)
+	_, err = client.GetImagesVariant(context.Background(), AccountIdentifier(""), testImagesVariantID)
 	assert.Equal(t, ErrMissingAccountID, err)
 
 	_, err = client.CreateImagesVariant(context.Background(), AccountIdentifier(""), CreateImagesVariantParams{})

--- a/testdata/fixtures/images_variants/single_full.json
+++ b/testdata/fixtures/images_variants/single_full.json
@@ -1,0 +1,17 @@
+{
+  "errors": [],
+  "messages": [],
+  "result": {
+    "variant": {
+      "id": "hero",
+      "neverRequireSignedURLs": true,
+      "options": {
+        "fit": "scale-down",
+        "height": 768,
+        "metadata": "none",
+        "width": 1366
+      }
+    }
+  },
+  "success": true
+}

--- a/testdata/fixtures/images_variants/single_list.json
+++ b/testdata/fixtures/images_variants/single_list.json
@@ -1,0 +1,19 @@
+{
+  "errors": [],
+  "messages": [],
+  "result": {
+    "variants": {
+      "hero": {
+        "id": "hero",
+        "neverRequireSignedURLs": true,
+        "options": {
+          "fit": "scale-down",
+          "height": 768,
+          "metadata": "none",
+          "width": 1366
+        }
+      }
+    }
+  },
+  "success": true
+}


### PR DESCRIPTION
## Description

Adds support for the [Images Variants](https://developers.cloudflare.com/api/operations/cloudflare-images-variants-list-variants) API.

Resolves #1495.

## Has your change been tested?

- Tested `ListImageVariantDetails` manually
- Tested `GetImageVariantDetails` manually
- Go Test

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
