### PR TITLE
feat: update teams antivirus settings to configure notification

### DIFF
--- a/.changelog/1499.txt
+++ b/.changelog/1499.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams_rules: `AntiVirus` settings includes notification settings
+```

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -54,9 +54,10 @@ type BrowserIsolation struct {
 }
 
 type TeamsAntivirus struct {
-	EnabledDownloadPhase bool `json:"enabled_download_phase"`
-	EnabledUploadPhase   bool `json:"enabled_upload_phase"`
-	FailClosed           bool `json:"fail_closed"`
+	EnabledDownloadPhase bool                       `json:"enabled_download_phase"`
+	EnabledUploadPhase   bool                       `json:"enabled_upload_phase"`
+	FailClosed           bool                       `json:"fail_closed"`
+	NotificationSettings *TeamsNotificationSettings `json:"notification_settings"`
 }
 
 type TeamsFIPS struct {

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -54,8 +54,13 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 			"result": {
 				"settings": {
 					"antivirus": {
-						"enabled_download_phase": true
-					},
+					"enabled_download_phase": true,
+						"notification_settings": {
+					  		"enabled":true,
+					   		"msg":"msg",
+					   		"support_url":"https://hi.com"
+						}
+				 	},
 					"tls_decrypt": {
 						"enabled": true
 					},
@@ -82,7 +87,7 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 					"browser_isolation": {
 						"url_browser_isolation_enabled": true,
 						"non_identity_enabled": true
-          				},
+					},
 					"body_scanning": {
 						"inspection_mode": "deep"
 					},
@@ -101,7 +106,14 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, actual.Settings, TeamsAccountSettings{
-			Antivirus:         &TeamsAntivirus{EnabledDownloadPhase: true},
+			Antivirus: &TeamsAntivirus{
+				EnabledDownloadPhase: true,
+				NotificationSettings: &TeamsNotificationSettings{
+					Enabled:    &trueValue,
+					Message:    "msg",
+					SupportURL: "https://hi.com",
+				},
+			},
 			ActivityLog:       &TeamsActivityLog{Enabled: true},
 			TLSDecrypt:        &TeamsTLSDecrypt{Enabled: true},
 			ProtocolDetection: &TeamsProtocolDetection{Enabled: true},


### PR DESCRIPTION
Adding a setting update on antivirus settings to include notification
DOC: https://developers.cloudflare.com/api/operations/zero-trust-accounts-patch-zero-trust-account-configuration



- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation. (Already added)
- [ x] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [x ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
