### PR TITLE
Hyperdrive: Password should be nested in Origin

### DIFF
--- a/.changelog/1501.txt
+++ b/.changelog/1501.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+hyperdrive: password should be nested in origin
+```

--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -10,8 +10,13 @@ import (
 )
 
 var (
-	ErrMissingHyperdriveConfigID       = errors.New("required hyperdrive config id is missing")
-	ErrMissingHyperdriveConfigName     = errors.New("required hyperdrive config name is missing")
+	ErrMissingHyperdriveConfigID             = errors.New("required hyperdrive config id is missing")
+	ErrMissingHyperdriveConfigName           = errors.New("required hyperdrive config name is missing")
+	ErrMissingHyperdriveConfigOriginDatabase = errors.New("required hyperdrive config origin database is missing")
+	ErrMissingHyperdriveConfigOriginPassword = errors.New("required hyperdrive config origin password is missing")
+	ErrMissingHyperdriveConfigOriginHost     = errors.New("required hyperdrive config origin host is missing")
+	ErrMissingHyperdriveConfigOriginScheme   = errors.New("required hyperdrive config origin scheme is missing")
+	ErrMissingHyperdriveConfigOriginUser     = errors.New("required hyperdrive config origin user is missing")
 )
 
 type HyperdriveConfig struct {
@@ -170,6 +175,26 @@ func (api *API) UpdateHyperdriveConfig(ctx context.Context, rc *ResourceContaine
 
 	if params.HyperdriveID == "" {
 		return HyperdriveConfig{}, ErrMissingHyperdriveConfigID
+	}
+
+	if params.Origin.Database == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginDatabase
+	}
+
+	if params.Origin.Password == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginPassword
+	}
+
+	if params.Origin.Host == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginHost
+	}
+
+	if params.Origin.Scheme == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginScheme
+	}
+
+	if params.Origin.User == "" {
+		return HyperdriveConfig{}, ErrMissingHyperdriveConfigOriginUser
 	}
 
 	uri := fmt.Sprintf("/accounts/%s/hyperdrive/configs/%s", rc.Identifier, params.HyperdriveID)

--- a/hyperdrive.go
+++ b/hyperdrive.go
@@ -12,7 +12,6 @@ import (
 var (
 	ErrMissingHyperdriveConfigID       = errors.New("required hyperdrive config id is missing")
 	ErrMissingHyperdriveConfigName     = errors.New("required hyperdrive config name is missing")
-	ErrMissingHyperdriveConfigPassword = errors.New("required hyperdrive config password is missing")
 )
 
 type HyperdriveConfig struct {
@@ -24,6 +23,7 @@ type HyperdriveConfig struct {
 
 type HyperdriveConfigOrigin struct {
 	Database string `json:"database,omitempty"`
+	Password string `json:"password"`
 	Host     string `json:"host,omitempty"`
 	Port     int    `json:"port,omitempty"`
 	Scheme   string `json:"scheme,omitempty"`
@@ -42,10 +42,9 @@ type HyperdriveConfigListResponse struct {
 }
 
 type CreateHyperdriveConfigParams struct {
-	Name     string                  `json:"name"`
-	Password string                  `json:"password"`
-	Origin   HyperdriveConfigOrigin  `json:"origin"`
-	Caching  HyperdriveConfigCaching `json:"caching,omitempty"`
+	Name    string                  `json:"name"`
+	Origin  HyperdriveConfigOrigin  `json:"origin"`
+	Caching HyperdriveConfigCaching `json:"caching,omitempty"`
 }
 
 type HyperdriveConfigResponse struct {
@@ -56,7 +55,6 @@ type HyperdriveConfigResponse struct {
 type UpdateHyperdriveConfigParams struct {
 	HyperdriveID string                  `json:"-"`
 	Name         string                  `json:"name"`
-	Password     string                  `json:"password"`
 	Origin       HyperdriveConfigOrigin  `json:"origin"`
 	Caching      HyperdriveConfigCaching `json:"caching,omitempty"`
 }
@@ -97,10 +95,6 @@ func (api *API) CreateHyperdriveConfig(ctx context.Context, rc *ResourceContaine
 
 	if params.Name == "" {
 		return HyperdriveConfig{}, ErrMissingHyperdriveConfigName
-	}
-
-	if params.Password == "" {
-		return HyperdriveConfig{}, ErrMissingHyperdriveConfigPassword
 	}
 
 	uri := fmt.Sprintf("/accounts/%s/hyperdrive/configs", rc.Identifier)

--- a/hyperdrive_test.go
+++ b/hyperdrive_test.go
@@ -164,16 +164,11 @@ func TestHyperdriveConfig_Create(t *testing.T) {
 		assert.Equal(t, ErrMissingHyperdriveConfigName, err)
 	}
 
-	_, err = client.CreateHyperdriveConfig(context.Background(), AccountIdentifier(testAccountID), CreateHyperdriveConfigParams{Name: "example-hyperdrive"})
-	if assert.Error(t, err) {
-		assert.Equal(t, ErrMissingHyperdriveConfigPassword, err)
-	}
-
 	result, err := client.CreateHyperdriveConfig(context.Background(), AccountIdentifier(testAccountID), CreateHyperdriveConfigParams{
-		Name:     "example-hyperdrive",
-		Password: "password",
+		Name: "example-hyperdrive",
 		Origin: HyperdriveConfigOrigin{
 			Database: "postgres",
+			Password: "password",
 			Host:     "database.example.com",
 			Port:     5432,
 			Scheme:   "postgres",
@@ -264,9 +259,9 @@ func TestHyperdriveConfig_Update(t *testing.T) {
 	result, err := client.UpdateHyperdriveConfig(context.Background(), AccountIdentifier(testAccountID), UpdateHyperdriveConfigParams{
 		HyperdriveID: "6b7efc370ea34ded8327fa20698dfe3a",
 		Name:         "example-hyperdrive",
-		Password:     "password",
 		Origin: HyperdriveConfigOrigin{
 			Database: "postgres",
+			Password: "password",
 			Host:     "database.example.com",
 			Port:     5432,
 			Scheme:   "postgres",


### PR DESCRIPTION
Update the Hyperdrive client to nest Password in Origin

## Description

[The docs for Hyperdrive](https://developers.cloudflare.com/api/operations/create-hyperdrive) are inconsistent with the API.

I asked in the discord and was pointed [here](https://github.com/cloudflare/workers-sdk/blob/d637bd59a8ea6612d59ed4b73e115287615e617d/packages/wrangler/src/hyperdrive/client.ts) as the best representation of this endpoint.


## Has your change been tested?

Automated tests updated to reflect correct types.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
