### PR TITLE
Add support for last_seen and state for crowdstrike_s2s posture rule

### DIFF
--- a/.changelog/1509.txt
+++ b/.changelog/1509.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+device_posture_rule: support last_seen and state for crowdstrike_s2s posture rule
+```

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -198,6 +198,8 @@ type DevicePostureRuleInput struct {
 	IsActive         bool     `json:"is_active,omitempty"`
 	EidLastSeen      string   `json:"eid_last_seen,omitempty"`
 	RiskLevel        string   `json:"risk_level,omitempty"`
+	State            string   `json:"state,omitempty"`
+	LastSeen         string   `json:"last_seen,omitempty"`
 }
 
 // DevicePostureRuleListResponse represents the response from the list


### PR DESCRIPTION
## Description

As part of code red item, `last_seen` and `state` have been added to the crowdstrike_s2s posture rule and needs to be supported within terraform.

## Has your change been tested?
Because it is just adding fields to the DevicePostureRuleInput struct, this should not affect existing uses of it. 

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
