### PR TITLE
DLP-1479: made DLP ContextAwareness a pointer

### DIFF
--- a/.changelog/1510.txt
+++ b/.changelog/1510.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dlp: added optional ContextAwareness support
+```

--- a/dlp_profile.go
+++ b/dlp_profile.go
@@ -50,12 +50,14 @@ type DLPContextAwareness struct {
 // DLPProfile represents a DLP Profile, which contains a set
 // of entries.
 type DLPProfile struct {
-	ID                string              `json:"id,omitempty"`
-	Name              string              `json:"name,omitempty"`
-	Type              string              `json:"type,omitempty"`
-	Description       string              `json:"description,omitempty"`
-	AllowedMatchCount int                 `json:"allowed_match_count"`
-	ContextAwareness  DLPContextAwareness `json:"context_awareness,omitempty"`
+	ID                string `json:"id,omitempty"`
+	Name              string `json:"name,omitempty"`
+	Type              string `json:"type,omitempty"`
+	Description       string `json:"description,omitempty"`
+	AllowedMatchCount int    `json:"allowed_match_count"`
+
+	// Optional and can be omitted with a nil pointer
+	ContextAwareness *DLPContextAwareness `json:"context_awareness,omitempty"`
 
 	// The following fields are omitted for predefined DLP
 	// profiles.

--- a/dlp_profile.go
+++ b/dlp_profile.go
@@ -56,7 +56,6 @@ type DLPProfile struct {
 	Description       string `json:"description,omitempty"`
 	AllowedMatchCount int    `json:"allowed_match_count"`
 
-	// Optional and can be omitted with a nil pointer
 	ContextAwareness *DLPContextAwareness `json:"context_awareness,omitempty"`
 
 	// The following fields are omitted for predefined DLP

--- a/dlp_profile_test.go
+++ b/dlp_profile_test.go
@@ -75,13 +75,7 @@ func TestDLPProfiles(t *testing.T) {
 					"updated_at": "2022-10-18T08:00:57Z",
 					"type": "custom",
 					"description": "just a custom profile example",
-					"allowed_match_count": 1,
-					"context_awareness": {
-						"enabled": false,
-						"skip": {
-							"files": false
-						}
-					}
+					"allowed_match_count": 1
 				}
 			]
 		}
@@ -98,7 +92,7 @@ func TestDLPProfiles(t *testing.T) {
 			Type:              "predefined",
 			Description:       "",
 			AllowedMatchCount: 0,
-			ContextAwareness: DLPContextAwareness{
+			ContextAwareness: &DLPContextAwareness{
 				Enabled: BoolPtr(true),
 				Skip: DLPContextAwarenessSkip{
 					Files: BoolPtr(true),
@@ -126,12 +120,7 @@ func TestDLPProfiles(t *testing.T) {
 			Type:              "custom",
 			Description:       "just a custom profile example",
 			AllowedMatchCount: 1,
-			ContextAwareness: DLPContextAwareness{
-				Enabled: BoolPtr(false),
-				Skip: DLPContextAwarenessSkip{
-					Files: BoolPtr(false),
-				},
-			},
+			// Omit ContextAwareness to test ContextAwareness optionality
 			Entries: []DLPEntry{
 				{
 					ID:        "ef79b054-12d4-4067-bb30-b85f6267b91c",
@@ -211,7 +200,7 @@ func TestGetDLPProfile(t *testing.T) {
 		Type:              "custom",
 		Description:       "just a custom profile example",
 		AllowedMatchCount: 42,
-		ContextAwareness: DLPContextAwareness{
+		ContextAwareness: &DLPContextAwareness{
 			Enabled: BoolPtr(false),
 			Skip: DLPContextAwarenessSkip{
 				Files: BoolPtr(false),
@@ -586,7 +575,7 @@ func TestUpdateDLPPredefinedProfile(t *testing.T) {
 		Type:              "predefined",
 		Description:       "example predefined profile",
 		AllowedMatchCount: 0,
-		ContextAwareness: DLPContextAwareness{
+		ContextAwareness: &DLPContextAwareness{
 			Enabled: BoolPtr(true),
 			Skip: DLPContextAwarenessSkip{
 				Files: BoolPtr(true),


### PR DESCRIPTION
<!-- 
Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points. 
-->

## Description

This is to allow for easier optionality checks with == nil

The parent context_awareness property is optional, if it is defined then all of the children are required.

https://developers.cloudflare.com/api/operations/dlp-profiles-update-predefined-profile

<!--
Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].
-->
## Has your change been tested?

Yes. Changed unit test to account for ContextAwareness being optional.

<!--
Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.
-->

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
