### PR TITLE
AUTH-5959 add support for access mutual tls hostname settings

### DIFF
--- a/.changelog/1516.txt
+++ b/.changelog/1516.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access_mutual_tls_certificates: add support for mutual tls hostname settings
+```

--- a/access_mutual_tls_certificates.go
+++ b/access_mutual_tls_certificates.go
@@ -58,6 +58,21 @@ type UpdateAccessMutualTLSCertificateParams struct {
 	AssociatedHostnames []string  `json:"associated_hostnames,omitempty"`
 }
 
+type AccessMutualTLSHostnameSettings struct {
+	ChinaNetwork                *bool  `json:"china_network,omitempty"`
+	ClientCertificateForwarding *bool  `json:"client_certificate_forwarding,omitempty"`
+	Hostname                    string `json:"hostname,omitempty"`
+}
+
+type ListAccessMutualTLSHostnameSettingsResponse struct {
+	Response
+	Result []AccessMutualTLSHostnameSettings `json:"result"`
+}
+
+type UpdateAccessMutualTLSHostnameSettingsParams struct {
+	Settings []AccessMutualTLSHostnameSettings `json:"settings,omitempty"`
+}
+
 // ListAccessMutualTLSCertificates returns all Access TLS certificates
 //
 // Account API Reference: https://developers.cloudflare.com/api/operations/access-mtls-authentication-list-mtls-certificates
@@ -211,4 +226,54 @@ func (api *API) DeleteAccessMutualTLSCertificate(ctx context.Context, rc *Resour
 	}
 
 	return nil
+}
+
+// ListAccessMutualTLSHostnameSettings returns all Access mTLS hostname settings.
+//
+// Account API Reference: https://developers.cloudflare.com/api/operations/access-mtls-authentication-update-an-mtls-certificate-settings
+// Zone API Reference: https://developers.cloudflare.com/api/operations/zone-level-access-mtls-authentication-list-mtls-certificates-hostname-settings
+func (api *API) ListAccessMutualTLSHostnameSettings(ctx context.Context, rc *ResourceContainer) ([]AccessMutualTLSHostnameSettings, error) {
+	uri := fmt.Sprintf(
+		"/%s/%s/access/certificates/settings",
+		rc.Level,
+		rc.Identifier,
+	)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errMakeRequestError, err)
+	}
+
+	var accessMutualTLSHostnameSettingsResponse ListAccessMutualTLSHostnameSettingsResponse
+	err = json.Unmarshal(res, &accessMutualTLSHostnameSettingsResponse)
+	if err != nil {
+		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return accessMutualTLSHostnameSettingsResponse.Result, nil
+}
+
+// UpdateAccessMutualTLSHostnameSettings updates Access mTLS certificate hostname settings.
+//
+// Account API Reference: https://developers.cloudflare.com/api/operations/access-mtls-authentication-update-an-mtls-certificate-settings
+// Zone API Reference: https://developers.cloudflare.com/api/operations/zone-level-access-mtls-authentication-update-an-mtls-certificate-settings
+func (api *API) UpdateAccessMutualTLSHostnameSettings(ctx context.Context, rc *ResourceContainer, params UpdateAccessMutualTLSHostnameSettingsParams) ([]AccessMutualTLSHostnameSettings, error) {
+	uri := fmt.Sprintf(
+		"/%s/%s/access/certificates/settings",
+		rc.Level,
+		rc.Identifier,
+	)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
+	if err != nil {
+		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errMakeRequestError, err)
+	}
+
+	var accessMutualTLSHostnameSettingsResponse ListAccessMutualTLSHostnameSettingsResponse
+	err = json.Unmarshal(res, &accessMutualTLSHostnameSettingsResponse)
+	if err != nil {
+		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return accessMutualTLSHostnameSettingsResponse.Result, nil
 }

--- a/access_mutual_tls_certificates.go
+++ b/access_mutual_tls_certificates.go
@@ -64,7 +64,7 @@ type AccessMutualTLSHostnameSettings struct {
 	Hostname                    string `json:"hostname,omitempty"`
 }
 
-type ListAccessMutualTLSHostnameSettingsResponse struct {
+type GetAccessMutualTLSHostnameSettingsResponse struct {
 	Response
 	Result []AccessMutualTLSHostnameSettings `json:"result"`
 }
@@ -228,11 +228,11 @@ func (api *API) DeleteAccessMutualTLSCertificate(ctx context.Context, rc *Resour
 	return nil
 }
 
-// ListAccessMutualTLSHostnameSettings returns all Access mTLS hostname settings.
+// GetAccessMutualTLSHostnameSettings returns all Access mTLS hostname settings.
 //
 // Account API Reference: https://developers.cloudflare.com/api/operations/access-mtls-authentication-update-an-mtls-certificate-settings
 // Zone API Reference: https://developers.cloudflare.com/api/operations/zone-level-access-mtls-authentication-list-mtls-certificates-hostname-settings
-func (api *API) ListAccessMutualTLSHostnameSettings(ctx context.Context, rc *ResourceContainer) ([]AccessMutualTLSHostnameSettings, error) {
+func (api *API) GetAccessMutualTLSHostnameSettings(ctx context.Context, rc *ResourceContainer) ([]AccessMutualTLSHostnameSettings, error) {
 	uri := fmt.Sprintf(
 		"/%s/%s/access/certificates/settings",
 		rc.Level,
@@ -244,7 +244,7 @@ func (api *API) ListAccessMutualTLSHostnameSettings(ctx context.Context, rc *Res
 		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errMakeRequestError, err)
 	}
 
-	var accessMutualTLSHostnameSettingsResponse ListAccessMutualTLSHostnameSettingsResponse
+	var accessMutualTLSHostnameSettingsResponse GetAccessMutualTLSHostnameSettingsResponse
 	err = json.Unmarshal(res, &accessMutualTLSHostnameSettingsResponse)
 	if err != nil {
 		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
@@ -269,7 +269,7 @@ func (api *API) UpdateAccessMutualTLSHostnameSettings(ctx context.Context, rc *R
 		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errMakeRequestError, err)
 	}
 
-	var accessMutualTLSHostnameSettingsResponse ListAccessMutualTLSHostnameSettingsResponse
+	var accessMutualTLSHostnameSettingsResponse GetAccessMutualTLSHostnameSettingsResponse
 	err = json.Unmarshal(res, &accessMutualTLSHostnameSettingsResponse)
 	if err != nil {
 		return []AccessMutualTLSHostnameSettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)

--- a/access_mutual_tls_certificates_test.go
+++ b/access_mutual_tls_certificates_test.go
@@ -277,7 +277,7 @@ func TestDeleteAccessMutualTLSCertificate(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestListAccessMutualTLSHostnameSettings(t *testing.T) {
+func TestGetAccessMutualTLSHostnameSettings(t *testing.T) {
 	setup()
 	defer teardown()
 
@@ -318,7 +318,7 @@ func TestListAccessMutualTLSHostnameSettings(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/certificates/settings", handler)
 
-	actual, err := client.ListAccessMutualTLSHostnameSettings(context.Background(), testAccountRC)
+	actual, err := client.GetAccessMutualTLSHostnameSettings(context.Background(), testAccountRC)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)
@@ -326,7 +326,7 @@ func TestListAccessMutualTLSHostnameSettings(t *testing.T) {
 
 	mux.HandleFunc("/zones/"+testZoneID+"/access/certificates/settings", handler)
 
-	actual, err = client.ListAccessMutualTLSHostnameSettings(context.Background(), testZoneRC)
+	actual, err = client.GetAccessMutualTLSHostnameSettings(context.Background(), testZoneRC)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/access_mutual_tls_certificates_test.go
+++ b/access_mutual_tls_certificates_test.go
@@ -276,3 +276,130 @@ func TestDeleteAccessMutualTLSCertificate(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+func TestListAccessMutualTLSHostnameSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"china_network": false,
+					"client_certificate_forwarding": true,
+					"hostname": "admin.example.com"
+				},
+				{
+					"china_network": true,
+					"client_certificate_forwarding": false,
+					"hostname": "foobar.example.com"
+				}
+			]
+		}`)
+	}
+
+	want := []AccessMutualTLSHostnameSettings{
+		{
+			ChinaNetwork:                BoolPtr(false),
+			ClientCertificateForwarding: BoolPtr(true),
+			Hostname:                    "admin.example.com",
+		},
+		{
+			ChinaNetwork:                BoolPtr(true),
+			ClientCertificateForwarding: BoolPtr(false),
+			Hostname:                    "foobar.example.com",
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/certificates/settings", handler)
+
+	actual, err := client.ListAccessMutualTLSHostnameSettings(context.Background(), testAccountRC)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/certificates/settings", handler)
+
+	actual, err = client.ListAccessMutualTLSHostnameSettings(context.Background(), testZoneRC)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestUpdateAccessMutualTLSHostnameSettings(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"china_network": false,
+					"client_certificate_forwarding": true,
+					"hostname": "admin.example.com"
+				},
+				{
+					"china_network": true,
+					"client_certificate_forwarding": false,
+					"hostname": "foobar.example.com"
+				}
+			]
+		}`)
+	}
+
+	certificateSettings := UpdateAccessMutualTLSHostnameSettingsParams{
+		Settings: []AccessMutualTLSHostnameSettings{
+			{
+				ChinaNetwork:                BoolPtr(false),
+				ClientCertificateForwarding: BoolPtr(true),
+				Hostname:                    "admin.example.com",
+			},
+			{
+				ChinaNetwork:                BoolPtr(true),
+				ClientCertificateForwarding: BoolPtr(false),
+				Hostname:                    "foobar.example.com",
+			},
+		},
+	}
+
+	want := []AccessMutualTLSHostnameSettings{
+		{
+			ChinaNetwork:                BoolPtr(false),
+			ClientCertificateForwarding: BoolPtr(true),
+			Hostname:                    "admin.example.com",
+		},
+		{
+			ChinaNetwork:                BoolPtr(true),
+			ClientCertificateForwarding: BoolPtr(false),
+			Hostname:                    "foobar.example.com",
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/certificates/settings", handler)
+
+	actual, err := client.UpdateAccessMutualTLSHostnameSettings(context.Background(), testAccountRC, certificateSettings)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/certificates/settings", handler)
+
+	actual, err = client.UpdateAccessMutualTLSHostnameSettings(context.Background(), testZoneRC, certificateSettings)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
## Description

Add support for list and update of access mTLS hostname settings
docs: https://developers.cloudflare.com/api/operations/access-mtls-authentication-update-an-mtls-certificate-settings

## Has your change been tested?

unit tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.
