### PR TITLE
Add support for replay_protection for Magic transit IPsec tunnels

### DIFF
--- a/.changelog/1710.txt
+++ b/.changelog/1710.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-cloudflare_ipsec_tunnel: Adds support for replay_protection boolean flag
+magic_transit_ipsec_tunnel: Adds support for replay_protection boolean flag
 ```

--- a/.changelog/1710.txt
+++ b/.changelog/1710.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+cloudflare_ipsec_tunnel: Adds support for replay_protection boolean flag
+```

--- a/magic_transit_ipsec_tunnel.go
+++ b/magic_transit_ipsec_tunnel.go
@@ -42,7 +42,7 @@ type MagicTransitIPsecTunnel struct {
 	PskMetadata        *MagicTransitIPsecTunnelPskMetadata `json:"psk_metadata,omitempty"`
 	RemoteIdentities   *RemoteIdentities                   `json:"remote_identities,omitempty"`
 	AllowNullCipher    bool                                `json:"allow_null_cipher"`
-	ReplayProtection   bool                                `json:"replay_protection"`
+	ReplayProtection   *bool                               `json:"replay_protection,omitempty"`
 }
 
 // ListMagicTransitIPsecTunnelsResponse contains a response including IPsec tunnels.

--- a/magic_transit_ipsec_tunnel.go
+++ b/magic_transit_ipsec_tunnel.go
@@ -42,6 +42,7 @@ type MagicTransitIPsecTunnel struct {
 	PskMetadata        *MagicTransitIPsecTunnelPskMetadata `json:"psk_metadata,omitempty"`
 	RemoteIdentities   *RemoteIdentities                   `json:"remote_identities,omitempty"`
 	AllowNullCipher    bool                                `json:"allow_null_cipher"`
+	ReplayProtection   bool                                `json:"replay_protection"`
 }
 
 // ListMagicTransitIPsecTunnelsResponse contains a response including IPsec tunnels.

--- a/magic_transit_ipsec_tunnel_test.go
+++ b/magic_transit_ipsec_tunnel_test.go
@@ -31,7 +31,8 @@ func TestListMagicTransitIPsecTunnels(t *testing.T) {
             "customer_endpoint": "203.0.113.1",
             "cloudflare_endpoint": "203.0.113.2",
             "interface_address": "192.0.2.0/31",
-            "description": "Tunnel for ISP X"
+            "description": "Tunnel for ISP X",
+			"replay_protection": true
           }
         ]
       }
@@ -53,6 +54,7 @@ func TestListMagicTransitIPsecTunnels(t *testing.T) {
 			CloudflareEndpoint: "203.0.113.2",
 			InterfaceAddress:   "192.0.2.0/31",
 			Description:        "Tunnel for ISP X",
+			ReplayProtection:   true,
 		},
 	}
 
@@ -83,7 +85,8 @@ func TestGetMagicTransitIPsecTunnel(t *testing.T) {
           "cloudflare_endpoint": "203.0.113.2",
           "interface_address": "192.0.2.0/31",
           "description": "Tunnel for ISP X",
-          "allow_null_cipher": true
+          "allow_null_cipher": true,
+		  "replay_protection": true
         }
       }
     }`)
@@ -104,6 +107,7 @@ func TestGetMagicTransitIPsecTunnel(t *testing.T) {
 		InterfaceAddress:   "192.0.2.0/31",
 		Description:        "Tunnel for ISP X",
 		AllowNullCipher:    true,
+		ReplayProtection:   true,
 	}
 
 	actual, err := client.GetMagicTransitIPsecTunnel(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821")
@@ -216,6 +220,58 @@ func TestCreateMagicTransitIPsecTunnelsWithHealthcheck(t *testing.T) {
 			Rate:      "mid",
 			Direction: "bidirectional",
 		},
+	}}
+
+	actual, err := client.CreateMagicTransitIPsecTunnels(context.Background(), testAccountID, want)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestCreateMagicTransitIPsecTunnelsWithReplayProtection(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "success": true,
+      "errors": [],
+      "messages": [],
+      "result": {
+        "ipsec_tunnels": [
+          {
+            "id": "c4a7362d577a6c3019a474fd6f485821",
+            "created_on": "2017-06-14T00:00:00Z",
+            "modified_on": "2017-06-14T05:20:00Z",
+            "name": "IPsec_1",
+            "customer_endpoint": "203.0.113.1",
+            "cloudflare_endpoint": "203.0.113.2",
+            "interface_address": "192.0.2.0/31",
+            "description": "Tunnel for ISP X",
+			"replay_protection": true
+          }
+        ]
+      }
+    }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/magic/ipsec_tunnels", handler)
+
+	createdOn, _ := time.Parse(time.RFC3339, "2017-06-14T00:00:00Z")
+	modifiedOn, _ := time.Parse(time.RFC3339, "2017-06-14T05:20:00Z")
+
+	want := []MagicTransitIPsecTunnel{{
+		ID:                 "c4a7362d577a6c3019a474fd6f485821",
+		CreatedOn:          &createdOn,
+		ModifiedOn:         &modifiedOn,
+		Name:               "IPsec_1",
+		CustomerEndpoint:   "203.0.113.1",
+		CloudflareEndpoint: "203.0.113.2",
+		InterfaceAddress:   "192.0.2.0/31",
+		Description:        "Tunnel for ISP X",
+		ReplayProtection:   true,
 	}}
 
 	actual, err := client.CreateMagicTransitIPsecTunnels(context.Background(), testAccountID, want)

--- a/magic_transit_ipsec_tunnel_test.go
+++ b/magic_transit_ipsec_tunnel_test.go
@@ -54,7 +54,7 @@ func TestListMagicTransitIPsecTunnels(t *testing.T) {
 			CloudflareEndpoint: "203.0.113.2",
 			InterfaceAddress:   "192.0.2.0/31",
 			Description:        "Tunnel for ISP X",
-			ReplayProtection:   true,
+			ReplayProtection:   BoolPtr(true),
 		},
 	}
 
@@ -107,7 +107,7 @@ func TestGetMagicTransitIPsecTunnel(t *testing.T) {
 		InterfaceAddress:   "192.0.2.0/31",
 		Description:        "Tunnel for ISP X",
 		AllowNullCipher:    true,
-		ReplayProtection:   true,
+		ReplayProtection:   BoolPtr(true),
 	}
 
 	actual, err := client.GetMagicTransitIPsecTunnel(context.Background(), testAccountID, "c4a7362d577a6c3019a474fd6f485821")
@@ -271,7 +271,7 @@ func TestCreateMagicTransitIPsecTunnelsWithReplayProtection(t *testing.T) {
 		CloudflareEndpoint: "203.0.113.2",
 		InterfaceAddress:   "192.0.2.0/31",
 		Description:        "Tunnel for ISP X",
-		ReplayProtection:   true,
+		ReplayProtection:   BoolPtr(true),
 	}}
 
 	actual, err := client.CreateMagicTransitIPsecTunnels(context.Background(), testAccountID, want)


### PR DESCRIPTION
<!-- 
Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points. 
-->

## Description
This change modifies the struct used to marshal/unmarshal the Magic Transit IPsec tunnel API. This is simply to have parity with the Cloudflare API and to allow the terraform provider to be updated to support this attribute.

<!--
Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].
-->
## Has your change been tested?
Yes. I've updated the existing "List" and "Get" tests as well as added a dedicated test for this parameter. I've also tested this against my environment and confirmed it works against the production api.

<!--
Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.
-->

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
