### PR TITLE
UpdateLogpushJobParams: Make it possible to remove logpull_options on update

### DIFF
--- a/.changelog/1711.txt
+++ b/.changelog/1711.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+UpdateLogpushJobParams: Make it possible to remove logpull_options on update
+```

--- a/logpush.go
+++ b/logpush.go
@@ -371,7 +371,7 @@ type UpdateLogpushJobParams struct {
 	Enabled                  bool                  `json:"enabled"`
 	Kind                     string                `json:"kind,omitempty"`
 	Name                     string                `json:"name"`
-	LogpullOptions           string                `json:"logpull_options,omitempty"`
+	LogpullOptions           string                `json:"logpull_options"`
 	OutputOptions            *LogpushOutputOptions `json:"output_options,omitempty"`
 	DestinationConf          string                `json:"destination_conf"`
 	OwnershipChallenge       string                `json:"ownership_challenge,omitempty"`


### PR DESCRIPTION
## Description
For reference: #1709
Make it possible to remove the `logpull_options` on update. I think this is still an issue with the Cloudflare API: I would expect a `PUT` to overwrite the existing resource, not only change the specified values.

**Before:**
`PUT` request (`TF_LOG=trace` output):
```
PUT /client/v4/zones/[redacted]/logpush/jobs/[redacted] HTTP/1.1
Host: api.cloudflare.com
User-Agent: terraform-provider-cloudflare/dev terraform-plugin-sdk/2.32.0 terraform/1.7.5
Content-Type: application/json
Body: {"dataset":"http_requests","enabled":false,"name":"example","output_options":{"field_names":[],"output_type":"ndjson","record_prefix":"{","record_suffix":"}","field_delimiter":",","timestamp_format":"unixnano","sample_rate":1,"CVE-2021-44228":false},"destination_conf":"[redacted]","frequency":"high"}
```

**With this change:**
`PUT` request (`TF_LOG=trace` output):
```
PUT /client/v4/zones/[redacted]/logpush/jobs/[redacted] HTTP/1.1
Host: api.cloudflare.com
User-Agent: terraform-provider-cloudflare/dev terraform-plugin-sdk/2.32.0 terraform/1.7.5
Body: {"dataset":"http_requests","enabled":false,"name":"example","logpull_options":"","output_options":{"field_names":[],"output_type":"ndjson","record_prefix":"{","record_suffix":"}","field_delimiter":",","timestamp_format":"unixnano","sample_rate":1,"CVE-2021-44228":false},"destination_conf":"[redacted]","frequency":"high"}
```

**Output of the second terraform plan**
```
No changes. Your infrastructure matches the configuration.
```

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
