### PR TITLE
Support deleting namespaced Workers in DeleteWorker

### DIFF
--- a/.changelog/1737.txt
+++ b/.changelog/1737.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+workers: support deleting namespaced Workers
+```

--- a/workers.go
+++ b/workers.go
@@ -216,6 +216,9 @@ type ListWorkersParams struct{}
 
 type DeleteWorkerParams struct {
 	ScriptName string
+
+	// DispatchNamespaceName is the dispatch namespace the Worker is uploaded to.
+	DispatchNamespace *string
 }
 
 type PlacementMode string
@@ -242,6 +245,10 @@ func (api *API) DeleteWorker(ctx context.Context, rc *ResourceContainer, params 
 	}
 
 	uri := fmt.Sprintf("/accounts/%s/workers/scripts/%s", rc.Identifier, params.ScriptName)
+	if params.DispatchNamespace != nil && *params.DispatchNamespace != "" {
+		uri = fmt.Sprintf("/accounts/%s/workers/dispatch/namespaces/%s/scripts/%s", rc.Identifier, *params.DispatchNamespace, params.ScriptName)
+	}
+
 	res, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
 
 	var r WorkerScriptResponse

--- a/workers_test.go
+++ b/workers_test.go
@@ -459,6 +459,23 @@ func TestDeleteWorker(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDeleteNamespacedWorker(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/workers/dispatch/namespaces/foo/scripts/bar", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/javascript")
+		fmt.Fprint(w, deleteWorkerResponseData)
+	})
+
+	err := client.DeleteWorker(context.Background(), AccountIdentifier(testAccountID), DeleteWorkerParams{
+		ScriptName:        "bar",
+		DispatchNamespace: &[]string{"foo"}[0],
+	})
+	assert.NoError(t, err)
+}
+
 func TestGetWorker(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
## Description

Support a new `DispatchNamespace` option in `DeleteWorker` params just like we do for the other APIs (UploadWorker, UpdateWorkersScriptContent, etc.).

## Has your change been tested?

TestDeleteNamespacedWorker test passes. Test script also passes:
```
func main() {
	api, err := cloudflare.New(os.Getenv("CLOUDFLARE_API_KEY"), os.Getenv("CLOUDFLARE_API_EMAIL"))
	if err != nil {
		log.Fatal(err)
	}

	ctx := context.Background()

	accountId := os.Getenv("ACCOUNT_ID")
	err = api.DeleteWorker(ctx, cloudflare.AccountIdentifier(accountId), cloudflare.DeleteWorkerParams{
		ScriptName:        "user-worker-1",
		DispatchNamespace: &[]string{"test"}[0],
	})
	if err != nil {
		log.Fatal(err)
	}
}

```

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
