### PR TITLE
Add support for create/update individual ruleset rules

### DIFF
--- a/.changelog/1744.txt
+++ b/.changelog/1744.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+rulesets: Add support for create/update calls for individual ruleset rules
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -733,6 +733,10 @@ type UpdateRulesetParams struct {
 	Rules       []RulesetRule `json:"rules"`
 }
 
+type UpdateRulesetRuleParams struct {
+	RulesetRule
+}
+
 type UpdateEntrypointRulesetParams struct {
 	Phase       string        `json:"-"`
 	Description string        `json:"description,omitempty"`
@@ -830,6 +834,25 @@ func (api *API) UpdateRuleset(ctx context.Context, rc *ResourceContainer, params
 
 	uri := fmt.Sprintf("/%s/%s/rulesets/%s", rc.Level, rc.Identifier, params.ID)
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
+	if err != nil {
+		return Ruleset{}, err
+	}
+
+	result := UpdateRulesetResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return Ruleset{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+func (api *API) UpdateRulesetRule(ctx context.Context, rc *ResourceContainer, rulesetID string, params UpdateRulesetRuleParams) (Ruleset, error) {
+	if params.ID == "" {
+		return Ruleset{}, ErrMissingResourceIdentifier
+	}
+
+	uri := fmt.Sprintf("/%s/%s/rulesets/%s/rules/%s", rc.Level, rc.Identifier, rulesetID, params.ID)
+	res, err := api.makeRequestContext(ctx, http.MethodPatch, uri, params)
 	if err != nil {
 		return Ruleset{}, err
 	}

--- a/rulesets.go
+++ b/rulesets.go
@@ -733,6 +733,10 @@ type UpdateRulesetParams struct {
 	Rules       []RulesetRule `json:"rules"`
 }
 
+type CreateRulesetRuleParams struct {
+	RulesetRule
+}
+
 type UpdateRulesetRuleParams struct {
 	RulesetRule
 }
@@ -846,6 +850,29 @@ func (api *API) UpdateRuleset(ctx context.Context, rc *ResourceContainer, params
 	return result.Result, nil
 }
 
+// CreateRulesetRule creates a new ruleset rule.
+//
+// API reference: https://developers.cloudflare.com/api/operations/createAccountRulesetRule
+// API reference: https://developers.cloudflare.com/api/operations/createZoneRulesetRule
+func (api *API) CreateRulesetRule(ctx context.Context, rc *ResourceContainer, rulesetID string, params CreateRulesetRuleParams) (Ruleset, error) {
+	uri := fmt.Sprintf("/%s/%s/rulesets/%s/rules", rc.Level, rc.Identifier, rulesetID)
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
+	if err != nil {
+		return Ruleset{}, err
+	}
+
+	result := CreateRulesetResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return Ruleset{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+// UpdateRulesetRule updates a ruleset rule based on the ruleset and rule ID.
+//
+// API reference: https://developers.cloudflare.com/api/operations/updateAccountRulesetRule
+// API reference: https://developers.cloudflare.com/api/operations/updateZoneRulesetRule
 func (api *API) UpdateRulesetRule(ctx context.Context, rc *ResourceContainer, rulesetID string, params UpdateRulesetRuleParams) (Ruleset, error) {
 	if params.ID == "" {
 		return Ruleset{}, ErrMissingResourceIdentifier


### PR DESCRIPTION
## Description

This PR extends the `ruleset.go` and adds two new methods `CreateRulesetRule` and `UpdateRulesetRule`. The code was only slightly modified from the corresponding ruleset methods. This when merged closes #1211.

## Has your change been tested?

The changes have been tested both using automated tests run locally (everything passing) and against a live CF Zone WAF API (**not** account API). Further, the new methods are also covered by two new tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.
