### PR TITLE
GATE-5639: update teams account via PATCH and add custom certificate setting

### DIFF
--- a/.changelog/1811.txt
+++ b/.changelog/1811.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-gateway: adds custom certificate setting to teams account configuration
+teams_account: adds custom certificate setting to teams account configuration
 ```

--- a/.changelog/1811.txt
+++ b/.changelog/1811.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-adds custom certificate setting to teams account configuration
+```release-note:enhancement
+gateway: adds custom certificate setting to teams account configuration
 ```

--- a/.changelog/1811.txt
+++ b/.changelog/1811.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+adds custom certificate setting to teams account configuration
+```

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -46,6 +46,7 @@ type TeamsAccountSettings struct {
 	ProtocolDetection     *TeamsProtocolDetection     `json:"protocol_detection,omitempty"`
 	BodyScanning          *TeamsBodyScanning          `json:"body_scanning,omitempty"`
 	ExtendedEmailMatching *TeamsExtendedEmailMatching `json:"extended_email_matching,omitempty"`
+	CustomCertificate     *TeamsCustomCertificate     `json:"custom_certificate,omitempty"`
 }
 
 type BrowserIsolation struct {
@@ -101,6 +102,14 @@ type TeamsBodyScanning struct {
 
 type TeamsExtendedEmailMatching struct {
 	Enabled *bool `json:"enabled,omitempty"`
+}
+
+type TeamsCustomCertificate struct {
+	Enabled       *bool      `json:"enabled,omitempty"`
+	ID            string     `json:"id,omitempty"`
+	BindingStatus string     `json:"binding_status,omitempty"`
+	QsPackId      string     `json:"qs_pack_id,omitempty"`
+	UpdatedAt     *time.Time `json:"updated_at,omitempty"`
 }
 
 type TeamsRuleType = string

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -169,6 +169,9 @@ func TestTeamsAccountUpdateConfiguration(t *testing.T) {
 					},
 					"extended_email_matching": {
 						"enabled": true
+					},
+					"custom_certificate": {
+						"enabled": true
 					}
 				}
 			}
@@ -182,6 +185,9 @@ func TestTeamsAccountUpdateConfiguration(t *testing.T) {
 		TLSDecrypt:        &TeamsTLSDecrypt{Enabled: true},
 		ProtocolDetection: &TeamsProtocolDetection{Enabled: true},
 		ExtendedEmailMatching: &TeamsExtendedEmailMatching{
+			Enabled: BoolPtr(true),
+		},
+		CustomCertificate: &TeamsCustomCertificate{
 			Enabled: BoolPtr(true),
 		},
 	}


### PR DESCRIPTION
## Description

Adds a fix for BUGS-726 in which the custom certificate setting was being overwritten. This adds the existing custom certificate setting to Teams account configuration.

Documentation in https://developers.cloudflare.com/api/operations/zero-trust-accounts-update-zero-trust-account-configuration

## Has your change been tested?

Tests in a/teams_accounts_test.go. 

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
