### PR TITLE
Add support for access reusable policies

### DIFF
--- a/.changelog/1956.txt
+++ b/.changelog/1956.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+access_policy: add support for reusable policies
+```
+
+```release-note:enhancement
+access_application: add support for `policies` array
+```

--- a/access_application.go
+++ b/access_application.go
@@ -58,6 +58,7 @@ type AccessApplication struct {
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
 	SCIMConfig               *AccessApplicationSCIMConfig   `json:"scim_config,omitempty"`
+	Policies                 []AccessPolicy                 `json:"policies,omitempty"`
 	AccessAppLauncherCustomization
 }
 
@@ -277,6 +278,8 @@ type CreateAccessApplicationParams struct {
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
 	SCIMConfig               *AccessApplicationSCIMConfig   `json:"scim_config,omitempty"`
+	// List of policy ids to link to this application in ascending order of precedence.
+	Policies []string `json:"policies,omitempty"`
 	AccessAppLauncherCustomization
 }
 
@@ -310,6 +313,10 @@ type UpdateAccessApplicationParams struct {
 	CustomPages              []string                       `json:"custom_pages,omitempty"`
 	Tags                     []string                       `json:"tags,omitempty"`
 	SCIMConfig               *AccessApplicationSCIMConfig   `json:"scim_config,omitempty"`
+	// List of policy ids to link to this application in ascending order of precedence.
+	// Can reference reusable policies and policies specific to this application.
+	// If this field is not provided, the existing policies will not be modified.
+	Policies *[]string `json:"policies,omitempty"`
 	AccessAppLauncherCustomization
 }
 

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -3,6 +3,7 @@ package cloudflare
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -51,7 +52,25 @@ func TestAccessApplications(t *testing.T) {
 					"custom_pages": ["480f4f69-1a28-4fdd-9240-1ed29f0ac1dc"],
 					"tags": ["engineers"],
 					"allow_authenticate_via_warp": true,
-					"options_preflight_bypass": false
+					"options_preflight_bypass": false,
+					"policies": [
+						{
+							"id": "699d98642c564d2e855e9661899b7252",
+							"precedence": 1,
+							"reusable": true,
+							"decision": "allow",
+							"created_at": "2014-01-01T05:20:00.12345Z",
+							"updated_at": "2014-01-01T05:20:00.12345Z",
+							"name": "Allow devs",
+							"include": [
+								{
+									"email": {
+										"email": "test@example.com"
+									}
+								}
+							]
+						}
+					]
 				}
 			],
 			"result_info": {
@@ -93,6 +112,20 @@ func TestAccessApplications(t *testing.T) {
 		CustomNonIdentityDenyURL: "https://blocked.com",
 		AllowAuthenticateViaWarp: BoolPtr(true),
 		OptionsPreflightBypass:   BoolPtr(false),
+		Policies: []AccessPolicy{
+			{
+				ID:         "699d98642c564d2e855e9661899b7252",
+				Precedence: 1,
+				Reusable:   BoolPtr(true),
+				Decision:   "allow",
+				CreatedAt:  &createdAt,
+				UpdatedAt:  &updatedAt,
+				Name:       "Allow devs",
+				Include: []any{
+					map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
+				},
+			},
+		},
 	}}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/apps", handler)
@@ -146,7 +179,25 @@ func TestAccessApplication(t *testing.T) {
 				"http_only_cookie_attribute": false,
 				"path_cookie_attribute": false,
 				"allow_authenticate_via_warp": false,
-				"options_preflight_bypass": false
+				"options_preflight_bypass": false,
+				"policies": [
+					{
+						"id": "699d98642c564d2e855e9661899b7252",
+						"precedence": 1,
+						"reusable": true,
+						"decision": "allow",
+						"created_at": "2014-01-01T05:20:00.12345Z",
+						"updated_at": "2014-01-01T05:20:00.12345Z",
+						"name": "Allow devs",
+						"include": [
+							{
+								"email": {
+									"email": "test@example.com"
+								}
+							}
+						]
+					}
+				]
 			}
 		}
 		`)
@@ -179,6 +230,20 @@ func TestAccessApplication(t *testing.T) {
 		CustomNonIdentityDenyURL: "https://blocked.com",
 		AllowAuthenticateViaWarp: BoolPtr(false),
 		OptionsPreflightBypass:   BoolPtr(false),
+		Policies: []AccessPolicy{
+			{
+				ID:         "699d98642c564d2e855e9661899b7252",
+				Precedence: 1,
+				Reusable:   BoolPtr(true),
+				Decision:   "allow",
+				CreatedAt:  &createdAt,
+				UpdatedAt:  &updatedAt,
+				Name:       "Allow devs",
+				Include: []any{
+					map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
+				},
+			},
+		},
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
@@ -231,7 +296,25 @@ func TestCreateAccessApplications(t *testing.T) {
 				"service_auth_401_redirect": true,
 				"tags": ["engineers"],
 				"allow_authenticate_via_warp": false,
-				"options_preflight_bypass": true
+				"options_preflight_bypass": true,
+				"policies": [
+					{
+						"id": "699d98642c564d2e855e9661899b7252",
+						"precedence": 1,
+						"reusable": true,
+						"decision": "allow",
+						"created_at": "2014-01-01T05:20:00.12345Z",
+						"updated_at": "2014-01-01T05:20:00.12345Z",
+						"name": "Allow devs",
+						"include": [
+							{
+								"email": {
+									"email": "test@example.com"
+								}
+							}
+						]
+					}
+				]
 			}
 		}
 		`)
@@ -262,6 +345,20 @@ func TestCreateAccessApplications(t *testing.T) {
 		Tags:                     []string{"engineers"},
 		AllowAuthenticateViaWarp: BoolPtr(false),
 		OptionsPreflightBypass:   BoolPtr(true),
+		Policies: []AccessPolicy{
+			{
+				ID:         "699d98642c564d2e855e9661899b7252",
+				Precedence: 1,
+				Reusable:   BoolPtr(true),
+				Decision:   "allow",
+				CreatedAt:  &createdAt,
+				UpdatedAt:  &updatedAt,
+				Name:       "Allow devs",
+				Include: []any{
+					map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
+				},
+			},
+		},
 	}
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/access/apps", handler)
@@ -270,6 +367,7 @@ func TestCreateAccessApplications(t *testing.T) {
 		Name:            "Admin Site",
 		Domain:          "test.example.com/admin",
 		SessionDuration: "24h",
+		Policies:        []string{"699d98642c564d2e855e9661899b7252"},
 	})
 
 	if assert.NoError(t, err) {
@@ -282,6 +380,7 @@ func TestCreateAccessApplications(t *testing.T) {
 		Name:            "Admin Site",
 		Domain:          "test.example.com/admin",
 		SessionDuration: "24h",
+		Policies:        []string{"699d98642c564d2e855e9661899b7252"},
 	})
 
 	if assert.NoError(t, err) {
@@ -322,7 +421,25 @@ func TestUpdateAccessApplication(t *testing.T) {
 				"service_auth_401_redirect": true,
 				"tags": ["engineers"],
 				"allow_authenticate_via_warp": true,
-				"options_preflight_bypass": true
+				"options_preflight_bypass": true,
+				"policies": [
+					{
+						"id": "699d98642c564d2e855e9661899b7252",
+						"precedence": 1,
+						"reusable": true,
+						"decision": "allow",
+						"created_at": "2014-01-01T05:20:00.12345Z",
+						"updated_at": "2014-01-01T05:20:00.12345Z",
+						"name": "Allow devs",
+						"include": [
+							{
+								"email": {
+									"email": "test@example.com"
+								}
+							}
+						]
+					}
+				]
 			}
 		}
 		`)
@@ -351,6 +468,180 @@ func TestUpdateAccessApplication(t *testing.T) {
 		OptionsPreflightBypass:   BoolPtr(true),
 		CreatedAt:                &createdAt,
 		UpdatedAt:                &updatedAt,
+		Policies: []AccessPolicy{
+			{
+				ID:         "699d98642c564d2e855e9661899b7252",
+				Precedence: 1,
+				Reusable:   BoolPtr(true),
+				Decision:   "allow",
+				CreatedAt:  &createdAt,
+				UpdatedAt:  &updatedAt,
+				Name:       "Allow devs",
+				Include: []any{
+					map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
+				},
+			},
+		},
+	}
+
+	params := UpdateAccessApplicationParams{
+		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:                     "Admin Site",
+		Domain:                   "test.example.com/admin",
+		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		Type:                     "self_hosted",
+		SessionDuration:          "24h",
+		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		AllowedIdps:              []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity:   BoolPtr(false),
+		EnableBindingCookie:      BoolPtr(false),
+		AppLauncherVisible:       BoolPtr(true),
+		ServiceAuth401Redirect:   BoolPtr(true),
+		CustomDenyMessage:        "denied!",
+		CustomDenyURL:            "https://www.example.com",
+		LogoURL:                  "https://www.example.com/example.png",
+		SkipInterstitial:         BoolPtr(true),
+		CustomNonIdentityDenyURL: "https://blocked.com",
+		Tags:                     []string{"engineers"},
+		AllowAuthenticateViaWarp: BoolPtr(true),
+		OptionsPreflightBypass:   BoolPtr(true),
+		Policies:                 &[]string{"699d98642c564d2e855e9661899b7252"},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err := client.UpdateAccessApplication(context.Background(), AccountIdentifier(testAccountID), params)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fullAccessApplication, actual)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
+
+	actual, err = client.UpdateAccessApplication(context.Background(), ZoneIdentifier(testZoneID), UpdateAccessApplicationParams{
+		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:                     "Admin Site",
+		Domain:                   "test.example.com/admin",
+		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		Type:                     "self_hosted",
+		SessionDuration:          "24h",
+		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		AllowedIdps:              []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity:   BoolPtr(false),
+		EnableBindingCookie:      BoolPtr(false),
+		AppLauncherVisible:       BoolPtr(true),
+		ServiceAuth401Redirect:   BoolPtr(true),
+		CustomDenyMessage:        "denied!",
+		CustomDenyURL:            "https://www.example.com",
+		LogoURL:                  "https://www.example.com/example.png",
+		SkipInterstitial:         BoolPtr(true),
+		CustomNonIdentityDenyURL: "https://blocked.com",
+		OptionsPreflightBypass:   BoolPtr(true),
+		Policies:                 &[]string{"699d98642c564d2e855e9661899b7252"},
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, fullAccessApplication, actual)
+	}
+}
+
+func TestUpdateAccessApplicationOmitPolicies(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		reqBody, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NotContains(t, string(reqBody), "policies")
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+				"created_at": "2014-01-01T05:20:00.12345Z",
+				"updated_at": "2014-01-01T05:20:00.12345Z",
+				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+				"name": "Admin Site",
+				"domain": "test.example.com/admin",
+				"self_hosted_domains": ["test.example.com/admin", "test.example.com/admin2"],
+				"type": "self_hosted",
+				"session_duration": "24h",
+				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
+				"auto_redirect_to_identity": false,
+				"enable_binding_cookie": false,
+				"custom_deny_url": "https://www.example.com",
+				"custom_deny_message": "denied!",
+				"custom_non_identity_deny_url": "https://blocked.com",
+				"logo_url": "https://www.example.com/example.png",
+				"skip_interstitial": true,
+				"app_launcher_visible": true,
+				"service_auth_401_redirect": true,
+				"tags": ["engineers"],
+				"allow_authenticate_via_warp": true,
+				"options_preflight_bypass": true,
+				"policies": [
+					{
+						"id": "699d98642c564d2e855e9661899b7252",
+						"precedence": 1,
+						"reusable": true,
+						"decision": "allow",
+						"created_at": "2014-01-01T05:20:00.12345Z",
+						"updated_at": "2014-01-01T05:20:00.12345Z",
+						"name": "Allow devs",
+						"include": [
+							{
+								"email": {
+									"email": "test@example.com"
+								}
+							}
+						]
+					}
+				]
+			}
+		}
+		`)
+	}
+
+	fullAccessApplication := AccessApplication{
+		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:                     "Admin Site",
+		Domain:                   "test.example.com/admin",
+		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		Type:                     "self_hosted",
+		SessionDuration:          "24h",
+		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		AllowedIdps:              []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
+		AutoRedirectToIdentity:   BoolPtr(false),
+		EnableBindingCookie:      BoolPtr(false),
+		AppLauncherVisible:       BoolPtr(true),
+		ServiceAuth401Redirect:   BoolPtr(true),
+		CustomDenyMessage:        "denied!",
+		CustomDenyURL:            "https://www.example.com",
+		LogoURL:                  "https://www.example.com/example.png",
+		CustomNonIdentityDenyURL: "https://blocked.com",
+		Tags:                     []string{"engineers"},
+		SkipInterstitial:         BoolPtr(true),
+		AllowAuthenticateViaWarp: BoolPtr(true),
+		OptionsPreflightBypass:   BoolPtr(true),
+		CreatedAt:                &createdAt,
+		UpdatedAt:                &updatedAt,
+		Policies: []AccessPolicy{
+			{
+				ID:         "699d98642c564d2e855e9661899b7252",
+				Precedence: 1,
+				Reusable:   BoolPtr(true),
+				Decision:   "allow",
+				CreatedAt:  &createdAt,
+				UpdatedAt:  &updatedAt,
+				Name:       "Allow devs",
+				Include: []any{
+					map[string]interface{}{"email": map[string]interface{}{"email": "test@example.com"}},
+				},
+			},
+		},
 	}
 
 	params := UpdateAccessApplicationParams{

--- a/access_policy_test.go
+++ b/access_policy_test.go
@@ -142,6 +142,23 @@ func TestAccessPolicies(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, []AccessPolicy{expectedAccessPolicy}, actual)
 	}
+
+	// Test Listing reusable policies
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/policies", handler)
+
+	actual, _, err = client.ListAccessPolicies(context.Background(), testAccountRC, ListAccessPoliciesParams{})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, []AccessPolicy{expectedAccessPolicy}, actual)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/policies", handler)
+
+	actual, _, err = client.ListAccessPolicies(context.Background(), testZoneRC, ListAccessPoliciesParams{})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, []AccessPolicy{expectedAccessPolicy}, actual)
+	}
 }
 
 func TestAccessPolicy(t *testing.T) {
@@ -214,6 +231,23 @@ func TestAccessPolicy(t *testing.T) {
 	mux.HandleFunc("/zones/"+testZoneID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
 
 	actual, err = client.GetAccessPolicy(context.Background(), testZoneRC, GetAccessPolicyParams{ApplicationID: accessApplicationID, PolicyID: accessPolicyID})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAccessPolicy, actual)
+	}
+
+	// Test getting a reusable policy
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/policies/"+accessPolicyID, handler)
+
+	actual, err = client.GetAccessPolicy(context.Background(), testAccountRC, GetAccessPolicyParams{PolicyID: accessPolicyID})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAccessPolicy, actual)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/policies/"+accessPolicyID, handler)
+
+	actual, err = client.GetAccessPolicy(context.Background(), testZoneRC, GetAccessPolicyParams{PolicyID: accessPolicyID})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, expectedAccessPolicy, actual)
@@ -322,6 +356,24 @@ func TestCreateAccessPolicy(t *testing.T) {
 	}
 
 	mux.HandleFunc("/zones/"+testZoneID+"/access/apps/"+accessApplicationID+"/policies", handler)
+
+	actual, err = client.CreateAccessPolicy(context.Background(), testZoneRC, accessPolicy)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAccessPolicy, actual)
+	}
+
+	// Test creating a reusable policy
+	accessPolicy.ApplicationID = ""
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/policies", handler)
+
+	actual, err = client.CreateAccessPolicy(context.Background(), testAccountRC, accessPolicy)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAccessPolicy, actual)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/policies", handler)
 
 	actual, err = client.CreateAccessPolicy(context.Background(), testZoneRC, accessPolicy)
 
@@ -571,6 +623,22 @@ func TestUpdateAccessPolicy(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, expectedAccessPolicy, actual)
 	}
+
+	// Test updating reusable policies
+	accessPolicy.ApplicationID = ""
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/policies/"+accessPolicyID, handler)
+	actual, err = client.UpdateAccessPolicy(context.Background(), testAccountRC, accessPolicy)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAccessPolicy, actual)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/policies/"+accessPolicyID, handler)
+	actual, err = client.UpdateAccessPolicy(context.Background(), testZoneRC, accessPolicy)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, expectedAccessPolicy, actual)
+	}
 }
 
 func TestUpdateAccessPolicyWithMissingID(t *testing.T) {
@@ -609,6 +677,17 @@ func TestDeleteAccessPolicy(t *testing.T) {
 
 	mux.HandleFunc("/zones/"+testZoneID+"/access/apps/"+accessApplicationID+"/policies/"+accessPolicyID, handler)
 	err = client.DeleteAccessPolicy(context.Background(), testZoneRC, DeleteAccessPolicyParams{ApplicationID: accessApplicationID, PolicyID: accessPolicyID})
+
+	assert.NoError(t, err)
+
+	// Test deleting a reusable policy
+	mux.HandleFunc("/accounts/"+testAccountID+"/access/policies/"+accessPolicyID, handler)
+	err = client.DeleteAccessPolicy(context.Background(), testAccountRC, DeleteAccessPolicyParams{PolicyID: accessPolicyID})
+
+	assert.NoError(t, err)
+
+	mux.HandleFunc("/zones/"+testZoneID+"/access/policies/"+accessPolicyID, handler)
+	err = client.DeleteAccessPolicy(context.Background(), testZoneRC, DeleteAccessPolicyParams{PolicyID: accessPolicyID})
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
1. Adds support for reusable access policies. Reusable policies are not bound to a single access application, but can instead be applied to multiple apps. 
2. Allows setting the 'policies' array field in access apps update/create request. This defines the order of which policies apply to an access application.
3. Return the access policies currently in use for an application under the application response JSON.

## Description
Reusable access policies have been a requested feature for a while now, the

## Has your change been tested?
Tested manually and with terraform in staging.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. - PENDING RELEASE
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
