### PR TITLE
Enhancement - teams_accounts: Support 'UseZtVirtualIP'

### DIFF
--- a/.changelog/2126.txt
+++ b/.changelog/2126.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams_accounts: Add `use_zt_virtual_ip` attribute
+```

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -131,10 +131,10 @@ type TeamsLoggingSettings struct {
 }
 
 type TeamsDeviceSettings struct {
-	GatewayProxyEnabled                bool `json:"gateway_proxy_enabled"`
-	GatewayProxyUDPEnabled             bool `json:"gateway_udp_proxy_enabled"`
-	RootCertificateInstallationEnabled bool `json:"root_certificate_installation_enabled"`
-	UseZTVirtualIP                     bool `json:"use_zt_virtual_ip"`
+	GatewayProxyEnabled                bool  `json:"gateway_proxy_enabled"`
+	GatewayProxyUDPEnabled             bool  `json:"gateway_udp_proxy_enabled"`
+	RootCertificateInstallationEnabled bool  `json:"root_certificate_installation_enabled"`
+	UseZTVirtualIP                     *bool `json:"use_zt_virtual_ip"`
 }
 
 type TeamsDeviceSettingsResponse struct {

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -134,7 +134,7 @@ type TeamsDeviceSettings struct {
 	GatewayProxyEnabled                bool `json:"gateway_proxy_enabled"`
 	GatewayProxyUDPEnabled             bool `json:"gateway_udp_proxy_enabled"`
 	RootCertificateInstallationEnabled bool `json:"root_certificate_installation_enabled"`
-	UseZtVirtualIP                     bool `json:"use_zt_virtual_ip"`
+	UseZTVirtualIP                     bool `json:"use_zt_virtual_ip"`
 }
 
 type TeamsDeviceSettingsResponse struct {

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -134,6 +134,7 @@ type TeamsDeviceSettings struct {
 	GatewayProxyEnabled                bool `json:"gateway_proxy_enabled"`
 	GatewayProxyUDPEnabled             bool `json:"gateway_udp_proxy_enabled"`
 	RootCertificateInstallationEnabled bool `json:"root_certificate_installation_enabled"`
+	UseZtVirtualIP                     bool `json:"use_zt_virtual_ip"`
 }
 
 type TeamsDeviceSettingsResponse struct {

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -302,7 +302,7 @@ func TestTeamsAccountGetDeviceConfiguration(t *testing.T) {
 			GatewayProxyEnabled:                true,
 			GatewayProxyUDPEnabled:             false,
 			RootCertificateInstallationEnabled: true,
-			UseZTVirtualIP:                     false,
+			UseZTVirtualIP:                     BoolPtr(false),
 		})
 	}
 }
@@ -328,7 +328,7 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 		GatewayProxyUDPEnabled:             true,
 		GatewayProxyEnabled:                true,
 		RootCertificateInstallationEnabled: true,
-		UseZTVirtualIP:                     true,
+		UseZTVirtualIP:                     BoolPtr(true),
 	})
 
 	if assert.NoError(t, err) {
@@ -336,7 +336,7 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 			GatewayProxyEnabled:                true,
 			GatewayProxyUDPEnabled:             true,
 			RootCertificateInstallationEnabled: true,
-			UseZTVirtualIP:                     true,
+			UseZTVirtualIP:                     BoolPtr(true),
 		})
 	}
 }

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -289,7 +289,7 @@ func TestTeamsAccountGetDeviceConfiguration(t *testing.T) {
 			"success": true,
 			"errors": [],
 			"messages": [],
-			"result": {"gateway_proxy_enabled": true,"gateway_udp_proxy_enabled":false, "root_certificate_installation_enabled":true}
+			"result": {"gateway_proxy_enabled": true,"gateway_udp_proxy_enabled":false, "root_certificate_installation_enabled":true, "use_zt_virtual_ip":false}
 		}`)
 	}
 
@@ -302,6 +302,7 @@ func TestTeamsAccountGetDeviceConfiguration(t *testing.T) {
 			GatewayProxyEnabled:                true,
 			GatewayProxyUDPEnabled:             false,
 			RootCertificateInstallationEnabled: true,
+			UseZtVirtualIP:                     false,
 		})
 	}
 }
@@ -317,7 +318,7 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 			"success": true,
 			"errors": [],
 			"messages": [],
-			"result": {"gateway_proxy_enabled": true,"gateway_udp_proxy_enabled":true, "root_certificate_installation_enabled":true}
+			"result": {"gateway_proxy_enabled": true,"gateway_udp_proxy_enabled":true, "root_certificate_installation_enabled":true, "use_zt_virtual_ip":true}
 		}`)
 	}
 
@@ -327,6 +328,7 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 		GatewayProxyUDPEnabled:             true,
 		GatewayProxyEnabled:                true,
 		RootCertificateInstallationEnabled: true,
+		UseZtVirtualIP:                     true,
 	})
 
 	if assert.NoError(t, err) {
@@ -334,6 +336,7 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 			GatewayProxyEnabled:                true,
 			GatewayProxyUDPEnabled:             true,
 			RootCertificateInstallationEnabled: true,
+			UseZtVirtualIP:                     true,
 		})
 	}
 }

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -302,7 +302,7 @@ func TestTeamsAccountGetDeviceConfiguration(t *testing.T) {
 			GatewayProxyEnabled:                true,
 			GatewayProxyUDPEnabled:             false,
 			RootCertificateInstallationEnabled: true,
-			UseZtVirtualIP:                     false,
+			UseZTVirtualIP:                     false,
 		})
 	}
 }
@@ -328,7 +328,7 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 		GatewayProxyUDPEnabled:             true,
 		GatewayProxyEnabled:                true,
 		RootCertificateInstallationEnabled: true,
-		UseZtVirtualIP:                     true,
+		UseZTVirtualIP:                     true,
 	})
 
 	if assert.NoError(t, err) {
@@ -336,7 +336,7 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 			GatewayProxyEnabled:                true,
 			GatewayProxyUDPEnabled:             true,
 			RootCertificateInstallationEnabled: true,
-			UseZtVirtualIP:                     true,
+			UseZTVirtualIP:                     true,
 		})
 	}
 }


### PR DESCRIPTION
## Description
Added field `UseZtVirtualIP` to `TeamsDeviceSettings` . Property `use_zt_virtual_ip` of `teams-devices_zero-trust-account-device-settings` in openapi.yaml. Allows us set up https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/private-net/warp-connector/#3-enable-cgnat-routing via the provider.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
