### PR TITLE
Add ZT connectivity settings

### DIFF
--- a/.changelog/2165.txt
+++ b/.changelog/2165.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams_account: Add Zero Trust connectivity settings
+```

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -149,7 +149,7 @@ type TeamsLoggingSettingsResponse struct {
 
 type TeamsConnectivitySettings struct {
 	ICMPProxyEnabled   *bool `json:"icmp_proxy_enabled"`
-	OfframpWarpEnabled *bool `json:"offramp_warp_enabled"`
+	OfframpWARPEnabled *bool `json:"offramp_warp_enabled"`
 }
 
 type TeamsAccountConnectivitySettingsResponse struct {

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -147,14 +147,14 @@ type TeamsLoggingSettingsResponse struct {
 	Result TeamsLoggingSettings `json:"result"`
 }
 
-type TeamsAccountConnectivitySettings struct {
+type TeamsConnectivitySettings struct {
 	ICMPProxyEnabled   *bool `json:"icmp_proxy_enabled"`
 	OfframpWarpEnabled *bool `json:"offramp_warp_enabled"`
 }
 
 type TeamsAccountConnectivitySettingsResponse struct {
 	Response
-	Result TeamsAccountConnectivitySettings `json:"result"`
+	Result TeamsConnectivitySettings `json:"result"`
 }
 
 // TeamsAccount returns teams account information with internal and external ID.
@@ -240,18 +240,18 @@ func (api *API) TeamsAccountLoggingConfiguration(ctx context.Context, accountID 
 // TeamsAccountConnectivityConfiguration returns zero trust account connectivity settings.
 //
 // API reference: https://developers.cloudflare.com/api/operations/zero-trust-accounts-get-connectivity-settings
-func (api *API) TeamsAccountConnectivityConfiguration(ctx context.Context, accountID string) (TeamsAccountConnectivitySettings, error) {
+func (api *API) TeamsAccountConnectivityConfiguration(ctx context.Context, accountID string) (TeamsConnectivitySettings, error) {
 	uri := fmt.Sprintf("/accounts/%s/zerotrust/connectivity_settings", accountID)
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
-		return TeamsAccountConnectivitySettings{}, err
+		return TeamsConnectivitySettings{}, err
 	}
 
 	var teamsConnectivityResponse TeamsAccountConnectivitySettingsResponse
 	err = json.Unmarshal(res, &teamsConnectivityResponse)
 	if err != nil {
-		return TeamsAccountConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return TeamsConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
 	return teamsConnectivityResponse.Result, nil
@@ -320,18 +320,18 @@ func (api *API) TeamsAccountDeviceUpdateConfiguration(ctx context.Context, accou
 // TeamsAccountConnectivityUpdateConfiguration updates zero trust account connectivity settings.
 //
 // API reference: https://developers.cloudflare.com/api/operations/zero-trust-accounts-patch-connectivity-settings
-func (api *API) TeamsAccountConnectivityUpdateConfiguration(ctx context.Context, accountID string, settings TeamsAccountConnectivitySettings) (TeamsAccountConnectivitySettings, error) {
+func (api *API) TeamsAccountConnectivityUpdateConfiguration(ctx context.Context, accountID string, settings TeamsConnectivitySettings) (TeamsConnectivitySettings, error) {
 	uri := fmt.Sprintf("/accounts/%s/zerotrust/connectivity_settings", accountID)
 
 	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, settings)
 	if err != nil {
-		return TeamsAccountConnectivitySettings{}, err
+		return TeamsConnectivitySettings{}, err
 	}
 
 	var teamsConnectivityResponse TeamsAccountConnectivitySettingsResponse
 	err = json.Unmarshal(res, &teamsConnectivityResponse)
 	if err != nil {
-		return TeamsAccountConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+		return TeamsConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
 	return teamsConnectivityResponse.Result, nil

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -147,6 +147,16 @@ type TeamsLoggingSettingsResponse struct {
 	Result TeamsLoggingSettings `json:"result"`
 }
 
+type TeamsAccountConnectivitySettings struct {
+	ICMPProxyEnabled   *bool `json:"icmp_proxy_enabled"`
+	OfframpWarpEnabled *bool `json:"offramp_warp_enabled"`
+}
+
+type TeamsAccountConnectivitySettingsResponse struct {
+	Response
+	Result TeamsAccountConnectivitySettings `json:"result"`
+}
+
 // TeamsAccount returns teams account information with internal and external ID.
 //
 // API reference: TBA.
@@ -227,6 +237,26 @@ func (api *API) TeamsAccountLoggingConfiguration(ctx context.Context, accountID 
 	return teamsConfigResponse.Result, nil
 }
 
+// TeamsAccountConnectivityConfiguration returns zero trust account connectivity settings.
+//
+// API reference: https://developers.cloudflare.com/api/operations/zero-trust-accounts-get-connectivity-settings
+func (api *API) TeamsAccountConnectivityConfiguration(ctx context.Context, accountID string) (TeamsAccountConnectivitySettings, error) {
+	uri := fmt.Sprintf("/accounts/%s/zerotrust/connectivity_settings", accountID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return TeamsAccountConnectivitySettings{}, err
+	}
+
+	var zeroTrustConfigResponse TeamsAccountConnectivitySettingsResponse
+	err = json.Unmarshal(res, &zeroTrustConfigResponse)
+	if err != nil {
+		return TeamsAccountConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return zeroTrustConfigResponse.Result, nil
+}
+
 // TeamsAccountUpdateConfiguration updates a teams account configuration.
 //
 // API reference: TBA.
@@ -285,4 +315,24 @@ func (api *API) TeamsAccountDeviceUpdateConfiguration(ctx context.Context, accou
 	}
 
 	return teamsDeviceResponse.Result, nil
+}
+
+// TeamsAccountConnectivityUpdateConfiguration updates zero trust account connectivity settings.
+//
+// API reference: https://developers.cloudflare.com/api/operations/zero-trust-accounts-patch-connectivity-settings
+func (api *API) TeamsAccountConnectivityUpdateConfiguration(ctx context.Context, accountID string, settings TeamsAccountConnectivitySettings) (TeamsAccountConnectivitySettings, error) {
+	uri := fmt.Sprintf("/accounts/%s/zerotrust/connectivity_settings", accountID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, settings)
+	if err != nil {
+		return TeamsAccountConnectivitySettings{}, err
+	}
+
+	var zeroTrustConfigResponse TeamsAccountConnectivitySettingsResponse
+	err = json.Unmarshal(res, &zeroTrustConfigResponse)
+	if err != nil {
+		return TeamsAccountConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return zeroTrustConfigResponse.Result, nil
 }

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -248,13 +248,13 @@ func (api *API) TeamsAccountConnectivityConfiguration(ctx context.Context, accou
 		return TeamsAccountConnectivitySettings{}, err
 	}
 
-	var zeroTrustConfigResponse TeamsAccountConnectivitySettingsResponse
-	err = json.Unmarshal(res, &zeroTrustConfigResponse)
+	var teamsConnectivityResponse TeamsAccountConnectivitySettingsResponse
+	err = json.Unmarshal(res, &teamsConnectivityResponse)
 	if err != nil {
 		return TeamsAccountConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return zeroTrustConfigResponse.Result, nil
+	return teamsConnectivityResponse.Result, nil
 }
 
 // TeamsAccountUpdateConfiguration updates a teams account configuration.
@@ -328,11 +328,11 @@ func (api *API) TeamsAccountConnectivityUpdateConfiguration(ctx context.Context,
 		return TeamsAccountConnectivitySettings{}, err
 	}
 
-	var zeroTrustConfigResponse TeamsAccountConnectivitySettingsResponse
-	err = json.Unmarshal(res, &zeroTrustConfigResponse)
+	var teamsConnectivityResponse TeamsAccountConnectivitySettingsResponse
+	err = json.Unmarshal(res, &teamsConnectivityResponse)
 	if err != nil {
 		return TeamsAccountConnectivitySettings{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}
 
-	return zeroTrustConfigResponse.Result, nil
+	return teamsConnectivityResponse.Result, nil
 }

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -363,7 +363,7 @@ func TestTeamsAccountGetConnectivityConfiguration(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Equal(t, actual, TeamsConnectivitySettings{
 			ICMPProxyEnabled:   BoolPtr(false),
-			OfframpWarpEnabled: BoolPtr(false),
+			OfframpWARPEnabled: BoolPtr(false),
 		})
 	}
 }
@@ -387,13 +387,13 @@ func TestTeamsAccountUpdateConnectivityConfiguration(t *testing.T) {
 
 	actual, err := client.TeamsAccountConnectivityUpdateConfiguration(context.Background(), testAccountID, TeamsConnectivitySettings{
 		ICMPProxyEnabled:   BoolPtr(true),
-		OfframpWarpEnabled: BoolPtr(true),
+		OfframpWARPEnabled: BoolPtr(true),
 	})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, actual, TeamsConnectivitySettings{
 			ICMPProxyEnabled:   BoolPtr(true),
-			OfframpWarpEnabled: BoolPtr(true),
+			OfframpWARPEnabled: BoolPtr(true),
 		})
 	}
 }

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -361,7 +361,7 @@ func TestTeamsAccountGetConnectivityConfiguration(t *testing.T) {
 	actual, err := client.TeamsAccountConnectivityConfiguration(context.Background(), testAccountID)
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, actual, TeamsAccountConnectivitySettings{
+		assert.Equal(t, actual, TeamsConnectivitySettings{
 			ICMPProxyEnabled:   BoolPtr(false),
 			OfframpWarpEnabled: BoolPtr(false),
 		})
@@ -385,13 +385,13 @@ func TestTeamsAccountUpdateConnectivityConfiguration(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/zerotrust/connectivity_settings", handler)
 
-	actual, err := client.TeamsAccountConnectivityUpdateConfiguration(context.Background(), testAccountID, TeamsAccountConnectivitySettings{
+	actual, err := client.TeamsAccountConnectivityUpdateConfiguration(context.Background(), testAccountID, TeamsConnectivitySettings{
 		ICMPProxyEnabled:   BoolPtr(true),
 		OfframpWarpEnabled: BoolPtr(true),
 	})
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, actual, TeamsAccountConnectivitySettings{
+		assert.Equal(t, actual, TeamsConnectivitySettings{
 			ICMPProxyEnabled:   BoolPtr(true),
 			OfframpWarpEnabled: BoolPtr(true),
 		})

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -340,3 +340,60 @@ func TestTeamsAccountUpdateDeviceConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestTeamsAccountGetConnectivityConfiguration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {"icmp_proxy_enabled": false,"offramp_warp_enabled":false}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/zerotrust/connectivity_settings", handler)
+
+	actual, err := client.TeamsAccountConnectivityConfiguration(context.Background(), testAccountID)
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, actual, TeamsAccountConnectivitySettings{
+			ICMPProxyEnabled:   BoolPtr(false),
+			OfframpWarpEnabled: BoolPtr(false),
+		})
+	}
+}
+
+func TestTeamsAccountUpdateConnectivityConfiguration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {"icmp_proxy_enabled": true,"offramp_warp_enabled":true}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/zerotrust/connectivity_settings", handler)
+
+	actual, err := client.TeamsAccountConnectivityUpdateConfiguration(context.Background(), testAccountID, TeamsAccountConnectivitySettings{
+		ICMPProxyEnabled:   BoolPtr(true),
+		OfframpWarpEnabled: BoolPtr(true),
+	})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, actual, TeamsAccountConnectivitySettings{
+			ICMPProxyEnabled:   BoolPtr(true),
+			OfframpWarpEnabled: BoolPtr(true),
+		})
+	}
+}


### PR DESCRIPTION
## Description

This PR enables configuring Zero Trust connectivity settings and addresses the missing support of enabling Warp to Warp as per 3.3 of https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/private-net/warp-connector/#3-enable-cgnat-routing, plan is to extend the provider. If discussion is needed on this change I'm happy to open a new issue.

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
