### PR TITLE
FLPROD-1370: Add client for CloudConnectorAPI

### DIFF
--- a/.changelog/2698.txt
+++ b/.changelog/2698.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Add CloudConnectorAPI Client
+```

--- a/cloud_connector.go
+++ b/cloud_connector.go
@@ -1,0 +1,71 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/goccy/go-json"
+)
+
+type CloudConnectorRulesResponse struct {
+	Response
+	Result []CloudConnectorRule `json:"result"`
+}
+
+type CloudConnectorRuleParameters struct {
+	Host string `json:"host"`
+}
+
+type CloudConnectorRule struct {
+	ID          string                       `json:"id"`
+	Enabled     *bool                        `json:"enabled,omitempty"`
+	Expression  string                       `json:"expression"`
+	Provider    string                       `json:"provider"`
+	Parameters  CloudConnectorRuleParameters `json:"parameters"`
+	Description string                       `json:"description"`
+}
+
+func (api *API) ListZoneCloudConnectorRules(ctx context.Context, rc *ResourceContainer) ([]CloudConnectorRule, error) {
+	if rc.Identifier == "" {
+		return nil, ErrMissingZoneID
+	}
+
+	uri := buildURI(fmt.Sprintf("/zones/%s/cloud_connector/rules", rc.Identifier), nil)
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := CloudConnectorRulesResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}
+
+func (api *API) UpdateZoneCloudConnectorRules(ctx context.Context, rc *ResourceContainer, params []CloudConnectorRule) ([]CloudConnectorRule, error) {
+	if rc.Identifier == "" {
+		return nil, ErrMissingZoneID
+	}
+
+	uri := fmt.Sprintf("/zones/%s/cloud_connector/rules", rc.Identifier)
+
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	result := CloudConnectorRulesResponse{}
+	if err := json.Unmarshal(res, &result); err != nil {
+		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return result.Result, nil
+}

--- a/cloud_connector_test.go
+++ b/cloud_connector_test.go
@@ -1,0 +1,161 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudConnectorRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "result": [
+		{
+			"id": "some_id_1",
+			"provider": "aws_s3",
+			"expression": "true",
+			"enabled": true,
+			"description": "some description",
+			"parameters": {
+				"host": "aws.s3.bucket"
+			}
+	  	},
+		{
+			"id": "some_id_2",
+			"provider": "r2",
+			"expression": "true",
+			"enabled": true,
+			"description": "some description",
+			"parameters": {
+				"host": "r2.hostname"
+			}
+	  	}
+	  ],
+      "success": true,
+      "errors": [],
+      "messages": []
+    }`)
+	}
+	mux.HandleFunc("/zones/"+testZoneID+"/cloud_connector/rules", handler)
+
+	want := []CloudConnectorRule{
+		{
+			ID:          "some_id_1",
+			Provider:    "aws_s3",
+			Expression:  "true",
+			Enabled:     BoolPtr(true),
+			Description: "some description",
+			Parameters: CloudConnectorRuleParameters{
+				Host: "aws.s3.bucket",
+			},
+		},
+		{
+			ID:          "some_id_2",
+			Provider:    "r2",
+			Expression:  "true",
+			Enabled:     BoolPtr(true),
+			Description: "some description",
+			Parameters: CloudConnectorRuleParameters{
+				Host: "r2.hostname",
+			},
+		},
+	}
+
+	zoneActual, err := client.ListZoneCloudConnectorRules(context.Background(), ZoneIdentifier(testZoneID))
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, zoneActual)
+	}
+}
+
+func TestUpdateCloudConnectorRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PATCH', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "result": [
+		{
+			"id": "some_id_1",
+			"provider": "aws_s3",
+			"expression": "true",
+			"enabled": true,
+			"description": "some description",
+			"parameters": {
+				"host": "aws.s3.bucket"
+			}
+	  	},
+		{
+			"id": "some_id_2",
+			"provider": "r2",
+			"expression": "true",
+			"enabled": true,
+			"description": "some description",
+			"parameters": {
+				"host": "r2.hostname"
+			}
+	  	}
+	  ],
+      "success": true,
+      "errors": [],
+      "messages": []
+    }`)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/cloud_connector/rules", handler)
+	toUpdate := []CloudConnectorRule{
+		{
+			Provider:    "aws_s3",
+			Expression:  "true",
+			Enabled:     BoolPtr(true),
+			Description: "some description",
+			Parameters: CloudConnectorRuleParameters{
+				Host: "aws.s3.bucket",
+			},
+		},
+		{
+			Provider:    "r2",
+			Expression:  "true",
+			Enabled:     BoolPtr(true),
+			Description: "some description",
+			Parameters: CloudConnectorRuleParameters{
+				Host: "r2.hostname",
+			},
+		},
+	}
+	want := []CloudConnectorRule{
+		{
+			ID:          "some_id_1",
+			Provider:    "aws_s3",
+			Expression:  "true",
+			Enabled:     BoolPtr(true),
+			Description: "some description",
+			Parameters: CloudConnectorRuleParameters{
+				Host: "aws.s3.bucket",
+			},
+		},
+		{
+			ID:          "some_id_2",
+			Provider:    "r2",
+			Expression:  "true",
+			Enabled:     BoolPtr(true),
+			Description: "some description",
+			Parameters: CloudConnectorRuleParameters{
+				Host: "r2.hostname",
+			},
+		},
+	}
+	zoneActual, err := client.UpdateZoneCloudConnectorRules(context.Background(), ZoneIdentifier(testZoneID), toUpdate)
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, zoneActual)
+	}
+}


### PR DESCRIPTION
FL Team: new product CloudConnector designed to create rules similar to ERE rules for connecting cloud providers for a zone.
Supports: GET and PUT methods.