### PR TITLE
GIN-341: add certificate setting to teams gateway account gateway configuration

### DIFF
--- a/.changelog/2713.txt
+++ b/.changelog/2713.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+teams: added per account certificate setting to teams gateway configuration
+```

--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -47,6 +47,7 @@ type TeamsAccountSettings struct {
 	BodyScanning          *TeamsBodyScanning          `json:"body_scanning,omitempty"`
 	ExtendedEmailMatching *TeamsExtendedEmailMatching `json:"extended_email_matching,omitempty"`
 	CustomCertificate     *TeamsCustomCertificate     `json:"custom_certificate,omitempty"`
+	Certificate           *TeamsCertificate           `json:"certificate,omitempty"`
 }
 
 type BrowserIsolation struct {
@@ -110,6 +111,10 @@ type TeamsCustomCertificate struct {
 	BindingStatus string     `json:"binding_status,omitempty"`
 	QsPackId      string     `json:"qs_pack_id,omitempty"`
 	UpdatedAt     *time.Time `json:"updated_at,omitempty"`
+}
+
+type TeamsCertificate struct {
+	ID string `json:"id"`
 }
 
 type TeamsRuleType = string

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -93,6 +93,9 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 					},
 					"extended_email_matching": {
 						"enabled": true
+					},
+					"certificate": {
+						"id": "7559a944-3dd7-41bf-b183-360a814a8c36"
 					}
 				}
 			}
@@ -137,6 +140,9 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 			},
 			ExtendedEmailMatching: &TeamsExtendedEmailMatching{
 				Enabled: BoolPtr(true),
+			},
+			Certificate: &TeamsCertificate{
+				ID: "7559a944-3dd7-41bf-b183-360a814a8c36",
 			},
 		})
 	}


### PR DESCRIPTION
## Description

This new `certificate` setting specifies the certificate used for Gateway TLS interception. It replaces and deprecates the custom certificate setting. 

https://developers.cloudflare.com/api/operations/zero-trust-accounts-get-zero-trust-account-configuration

## Has your change been tested?

Added to unit tests in teams_accounts_test.go

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
