### PR TITLE
Feat/add gateway categories

### DIFF
--- a/.changelog/2722.txt
+++ b/.changelog/2722.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-gateway: add ListGatewayCategories which returns all gateway categories.
+gateway_categories: add ListGatewayCategories which returns all gateway categories.
 ```

--- a/.changelog/2722.txt
+++ b/.changelog/2722.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+gateway: add ListGatewayCategories which returns all gateway categories.
+```

--- a/gateway_categories.go
+++ b/gateway_categories.go
@@ -10,7 +10,7 @@ import (
 
 // GatewayCategory represents a single gateway category.
 type GatewayCategory struct {
-	Beta          bool              `json:"beta"`
+	Beta          *bool             `json:"beta,omitempty"`
 	Class         string            `json:"class"`
 	Description   string            `json:"description"`
 	ID            int               `json:"id"`
@@ -36,8 +36,8 @@ type ListGatewayCategoriesParams struct {
 // ListGatewayCategories returns all gateway categories within an account.
 //
 // API reference: https://developers.cloudflare.com/api/operations/zero-trust-gateway-categories-list-categories
-func (api *API) ListGatewayCategories(ctx context.Context, accountID string, params ListGatewayCategoriesParams) ([]GatewayCategory, ResultInfo, error) {
-	uri := fmt.Sprintf("/accounts/%s/gateway/categories", accountID)
+func (api *API) ListGatewayCategories(ctx context.Context, rc *ResourceContainer, params ListGatewayCategoriesParams) ([]GatewayCategory, ResultInfo, error) {
+	uri := fmt.Sprintf("/accounts/%s/gateway/categories", rc.Identifier)
 
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {

--- a/gateway_categories.go
+++ b/gateway_categories.go
@@ -1,0 +1,54 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/goccy/go-json"
+)
+
+// GatewayCategory represents a single gateway category.
+type GatewayCategory struct {
+	Beta          bool              `json:"beta"`
+	Class         string            `json:"class"`
+	Description   string            `json:"description"`
+	ID            int               `json:"id"`
+	Name          string            `json:"name"`
+	Subcategories []GatewayCategory `json:"subcategories"`
+}
+
+// GatewayCategoriesResponse represents the response from the list
+// gateway categories endpoint.
+type GatewayCategoriesResponse struct {
+	Success    bool              `json:"success"`
+	Result     []GatewayCategory `json:"result"`
+	Errors     []string          `json:"errors"`
+	Messages   []string          `json:"messages"`
+	ResultInfo ResultInfo        `json:"result_info"`
+}
+
+// ListGatewayCategoriesParams represents the parameters for listing gateway categories.
+type ListGatewayCategoriesParams struct {
+	ResultInfo
+}
+
+// ListGatewayCategories returns all gateway categories within an account.
+//
+// API reference: https://developers.cloudflare.com/api/operations/zero-trust-gateway-categories-list-categories
+func (api *API) ListGatewayCategories(ctx context.Context, accountID string, params ListGatewayCategoriesParams) ([]GatewayCategory, ResultInfo, error) {
+	uri := fmt.Sprintf("/accounts/%s/gateway/categories", accountID)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []GatewayCategory{}, ResultInfo{}, err
+	}
+
+	var gResponse GatewayCategoriesResponse
+	err = json.Unmarshal(res, &gResponse)
+	if err != nil {
+		return []GatewayCategory{}, ResultInfo{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return gResponse.Result, gResponse.ResultInfo, nil
+}

--- a/gateway_categories_test.go
+++ b/gateway_categories_test.go
@@ -47,18 +47,16 @@ func TestListGatewayCategories(t *testing.T) {
 		}`)
 	}
 
-	falseValue := false
-	trueValue := true
 	want := []GatewayCategory{
 		{
-			Beta:        &falseValue,
+			Beta:        BoolPtr(false),
 			Class:       "premium",
 			Description: "Sites related to educational content.",
 			ID:          0,
 			Name:        "Education",
 			Subcategories: []GatewayCategory{
 				{
-					Beta:        &trueValue,
+					Beta:        BoolPtr(true),
 					Class:       "premium",
 					Description: "Sites related to educational content.",
 					ID:          0,
@@ -70,12 +68,7 @@ func TestListGatewayCategories(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/categories", handler)
 
-	rc := &ResourceContainer{
-		Level:      AccountRouteLevel,
-		Identifier: testAccountID,
-	}
-
-	actual, _, err := client.ListGatewayCategories(context.Background(), rc, ListGatewayCategoriesParams{})
+	actual, _, err := client.ListGatewayCategories(context.Background(), AccountIdentifier(testAccountID), ListGatewayCategoriesParams{})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/gateway_categories_test.go
+++ b/gateway_categories_test.go
@@ -29,10 +29,10 @@ func TestListGatewayCategories(t *testing.T) {
 					"name": "Education",
 					"subcategories": [
 						{
-							"beta": false,
+							"beta": true,
 							"class": "premium",
 							"description": "Sites related to educational content.",
-							"id": 10,
+							"id": 0,
 							"name": "Education"
 						}
 					]
@@ -47,19 +47,21 @@ func TestListGatewayCategories(t *testing.T) {
 		}`)
 	}
 
+	falseValue := false
+	trueValue := true
 	want := []GatewayCategory{
 		{
-			Beta:        false,
+			Beta:        &falseValue,
 			Class:       "premium",
 			Description: "Sites related to educational content.",
 			ID:          0,
 			Name:        "Education",
 			Subcategories: []GatewayCategory{
 				{
-					Beta:        false,
+					Beta:        &trueValue,
 					Class:       "premium",
 					Description: "Sites related to educational content.",
-					ID:          10,
+					ID:          0,
 					Name:        "Education",
 				},
 			},
@@ -68,7 +70,12 @@ func TestListGatewayCategories(t *testing.T) {
 
 	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/categories", handler)
 
-	actual, _, err := client.ListGatewayCategories(context.Background(), testAccountID, ListGatewayCategoriesParams{})
+	rc := &ResourceContainer{
+		Level:      AccountRouteLevel,
+		Identifier: testAccountID,
+	}
+
+	actual, _, err := client.ListGatewayCategories(context.Background(), rc, ListGatewayCategoriesParams{})
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, want, actual)

--- a/gateway_categories_test.go
+++ b/gateway_categories_test.go
@@ -1,0 +1,76 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListGatewayCategories(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": [
+				{
+					"beta": false,
+					"class": "premium",
+					"description": "Sites related to educational content.",
+					"id": 0,
+					"name": "Education",
+					"subcategories": [
+						{
+							"beta": false,
+							"class": "premium",
+							"description": "Sites related to educational content.",
+							"id": 10,
+							"name": "Education"
+						}
+					]
+				}
+			],
+			"result_info": {
+				"count": 1,
+				"page": 1,
+				"per_page": 20,
+				"total_count": 2000
+			}
+		}`)
+	}
+
+	want := []GatewayCategory{
+		{
+			Beta:        false,
+			Class:       "premium",
+			Description: "Sites related to educational content.",
+			ID:          0,
+			Name:        "Education",
+			Subcategories: []GatewayCategory{
+				{
+					Beta:        false,
+					Class:       "premium",
+					Description: "Sites related to educational content.",
+					ID:          10,
+					Name:        "Education",
+				},
+			},
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/categories", handler)
+
+	actual, _, err := client.ListGatewayCategories(context.Background(), testAccountID, ListGatewayCategoriesParams{})
+
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}


### PR DESCRIPTION
This pull request adds support for the `ListGatewayCategories` endpoint.

## Description
Our main driver is that we are looking into have this data available as a data resource in the terraform provider, please let me know if this is the right direction.

## Has your change been tested?

besides the test case I created [this script](https://gist.github.com/brennoo/e3e04bf76cebe1ccdbfe5b550627204a) and the output seems correct

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
