### PR TITLE
zones skips the first result if not paging

### DIFF
--- a/zones.go
+++ b/zones.go
@@ -92,6 +92,7 @@ func (s *ZonesService) List(ctx context.Context, params *ZoneListParams) ([]Zone
 		var zones []Zone
 		params.PerPage = defaultZonesPerPage
 		params.Page = 1
+		zones = append(zones, r.Result...)
 		for !params.ResultInfo.Done() {
 			res, _ := s.client.get(ctx, buildURI("/zones", params), nil)
 


### PR DESCRIPTION
The zones API call skips the initial result if used with no paging.

## Description

I miss the initial zones.

## Has your change been tested?

I'm too lazy to start a zones_test.go -- but a regression would be nice. 

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
