### PR TITLE
DLP-1890: add support for Risk Score Integrations

### DIFF
--- a/.changelog/2786.txt
+++ b/.changelog/2786.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+risk_score_integration: Add support for Risk Score Integrations
+```

--- a/zt_risk_score_integration.go
+++ b/zt_risk_score_integration.go
@@ -1,0 +1,180 @@
+package cloudflare
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/goccy/go-json"
+)
+
+var (
+	ErrMissingRiskScoreIntegrationID = errors.New("missing required Risk Score Integration UUID")
+)
+
+// Represents a Risk Score Sharing Integration.
+// If enabled, Cloudflare will share changes in user risk score with the specified vendor.
+type RiskScoreIntegration struct {
+	ID              string     `json:"id,omitempty"`
+	IntegrationType string     `json:"integration_type,omitempty"`
+	TenantUrl       string     `json:"tenant_url,omitempty"`
+	ReferenceID     string     `json:"reference_id,omitempty"`
+	AccountTag      string     `json:"account_tag,omitempty"`
+	WellKnownUrl    string     `json:"well_known_url,omitempty"`
+	Active          *bool      `json:"active,omitempty"`
+	CreatedAt       *time.Time `json:"created_at,omitempty"`
+}
+
+// The properties required to create a new risk score integration
+type RiskScoreIntegrationCreateRequest struct {
+	IntegrationType string `json:"integration_type,omitempty"`
+	TenantUrl       string `json:"tenant_url,omitempty"`
+	ReferenceID     string `json:"reference_id,omitempty"`
+}
+
+// The properties required to update a risk score integration
+type RiskScoreIntegrationUpdateRequest struct {
+	IntegrationType string `json:"integration_type,omitempty"`
+	TenantUrl       string `json:"tenant_url,omitempty"`
+	ReferenceID     string `json:"reference_id,omitempty"`
+	Active          *bool  `json:"active,omitempty"`
+}
+
+// A list of risk score integrations as returned from the API.
+type RiskScoreIntegrationListResponse struct {
+	Result []RiskScoreIntegration `json:"result"`
+	Response
+}
+
+// A risk score integration as returned from the API.
+type RiskScoreIntegrationResponse struct {
+	Result RiskScoreIntegration `json:"result"`
+	Response
+}
+
+type ListRiskScoreIntegrationParams struct{}
+
+// GetRiskScoreIntegration returns a single Risk Score Integration by its ID.
+//
+// API reference: https://developers.cloudflare.com/api/operations/dlp-zt-risk-score-integration-get
+func (api *API) GetRiskScoreIntegration(ctx context.Context, rc *ResourceContainer, integrationID string) (RiskScoreIntegration, error) {
+	if rc.Identifier == "" {
+		return RiskScoreIntegration{}, ErrMissingResourceIdentifier
+	}
+
+	if integrationID == "" {
+		return RiskScoreIntegration{}, ErrMissingRiskScoreIntegrationID
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/zt_risk_scoring/integrations/%s", rc.Level, rc.Identifier, integrationID), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return RiskScoreIntegration{}, err
+	}
+
+	var integrationResponse RiskScoreIntegrationResponse
+	err = json.Unmarshal(res, &integrationResponse)
+	if err != nil {
+		return RiskScoreIntegration{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return integrationResponse.Result, nil
+}
+
+// ListRiskScoreIntegrations returns all Risk Score Integrations for an account.
+//
+// API reference: https://developers.cloudflare.com/api/operations/dlp-zt-risk-score-integration-list
+func (api *API) ListRiskScoreIntegrations(ctx context.Context, rc *ResourceContainer, params ListRiskScoreIntegrationParams) ([]RiskScoreIntegration, error) {
+	if rc.Identifier == "" {
+		return []RiskScoreIntegration{}, ErrMissingResourceIdentifier
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/zt_risk_scoring/integrations", rc.Level, rc.Identifier), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return []RiskScoreIntegration{}, err
+	}
+
+	var integrationsResponse RiskScoreIntegrationListResponse
+	err = json.Unmarshal(res, &integrationsResponse)
+	if err != nil {
+		return []RiskScoreIntegration{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return integrationsResponse.Result, nil
+}
+
+// CreateRiskScoreIntegration creates a new Risk Score Integration.
+//
+// API reference: https://developers.cloudflare.com/api/operations/dlp-zt-risk-score-integration-create
+func (api *API) CreateRiskScoreIntegration(ctx context.Context, rc *ResourceContainer, params RiskScoreIntegrationCreateRequest) (RiskScoreIntegration, error) {
+	if rc.Identifier == "" {
+		return RiskScoreIntegration{}, ErrMissingResourceIdentifier
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/zt_risk_scoring/integrations", rc.Level, rc.Identifier), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPost, uri, params)
+	if err != nil {
+		return RiskScoreIntegration{}, err
+	}
+
+	var integrationResponse RiskScoreIntegrationResponse
+	err = json.Unmarshal(res, &integrationResponse)
+	if err != nil {
+		return RiskScoreIntegration{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return integrationResponse.Result, nil
+}
+
+// UpdateRiskScoreIntegration updates a Risk Score Integration.
+//
+// Can be used to disable or active the integration using the "active" boolean property.
+// API reference: https://developers.cloudflare.com/api/operations/dlp-zt-risk-score-integration-update
+func (api *API) UpdateRiskScoreIntegration(ctx context.Context, rc *ResourceContainer, integrationID string, params RiskScoreIntegrationUpdateRequest) (RiskScoreIntegration, error) {
+	if rc.Identifier == "" {
+		return RiskScoreIntegration{}, ErrMissingResourceIdentifier
+	}
+
+	if integrationID == "" {
+		return RiskScoreIntegration{}, ErrMissingRiskScoreIntegrationID
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/zt_risk_scoring/integrations/%s", rc.Level, rc.Identifier, integrationID), nil)
+
+	res, err := api.makeRequestContext(ctx, http.MethodPut, uri, params)
+	if err != nil {
+		return RiskScoreIntegration{}, err
+	}
+
+	var integrationResponse RiskScoreIntegrationResponse
+	err = json.Unmarshal(res, &integrationResponse)
+	if err != nil {
+		return RiskScoreIntegration{}, fmt.Errorf("%s: %w", errUnmarshalError, err)
+	}
+
+	return integrationResponse.Result, nil
+}
+
+// DeleteRiskScoreIntegration deletes a Risk Score Integration.
+//
+// API reference: https://developers.cloudflare.com/api/operations/dlp-zt-risk-score-integration-delete
+func (api *API) DeleteRiskScoreIntegration(ctx context.Context, rc *ResourceContainer, integrationID string) error {
+	if rc.Identifier == "" {
+		return ErrMissingResourceIdentifier
+	}
+
+	if integrationID == "" {
+		return ErrMissingRiskScoreIntegrationID
+	}
+
+	uri := buildURI(fmt.Sprintf("/%s/%s/zt_risk_scoring/integrations/%s", rc.Level, rc.Identifier, integrationID), nil)
+
+	_, err := api.makeRequestContext(ctx, http.MethodDelete, uri, nil)
+	return err
+}

--- a/zt_risk_score_integration.go
+++ b/zt_risk_score_integration.go
@@ -27,14 +27,14 @@ type RiskScoreIntegration struct {
 	CreatedAt       *time.Time `json:"created_at,omitempty"`
 }
 
-// The properties required to create a new risk score integration
+// The properties required to create a new risk score integration.
 type RiskScoreIntegrationCreateRequest struct {
 	IntegrationType string `json:"integration_type,omitempty"`
 	TenantUrl       string `json:"tenant_url,omitempty"`
 	ReferenceID     string `json:"reference_id,omitempty"`
 }
 
-// The properties required to update a risk score integration
+// The properties required to update a risk score integration.
 type RiskScoreIntegrationUpdateRequest struct {
 	IntegrationType string `json:"integration_type,omitempty"`
 	TenantUrl       string `json:"tenant_url,omitempty"`

--- a/zt_risk_score_integration_test.go
+++ b/zt_risk_score_integration_test.go
@@ -1,0 +1,259 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRiskScoreIntegrations(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `
+		{
+			"result": [
+				{
+					"id": "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+					"account_tag": "f772f54476db1178347e5bfba3c9ac83",
+					"integration_type": "Okta",
+					"reference_id": "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+					"tenant_url": "https://my-tenant.oktapreview.com",
+					"well_known_url": "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+					"active": true,
+					"created_at": "2024-06-13T18:17:22Z"
+				},
+				{
+					"id": "0d5e7916-0b18-4a22-839f-b82e33a87843",
+					"account_tag": "f772f54476db1178347e5bfba3c9ac83",
+					"integration_type": "Okta",
+					"reference_id": "d77c9506-00bc-43aa-8e95-3223351ea330",
+					"tenant_url": "https://my-tenant-2.oktapreview.com",
+					"well_known_url": "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/0d5e7916-0b18-4a22-839f-b82e33a87843",
+					"active": false,
+					"created_at": "2024-06-13T18:17:22Z"
+				}
+			],
+			"success": true,
+			"errors": [],
+			"messages": []
+		}
+		`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2024-06-13T18:17:22Z")
+
+	want := []RiskScoreIntegration{
+		{
+			ID:              "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+			AccountTag:      "f772f54476db1178347e5bfba3c9ac83",
+			IntegrationType: "Okta",
+			ReferenceID:     "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+			TenantUrl:       "https://my-tenant.oktapreview.com",
+			WellKnownUrl:    "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+			Active:          BoolPtr(true),
+			CreatedAt:       &createdAt,
+		},
+		{
+			ID:              "0d5e7916-0b18-4a22-839f-b82e33a87843",
+			AccountTag:      "f772f54476db1178347e5bfba3c9ac83",
+			IntegrationType: "Okta",
+			ReferenceID:     "d77c9506-00bc-43aa-8e95-3223351ea330",
+			TenantUrl:       "https://my-tenant-2.oktapreview.com",
+			WellKnownUrl:    "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/0d5e7916-0b18-4a22-839f-b82e33a87843",
+			Active:          BoolPtr(false),
+			CreatedAt:       &createdAt,
+		},
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/zt_risk_scoring/integrations", handler)
+
+	actual, err := client.ListRiskScoreIntegrations(context.Background(), AccountIdentifier(testAccountID), ListRiskScoreIntegrationParams{})
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestGetRiskScoreIntegration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+				"account_tag": "f772f54476db1178347e5bfba3c9ac83",
+				"integration_type": "Okta",
+				"reference_id": "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+				"tenant_url": "https://my-tenant.oktapreview.com",
+				"well_known_url": "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+				"active": true,
+				"created_at": "2024-06-13T18:17:22Z"
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2024-06-13T18:17:22Z")
+
+	want := RiskScoreIntegration{
+		ID:              "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+		AccountTag:      "f772f54476db1178347e5bfba3c9ac83",
+		IntegrationType: "Okta",
+		ReferenceID:     "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+		TenantUrl:       "https://my-tenant.oktapreview.com",
+		WellKnownUrl:    "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+		Active:          BoolPtr(true),
+		CreatedAt:       &createdAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/zt_risk_scoring/integrations/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9", handler)
+
+	actual, err := client.GetRiskScoreIntegration(context.Background(), AccountIdentifier(testAccountID), "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9")
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestCreateRiskScoreIntegration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+
+		var reqBody RiskScoreIntegrationCreateRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.Nil(t, err)
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+				"account_tag": "f772f54476db1178347e5bfba3c9ac83",
+				"integration_type": "`+reqBody.IntegrationType+`",
+				"reference_id": "`+reqBody.ReferenceID+`",
+				"tenant_url": "`+reqBody.TenantUrl+`",
+				"well_known_url": "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+				"active": true,
+				"created_at": "2024-06-13T18:17:22Z"
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2024-06-13T18:17:22Z")
+
+	want := RiskScoreIntegration{
+		ID:              "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+		AccountTag:      "f772f54476db1178347e5bfba3c9ac83",
+		IntegrationType: "Okta",
+		ReferenceID:     "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+		TenantUrl:       "https://my-tenant.oktapreview.com",
+		WellKnownUrl:    "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+		Active:          BoolPtr(true),
+		CreatedAt:       &createdAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/zt_risk_scoring/integrations", handler)
+
+	integration := RiskScoreIntegrationCreateRequest{
+		IntegrationType: "Okta",
+		TenantUrl:       "https://my-tenant.oktapreview.com",
+		ReferenceID:     "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+	}
+	actual, err := client.CreateRiskScoreIntegration(context.Background(), AccountIdentifier(testAccountID), integration)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestUpdateRiskScoreIntegration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+
+		var reqBody RiskScoreIntegrationUpdateRequest
+		err := json.NewDecoder(r.Body).Decode(&reqBody)
+		require.Nil(t, err)
+
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {
+				"id": "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+				"account_tag": "f772f54476db1178347e5bfba3c9ac83",
+				"integration_type": "`+reqBody.IntegrationType+`",
+				"reference_id": "`+reqBody.ReferenceID+`",
+				"tenant_url": "`+reqBody.TenantUrl+`",
+				"well_known_url": "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+				"active": `+strconv.FormatBool(*reqBody.Active)+`,
+				"created_at": "2024-06-13T18:17:22Z"
+			}
+		}`)
+	}
+
+	createdAt, _ := time.Parse(time.RFC3339, "2024-06-13T18:17:22Z")
+
+	want := RiskScoreIntegration{
+		ID:              "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+		AccountTag:      "f772f54476db1178347e5bfba3c9ac83",
+		IntegrationType: "Okta",
+		ReferenceID:     "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+		TenantUrl:       "https://my-tenant.oktapreview.com",
+		WellKnownUrl:    "https://ssf.risk-score.teams.cloudflare.com/.well-known/sse-configuration/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9",
+		Active:          BoolPtr(false),
+		CreatedAt:       &createdAt,
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/zt_risk_scoring/integrations/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9", handler)
+
+	integration := RiskScoreIntegrationUpdateRequest{
+		IntegrationType: "Okta",
+		TenantUrl:       "https://my-tenant.oktapreview.com",
+		ReferenceID:     "72f826ea-8744-4dcb-a00e-8cc00bb6d34b",
+		Active:          BoolPtr(false),
+	}
+
+	actual, err := client.UpdateRiskScoreIntegration(context.Background(), AccountIdentifier(testAccountID), "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9", integration)
+	require.NoError(t, err)
+	require.Equal(t, want, actual)
+}
+
+func TestDeleteRiskScoreIntegration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method, "Expected method 'DELETE', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"result": null,
+			"success": true,
+			"errors": [],
+			"messages": []
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/zt_risk_scoring/integrations/91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9", handler)
+
+	err := client.DeleteRiskScoreIntegration(context.Background(), AccountIdentifier(testAccountID), "91dbf25d-2b51-415e-a6df-5a6d2ff4f7e9")
+	require.NoError(t, err)
+}


### PR DESCRIPTION
https://developers.cloudflare.com/api/operations/dlp-zt-risk-score-integration-create

## Description

Adds support for the Risk Score Integrations API to the CF Go library.

## Has your change been tested?

Unit tests. Have also tested these changes alongside my terraform-provider-cloudflare changes to check it works.

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
