### PR TITLE
fix: enable removing access application custom attributes and claims

### DIFF
--- a/.changelog/2838.txt
+++ b/.changelog/2838.txt
@@ -1,0 +1,3 @@
+```release-notes:bug
+access_application: enable removing access application custom attributes and claims
+```

--- a/access_application.go
+++ b/access_application.go
@@ -224,15 +224,15 @@ type SaasApplication struct {
 	AuthType  string     `json:"auth_type,omitempty"`
 
 	// SAML saas app
-	ConsumerServiceUrl            string                `json:"consumer_service_url,omitempty"`
-	SPEntityID                    string                `json:"sp_entity_id,omitempty"`
-	IDPEntityID                   string                `json:"idp_entity_id,omitempty"`
-	NameIDFormat                  string                `json:"name_id_format,omitempty"`
-	SSOEndpoint                   string                `json:"sso_endpoint,omitempty"`
-	DefaultRelayState             string                `json:"default_relay_state,omitempty"`
-	CustomAttributes              []SAMLAttributeConfig `json:"custom_attributes,omitempty"`
-	NameIDTransformJsonata        string                `json:"name_id_transform_jsonata,omitempty"`
-	SamlAttributeTransformJsonata string                `json:"saml_attribute_transform_jsonata"`
+	ConsumerServiceUrl            string                 `json:"consumer_service_url,omitempty"`
+	SPEntityID                    string                 `json:"sp_entity_id,omitempty"`
+	IDPEntityID                   string                 `json:"idp_entity_id,omitempty"`
+	NameIDFormat                  string                 `json:"name_id_format,omitempty"`
+	SSOEndpoint                   string                 `json:"sso_endpoint,omitempty"`
+	DefaultRelayState             string                 `json:"default_relay_state,omitempty"`
+	CustomAttributes              *[]SAMLAttributeConfig `json:"custom_attributes"`
+	NameIDTransformJsonata        string                 `json:"name_id_transform_jsonata,omitempty"`
+	SamlAttributeTransformJsonata string                 `json:"saml_attribute_transform_jsonata"`
 
 	// OIDC saas app
 	ClientID                     string                                     `json:"client_id,omitempty"`
@@ -242,7 +242,7 @@ type SaasApplication struct {
 	Scopes                       []string                                   `json:"scopes,omitempty"`
 	AppLauncherURL               string                                     `json:"app_launcher_url,omitempty"`
 	GroupFilterRegex             string                                     `json:"group_filter_regex,omitempty"`
-	CustomClaims                 []OIDCClaimConfig                          `json:"custom_claims,omitempty"`
+	CustomClaims                 *[]OIDCClaimConfig                         `json:"custom_claims"`
 	AllowPKCEWithoutClientSecret *bool                                      `json:"allow_pkce_without_client_secret,omitempty"`
 	RefreshTokenOptions          *RefreshTokenOptions                       `json:"refresh_token_options,omitempty"`
 	HybridAndImplicitOptions     *AccessApplicationHybridAndImplicitOptions `json:"hybrid_and_implicit_options,omitempty"`

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -1011,7 +1011,7 @@ func TestCreateSAMLSaasAccessApplications(t *testing.T) {
 			SPEntityID:         "dash.example.com",
 			NameIDFormat:       "id",
 			DefaultRelayState:  "https://saas.example.com",
-			CustomAttributes: []SAMLAttributeConfig{
+			CustomAttributes: &[]SAMLAttributeConfig{
 				{
 					Name:       "test1",
 					NameFormat: "urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified",
@@ -1166,7 +1166,7 @@ func TestCreateOIDCSaasAccessApplications(t *testing.T) {
 			AppLauncherURL:               "https://saas.example.com",
 			GroupFilterRegex:             ".*",
 			AllowPKCEWithoutClientSecret: BoolPtr(false),
-			CustomClaims: []OIDCClaimConfig{
+			CustomClaims: &[]OIDCClaimConfig{
 				{
 					Name:     "test1",
 					Source:   SourceConfig{Name: "test1"},
@@ -1197,7 +1197,7 @@ func TestCreateOIDCSaasAccessApplications(t *testing.T) {
 			AppLauncherURL:               "https://saas.example.com",
 			GroupFilterRegex:             ".*",
 			AllowPKCEWithoutClientSecret: BoolPtr(false),
-			CustomClaims: []OIDCClaimConfig{
+			CustomClaims: &[]OIDCClaimConfig{
 				{
 					Name:     "test1",
 					Source:   SourceConfig{Name: "test1"},
@@ -1229,7 +1229,7 @@ func TestCreateOIDCSaasAccessApplications(t *testing.T) {
 			AppLauncherURL:               "https://saas.example.com",
 			GroupFilterRegex:             ".*",
 			AllowPKCEWithoutClientSecret: BoolPtr(false),
-			CustomClaims: []OIDCClaimConfig{
+			CustomClaims: &[]OIDCClaimConfig{
 				{
 					Name:     "test1",
 					Source:   SourceConfig{Name: "test1"},


### PR DESCRIPTION
Removes the `omitempty` on Access application custom attributes. This allows an empty list to be passed to remove empty attributes, which would have otherwise been omitted.

closes #2837

## Description

Removes the `omitempty` on Access application custom attributes.

## Has your change been tested?

Using the script in #2837

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
