### PR TITLE
implement the Unwrap method for custom error types

### DIFF
--- a/.changelog/2857.txt
+++ b/.changelog/2857.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+errors: implement the Unwrap method for custom error types to access the wrapped errors via errors.Is and errors.As
+```

--- a/errors.go
+++ b/errors.go
@@ -152,6 +152,10 @@ func (e RequestError) Type() ErrorType {
 	return e.cloudflareError.Type
 }
 
+func (e RequestError) Unwrap() error {
+	return e.cloudflareError
+}
+
 func NewRequestError(e *Error) RequestError {
 	return RequestError{
 		cloudflareError: e,
@@ -190,6 +194,10 @@ func (e RatelimitError) RayID() string {
 
 func (e RatelimitError) Type() ErrorType {
 	return e.cloudflareError.Type
+}
+
+func (e RatelimitError) Unwrap() error {
+	return e.cloudflareError
 }
 
 func NewRatelimitError(e *Error) RatelimitError {
@@ -231,6 +239,10 @@ func (e ServiceError) Type() ErrorType {
 	return e.cloudflareError.Type
 }
 
+func (e ServiceError) Unwrap() error {
+	return e.cloudflareError
+}
+
 func NewServiceError(e *Error) ServiceError {
 	return ServiceError{
 		cloudflareError: e,
@@ -268,6 +280,10 @@ func (e AuthenticationError) RayID() string {
 
 func (e AuthenticationError) Type() ErrorType {
 	return e.cloudflareError.Type
+}
+
+func (e AuthenticationError) Unwrap() error {
+	return e.cloudflareError
 }
 
 func NewAuthenticationError(e *Error) AuthenticationError {
@@ -309,6 +325,10 @@ func (e AuthorizationError) Type() ErrorType {
 	return e.cloudflareError.Type
 }
 
+func (e AuthorizationError) Unwrap() error {
+	return e.cloudflareError
+}
+
 func NewAuthorizationError(e *Error) AuthorizationError {
 	return AuthorizationError{
 		cloudflareError: e,
@@ -346,6 +366,10 @@ func (e NotFoundError) RayID() string {
 
 func (e NotFoundError) Type() ErrorType {
 	return e.cloudflareError.Type
+}
+
+func (e NotFoundError) Unwrap() error {
+	return e.cloudflareError
 }
 
 func NewNotFoundError(e *Error) NotFoundError {


### PR DESCRIPTION
## Description

Since the introduction of error wrapping in Go 1.13, more and more Go errors implement the `Unwrap` method to work with the new error checking paradigm using `errors.{Is,As}`. This PR is to implement such an `Unwrap` method for custom error types defined in this library that wrap around a private `Error`. By implementing `Unwrap` that returns the private `Error`, these custom errors will be automatically seen by the Go standard library as wrappers of the private `Error`. Here's some sample code enabled by this PR:

```go
var cloudflareErr cloudflare.Error
if errors.As(err, &cloudflareErr) {
	fmt.Printf("HTTP status code: %d", cloudflareErr.StatusCode)
}
```

This is extremely useful when trying to distinguish "errors from the Cloudflare API itself" and "errors due to other reasons (e.g., network errors)". Also, for reasons, only `cloudflare.Error` implements the `ErrorMessageContains` method. In sum, the `Unwrap` function gives users a clean interface to retrieve the private `Error` that works very well with the current Go standard library.

## Has your change been tested?

Not yet. I'm worried a test involving `errors.As` would not run on platforms using older Go compilers.

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.