### PR TITLE
add waiting_room enabled_origin_commands support

### DIFF
--- a/.changelog/2931.txt
+++ b/.changelog/2931.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+waiting_room: add support for `enabled_origin_commands`
+```

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -39,7 +39,7 @@ type WaitingRoom struct {
 	CookieSuffix               string              `json:"cookie_suffix"`
 	AdditionalRoutes           []*WaitingRoomRoute `json:"additional_routes,omitempty"`
 	QueueingStatusCode         int                 `json:"queueing_status_code"`
-	EnabledOriginCommands      []string            `json:"enabled_origin_commands"`
+	EnabledOriginCommands      []string            `json:"enabled_origin_commands,omitempty"`
 }
 
 // WaitingRoomStatus describes the status of a waiting room.

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -39,6 +39,7 @@ type WaitingRoom struct {
 	CookieSuffix               string              `json:"cookie_suffix"`
 	AdditionalRoutes           []*WaitingRoomRoute `json:"additional_routes,omitempty"`
 	QueueingStatusCode         int                 `json:"queueing_status_code"`
+	EnabledOriginCommands      []string            `json:"enabled_origin_commands"`
 }
 
 // WaitingRoomStatus describes the status of a waiting room.

--- a/waiting_room_test.go
+++ b/waiting_room_test.go
@@ -40,9 +40,10 @@ var waitingRoomJSON = fmt.Sprintf(`
       "default_template_language": "en-US",
       "next_event_prequeue_start_time": null,
       "next_event_start_time": "%s",
-	  "cookie_suffix": "example_shop",
-	  "additional_routes": [{"host": "shop2.example.com", "path": "/shop/checkout"}],
-	  "queueing_status_code": 200
+      "cookie_suffix": "example_shop",
+      "additional_routes": [{"host": "shop2.example.com", "path": "/shop/checkout"}],
+      "queueing_status_code": 200,
+      "enabled_origin_commands": ["revoke"]
     }
    `, waitingRoomID, testTimestampWaitingRoom.Format(time.RFC3339Nano), testTimestampWaitingRoom.Format(time.RFC3339Nano),
 	testTimestampWaitingRoomEventStart.Format(time.RFC3339Nano))
@@ -129,6 +130,7 @@ var waitingRoom = WaitingRoom{
 	CookieSuffix:               "example_shop",
 	AdditionalRoutes:           []*WaitingRoomRoute{{Host: "shop2.example.com", Path: "/shop/checkout"}},
 	QueueingStatusCode:         200,
+	EnabledOriginCommands:      []string{"revoke"},
 }
 
 var waitingRoomEvent = WaitingRoomEvent{


### PR DESCRIPTION
<!-- 
Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points. 
-->

## Description

Add support for the new `enabled_origin_commands` parameter when creating, modifying, and reading a waiting room.

## Has your change been tested?

Updated unit tests, also tested the branch changes using the Cloudflare API.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.
  - https://developers.cloudflare.com/api/operations/waiting-room-create-waiting-room



