### PR TITLE
Adjust Hyperdrive Worker binding to more align with wrangler syntax

### DIFF
--- a/.changelog/2932.txt
+++ b/.changelog/2932.txt
@@ -1,0 +1,3 @@
+```release-notes:enhancement
+worker_bindings: Adjust struct of `hyperdrive` bindings to better align with wrangler.toml syntax
+```

--- a/workers_bindings.go
+++ b/workers_bindings.go
@@ -437,6 +437,7 @@ func (b WorkerD1DatabaseBinding) serialize(bindingName string) (workerBindingMet
 
 // WorkerHyperdriveBinding is a binding to a Hyperdrive config.
 type WorkerHyperdriveBinding struct {
+	Binding  string
 	ConfigID string
 }
 
@@ -446,12 +447,15 @@ func (b WorkerHyperdriveBinding) Type() WorkerBindingType {
 }
 
 func (b WorkerHyperdriveBinding) serialize(bindingName string) (workerBindingMeta, workerBindingBodyWriter, error) {
+	if b.Binding == "" {
+		return nil, nil, fmt.Errorf(`binding name for binding "%s" cannot be empty`, bindingName)
+	}
 	if b.ConfigID == "" {
 		return nil, nil, fmt.Errorf(`config ID for binding "%s" cannot be empty`, bindingName)
 	}
 
 	return workerBindingMeta{
-		"name": bindingName,
+		"name": b.Binding,
 		"type": b.Type(),
 		"id":   b.ConfigID,
 	}, nil, nil
@@ -589,6 +593,7 @@ func (api *API) ListWorkerBindings(ctx context.Context, rc *ResourceContainer, p
 		case WorkerHyperdriveBindingType:
 			id := jsonBinding["id"].(string)
 			bindingListItem.Binding = WorkerHyperdriveBinding{
+				Binding:  name,
 				ConfigID: id,
 			}
 		default:

--- a/workers_bindings_test.go
+++ b/workers_bindings_test.go
@@ -110,6 +110,7 @@ func TestListWorkerBindings(t *testing.T) {
 	assert.Equal(t, res.BindingList[9], WorkerBindingListItem{
 		Name: "MY_HYPERDRIVE",
 		Binding: WorkerHyperdriveBinding{
+			Binding:  "MY_HYPERDRIVE",
 			ConfigID: "aaf4609248cc493cbc8d3e446e38fdfa",
 		},
 	})
@@ -203,6 +204,7 @@ func TestListWorkerBindings_Wfp(t *testing.T) {
 	assert.Equal(t, res.BindingList[9], WorkerBindingListItem{
 		Name: "MY_HYPERDRIVE",
 		Binding: WorkerHyperdriveBinding{
+			Binding:  "MY_HYPERDRIVE",
 			ConfigID: "aaf4609248cc493cbc8d3e446e38fdfa",
 		},
 	})


### PR DESCRIPTION
It works either way, but using "binding" instead of "name" in this API more aligns with our wrangler syntax https://developers.cloudflare.com/hyperdrive/get-started/#4-bind-your-worker-to-hyperdrive

## Description

Very slight adjustment to the Hyperdrive Binding struct to use `Binding` instead of the implicit `name` as the identifier to more align with how users bind Hyperdrive configs to their workers via `wrangler.toml` files.

## Has your change been tested?

Covered by existing test suites.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
