### PR TITLE
add "contains" field to custom cache key

### DIFF
--- a/.changelog/2935.txt
+++ b/.changelog/2935.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-add "contains" field to custom cache key header
+rulesets: add "contains" field to custom cache key header
 ```

--- a/.changelog/2935.txt
+++ b/.changelog/2935.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+add "contains" field to custom cache key header
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -334,7 +334,8 @@ type RulesetRuleActionParametersCustomKey struct {
 
 type RulesetRuleActionParametersCustomKeyHeader struct {
 	RulesetRuleActionParametersCustomKeyFields
-	ExcludeOrigin *bool `json:"exclude_origin,omitempty"`
+	ExcludeOrigin *bool               `json:"exclude_origin,omitempty"`
+	Contains      map[string][]string `json:"contains,omitempty"`
 }
 
 type RulesetRuleActionParametersCustomKeyCookie RulesetRuleActionParametersCustomKeyFields

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -229,7 +229,7 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 					"ignore_query_strings_order":true,
 					"custom_key": {
 						"query_string":{"include":"*"},
-						"header":{"include":["habc","hdef"],"check_presence":["hfizz","hbuzz"],"exclude_origin":true},
+						"header":{"include":["habc","hdef"],"check_presence":["hfizz","hbuzz"],"exclude_origin":true,"contains":{"accept":["image/web", "image/png"]}},
 						"cookie":{"include":["cabc","cdef"],"check_presence":["cfizz","cbuzz"]},
 						"user":{
 							"device_type":true,
@@ -316,6 +316,9 @@ func TestGetRuleset_SetCacheSettings(t *testing.T) {
 							CheckPresence: []string{"hfizz", "hbuzz"},
 						},
 						ExcludeOrigin: BoolPtr(true),
+						Contains: map[string][]string{
+							"accept": {"image/web", "image/png"},
+						},
 					},
 					Cookie: &RulesetRuleActionParametersCustomKeyCookie{
 						Include:       []string{"cabc", "cdef"},


### PR DESCRIPTION
The Cloudflare CDN team has introduced changes to the Cache Rules API so customers can shard cache based on headers they include in the `cache_key.custom_key.header.contains` field of their cache rules. I am working on Terraform support and need this change to go in first.

## Description

This change adds support for a new field. It is required for the Terraform provider support to work.

## Has your change been tested?

Unit tests in this PR.

## Screenshots (if appropriate):

N/a

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
