### PR TITLE
Rename enabled to in use for gateway certificates

### DIFF
--- a/.changelog/2937.txt
+++ b/.changelog/2937.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+GIN-341: renamed enabled to in use for gateway certificates
+```

--- a/.changelog/2937.txt
+++ b/.changelog/2937.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-GIN-341: renamed enabled to in use for gateway certificates
+teams_certificates: renamed `enabled` to `in_use`
 ```

--- a/teams_certificates.go
+++ b/teams_certificates.go
@@ -10,7 +10,7 @@ import (
 )
 
 type TeamsCertificate struct {
-	Enabled       *bool      `json:"enabled"`
+	InUse         *bool      `json:"in_use"`
 	ID            string     `json:"id"`
 	BindingStatus string     `json:"binding_status"`
 	QsPackId      string     `json:"qs_pack_id"`

--- a/teams_certificates_test.go
+++ b/teams_certificates_test.go
@@ -23,7 +23,7 @@ func TestTeamsCertificate(t *testing.T) {
 			"errors": [],
 			"messages": [],
 			"result": {
-				"enabled": false,
+				"in_use": false,
 				"id": "80c8a54e-d55c-46c6-86bb-e8a3c90472f4",
 				"binding_status": "inactive",
 				"qs_pack_id": "00000000-0000-0000-0000-000000000000",
@@ -42,7 +42,7 @@ func TestTeamsCertificate(t *testing.T) {
 	actual, err := client.TeamsCertificate(context.Background(), testAccountID, testCertID)
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, *actual.Enabled, false)
+		assert.Equal(t, *actual.InUse, false)
 		assert.Equal(t, actual.ID, testCertID)
 		assert.Equal(t, actual.BindingStatus, "inactive")
 		assert.Equal(t, actual.Type, "gateway_managed")
@@ -62,7 +62,7 @@ func TestTeamsCertificatesList(t *testing.T) {
 			"messages": [],
 			"result": [
 				{
-					"enabled": false,
+					"in_use": false,
 					"id": "43a36083-987b-4321-95ab-4052771c4e6f",
 					"binding_status": "inactive",
 					"qs_pack_id": "00000000-0000-0000-0000-000000000000",
@@ -73,7 +73,7 @@ func TestTeamsCertificatesList(t *testing.T) {
 					"expires_on": "2122-10-29T16:59:47Z"
 				},
 				{
-					"enabled": false,
+					"in_use": false,
 					"id": "4a9d6ecf-0fdd-4676-818a-ee6b45f17f9b",
 					"binding_status": "inactive",
 					"qs_pack_id": "00000000-0000-0000-0000-000000000000",
@@ -111,7 +111,7 @@ func TestTeamsAccountGenerateCertificate(t *testing.T) {
 			"errors": [],
 			"messages": [],
 			"result": {
-				"enabled": false,
+				"in_use": false,
 				"id": "80c8a54e-d55c-46c6-86bb-e8a3c90472f4",
 				"binding_status": "inactive",
 				"qs_pack_id": "00000000-0000-0000-0000-000000000000",
@@ -149,7 +149,7 @@ func TestTeamsActivateCertificate(t *testing.T) {
 			"errors": [],
 			"messages": [],
 			"result": {
-				"enabled": false,
+				"in_use": false,
 				"id": "80c8a54e-d55c-46c6-86bb-e8a3c90472f4",
 				"binding_status": "pending_deployment",
 				"qs_pack_id": "00000000-0000-0000-0000-000000000000",
@@ -183,7 +183,7 @@ func TestTeamsDeactivateCertificate(t *testing.T) {
 			"errors": [],
 			"messages": [],
 			"result": {
-				"enabled": false,
+				"in_use": false,
 				"id": "80c8a54e-d55c-46c6-86bb-e8a3c90472f4",
 				"binding_status": "pending_deletion",
 				"qs_pack_id": "00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
The `enabled` field for certificates was renamed to `in_use` following Cloudflare style guidelines.

https://developers.cloudflare.com/api/operations/zero-trust-certificates-zero-trust-certificate-details

## Has your change been tested?

Unit tests were updated

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
