### PR TITLE
add support for custom_s2s posture rule

### DIFF
--- a/.changelog/3031.txt
+++ b/.changelog/3031.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+device_posture_rule: add score field for custom_s2s posture rule
+```

--- a/device_posture_rule.go
+++ b/device_posture_rule.go
@@ -203,6 +203,7 @@ type DevicePostureRuleInput struct {
 	ExtendedKeyUsage []string             `json:"extended_key_usage,omitempty"`
 	CheckPrivateKey  *bool                `json:"check_private_key,omitempty"`
 	Locations        CertificateLocations `json:"locations,omitempty"`
+	Score            int                  `json:"score,omitempty"`
 }
 
 // Locations struct for client certificate rule v2.


### PR DESCRIPTION
## Description

Added 'score' field to DevicePostureRuleInput to accommodate needed input for the new posture types: custom_s2s.
(pending documentation)

## Has your change been tested?

Because it is just adding fields to the DevicePostureRuleInput struct, this should not affect existing uses of it. 

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
