### PR TITLE
Added CustomID to UploadImageParams

### DIFF
--- a/images.go
+++ b/images.go
@@ -42,6 +42,7 @@ type UploadImageParams struct {
 	Name              string
 	RequireSignedURLs bool
 	Metadata          map[string]interface{}
+	CustomID          string
 }
 
 // write writes the image upload data to a multipart writer, so
@@ -72,6 +73,13 @@ func (b UploadImageParams) write(mpw *multipart.Writer) error {
 		}
 	}
 
+	if b.CustomID != "" {
+		err := mpw.WriteField("id", b.CustomID)
+		if err != nil {
+			return err
+		}
+	}
+
 	// According to the Cloudflare docs, this field defaults to false.
 	// For simplicity, we will only send it if the value is true, however
 	// if the default is changed to true, this logic will need to be updated.
@@ -81,7 +89,6 @@ func (b UploadImageParams) write(mpw *multipart.Writer) error {
 			return err
 		}
 	}
-
 	if b.Metadata != nil {
 		part, err := mpw.CreateFormField("metadata")
 		if err != nil {


### PR DESCRIPTION
## Description
I added support for `CustomID` when we upload images to Cloudflare images which *I hope* is supported by CF API: https://developers.cloudflare.com/images/upload-images/upload-custom-path/

Please correct me if I'm wrong but Custom ID means that we can select which ID to have for the image right?

## Has your change been tested?
Yes. I tested this in my own app and seems to be working
## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
