### PR TITLE
Add WaitingRoom.CookieAttributes property

### DIFF
--- a/.changelog/3388.txt
+++ b/.changelog/3388.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+waiting_room: Add CookieAttributes property
+```

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -104,7 +104,7 @@ type WaitingRoomRoute struct {
 	Path string `json:"path"`
 }
 
-// WaitingRoomCookieAttributes describes a WaitingRoomCookieAttributes object
+// WaitingRoomCookieAttributes describes a WaitingRoomCookieAttributes object.
 type WaitingRoomCookieAttributes struct {
 	Samesite string `json:"samesite"`
 	Secure   string `json:"secure"`

--- a/waiting_room.go
+++ b/waiting_room.go
@@ -17,29 +17,30 @@ var (
 
 // WaitingRoom describes a WaitingRoom object.
 type WaitingRoom struct {
-	CreatedOn                  time.Time           `json:"created_on,omitempty"`
-	ModifiedOn                 time.Time           `json:"modified_on,omitempty"`
-	Path                       string              `json:"path"`
-	Name                       string              `json:"name"`
-	Description                string              `json:"description,omitempty"`
-	QueueingMethod             string              `json:"queueing_method,omitempty"`
-	CustomPageHTML             string              `json:"custom_page_html,omitempty"`
-	DefaultTemplateLanguage    string              `json:"default_template_language,omitempty"`
-	Host                       string              `json:"host"`
-	ID                         string              `json:"id,omitempty"`
-	NewUsersPerMinute          int                 `json:"new_users_per_minute"`
-	TotalActiveUsers           int                 `json:"total_active_users"`
-	SessionDuration            int                 `json:"session_duration"`
-	QueueAll                   bool                `json:"queue_all"`
-	DisableSessionRenewal      bool                `json:"disable_session_renewal"`
-	Suspended                  bool                `json:"suspended"`
-	JsonResponseEnabled        bool                `json:"json_response_enabled"`
-	NextEventPrequeueStartTime *time.Time          `json:"next_event_prequeue_start_time,omitempty"`
-	NextEventStartTime         *time.Time          `json:"next_event_start_time,omitempty"`
-	CookieSuffix               string              `json:"cookie_suffix"`
-	AdditionalRoutes           []*WaitingRoomRoute `json:"additional_routes,omitempty"`
-	QueueingStatusCode         int                 `json:"queueing_status_code"`
-	EnabledOriginCommands      []string            `json:"enabled_origin_commands,omitempty"`
+	CreatedOn                  time.Time                    `json:"created_on,omitempty"`
+	ModifiedOn                 time.Time                    `json:"modified_on,omitempty"`
+	Path                       string                       `json:"path"`
+	Name                       string                       `json:"name"`
+	Description                string                       `json:"description,omitempty"`
+	QueueingMethod             string                       `json:"queueing_method,omitempty"`
+	CustomPageHTML             string                       `json:"custom_page_html,omitempty"`
+	DefaultTemplateLanguage    string                       `json:"default_template_language,omitempty"`
+	Host                       string                       `json:"host"`
+	ID                         string                       `json:"id,omitempty"`
+	NewUsersPerMinute          int                          `json:"new_users_per_minute"`
+	TotalActiveUsers           int                          `json:"total_active_users"`
+	SessionDuration            int                          `json:"session_duration"`
+	QueueAll                   bool                         `json:"queue_all"`
+	DisableSessionRenewal      bool                         `json:"disable_session_renewal"`
+	Suspended                  bool                         `json:"suspended"`
+	JsonResponseEnabled        bool                         `json:"json_response_enabled"`
+	NextEventPrequeueStartTime *time.Time                   `json:"next_event_prequeue_start_time,omitempty"`
+	NextEventStartTime         *time.Time                   `json:"next_event_start_time,omitempty"`
+	CookieSuffix               string                       `json:"cookie_suffix"`
+	AdditionalRoutes           []*WaitingRoomRoute          `json:"additional_routes,omitempty"`
+	QueueingStatusCode         int                          `json:"queueing_status_code"`
+	EnabledOriginCommands      []string                     `json:"enabled_origin_commands,omitempty"`
+	CookieAttributes           *WaitingRoomCookieAttributes `json:"cookie_attributes,omitempty"`
 }
 
 // WaitingRoomStatus describes the status of a waiting room.
@@ -101,6 +102,12 @@ type WaitingRoomPagePreviewCustomHTML struct {
 type WaitingRoomRoute struct {
 	Host string `json:"host"`
 	Path string `json:"path"`
+}
+
+// WaitingRoomCookieAttributes describes a WaitingRoomCookieAttributes object
+type WaitingRoomCookieAttributes struct {
+	Samesite string `json:"samesite"`
+	Secure   string `json:"secure"`
 }
 
 // WaitingRoomDetailResponse is the API response, containing a single WaitingRoom.


### PR DESCRIPTION
## Description

Add the [`WaitingRoom.CookieAttributes`](https://developers.cloudflare.com/api/operations/waiting-room-create-waiting-room) property.

Note that this property is mentioned in the API docs and in some guidelines (eg [Waiting Room / Additional options / Embed in an iFrame](https://developers.cloudflare.com/waiting-room/additional-options/embed-waiting-room-in-iframe/), but is not available via dash.cloudflare.com (which is mentioned in the iFrame guide).

This property is also supported in the Python and Typescript SDKs.

## Has your change been tested?
I've tested this locally by setting this property do non-default values in the input for the `CreateWaitingRoom()` and `UpdateWaitingRoom()` calls, and then observing that `ListWaitingRooms()` returns the correct values.

I haven't added automated tests, because there is no logic change. All a unit test would prove is that the name of the property can be copy-pasted from the Go tag into a unittest.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
