### PR TITLE
Support schema strictness setting in access application scim mappings

### DIFF
--- a/.changelog/3510.txt
+++ b/.changelog/3510.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-snippets: add support for controlling schema strictness in Access SCIM application provisioning mappings
+access_application: add support for controlling schema strictness in Access SCIM application provisioning mappings
 ```

--- a/.changelog/3510.txt
+++ b/.changelog/3510.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+snippets: add support for controlling schema strictness in Access SCIM application provisioning mappings
+```

--- a/access_application.go
+++ b/access_application.go
@@ -163,6 +163,7 @@ type AccessApplicationScimMapping struct {
 	Filter           string                                  `json:"filter,omitempty"`
 	TransformJsonata string                                  `json:"transform_jsonata,omitempty"`
 	Operations       *AccessApplicationScimMappingOperations `json:"operations,omitempty"`
+	Strictness       string                                  `json:"strictness,omitempty"`
 }
 
 type AccessApplicationScimMappingOperations struct {

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -1418,7 +1418,8 @@ func TestCreateAccessApplicationWithSCIMProvisioning(t *testing.T) {
 								"create": true,
 								"update": true,
 								"delete": true
-							}
+							},
+							"strictness": "passthrough"
 						}
 					]
 				}
@@ -1471,6 +1472,7 @@ func TestCreateAccessApplicationWithSCIMProvisioning(t *testing.T) {
 						Update: BoolPtr(true),
 						Delete: BoolPtr(true),
 					},
+					Strictness: "passthrough",
 				},
 			},
 		},
@@ -1502,6 +1504,7 @@ func TestCreateAccessApplicationWithSCIMProvisioning(t *testing.T) {
 						Update: BoolPtr(true),
 						Delete: BoolPtr(true),
 					},
+					Strictness: "strict",
 				},
 			},
 		},
@@ -1537,6 +1540,7 @@ func TestCreateAccessApplicationWithSCIMProvisioning(t *testing.T) {
 						Update: BoolPtr(true),
 						Delete: BoolPtr(true),
 					},
+					Strictness: "strict",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- 
Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points. 
-->

## Description

Add a setting to control how strictly we adhere to published SCIM schemas when provisioning to configured SCIM service provider targets. 

Tested via automated unit tests

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ x All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
