### PR TITLE
Added new and optional routing field to a regional hostname

### DIFF
--- a/.changelog/3560.txt
+++ b/.changelog/3560.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-addressing: add support for `routing` attribute
+regional_hostname: add support for `routing` attribute
 ```

--- a/.changelog/3560.txt
+++ b/.changelog/3560.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+addressing: add support for `routing` attribute
+```

--- a/regional_hostnames.go
+++ b/regional_hostnames.go
@@ -17,6 +17,7 @@ type Region struct {
 type RegionalHostname struct {
 	Hostname  string     `json:"hostname"`
 	RegionKey string     `json:"region_key"`
+	Routing   string     `json:"routing,omitempty"`
 	CreatedOn *time.Time `json:"created_on,omitempty"`
 }
 

--- a/regional_hostnames_test.go
+++ b/regional_hostnames_test.go
@@ -93,6 +93,46 @@ func TestListRegionalHostnames(t *testing.T) {
 	}
 }
 
+func TestListRegionalHostnamesWithRouting(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": [
+			{
+			  "hostname": "%s",
+			  "region_key": "ca",
+			  "routing": "dns",
+			  "created_on": "2023-01-14T00:47:57.060267Z"
+			}
+		  ],
+		  "success": true,
+		  "errors": [],
+		  "messages": []
+		}`, regionalHostname)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/addressing/regional_hostnames", handler)
+
+	createdOn, _ := time.Parse(time.RFC3339, "2023-01-14T00:47:57.060267Z")
+	want := []RegionalHostname{
+		{
+			Hostname:  regionalHostname,
+			RegionKey: "ca",
+			Routing:   "dns",
+			CreatedOn: &createdOn,
+		},
+	}
+
+	actual, err := client.ListDataLocalizationRegionalHostnames(context.Background(), ZoneIdentifier(testZoneID), ListDataLocalizationRegionalHostnamesParams{})
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
 func TestCreateRegionalHostname(t *testing.T) {
 	setup()
 	defer teardown()
@@ -132,6 +172,47 @@ func TestCreateRegionalHostname(t *testing.T) {
 	}
 }
 
+func TestCreateRegionalHostnameWithRouting(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method, "Expected method 'POST', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": {
+			  "hostname": "%s",
+			  "region_key": "ca",
+			  "routing": "dns",
+			  "created_on": "2023-01-14T00:47:57.060267Z"
+		  },
+		  "success": true,
+		  "errors": [],
+		  "messages": []
+		}`, regionalHostname)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/addressing/regional_hostnames", handler)
+
+	params := CreateDataLocalizationRegionalHostnameParams{
+		RegionKey: "ca",
+		Hostname:  regionalHostname,
+	}
+
+	want := RegionalHostname{
+		RegionKey: "ca",
+		Routing:   "dns",
+		Hostname:  regionalHostname,
+	}
+
+	actual, err := client.CreateDataLocalizationRegionalHostname(context.Background(), ZoneIdentifier(testZoneID), params)
+	createdOn, _ := time.Parse(time.RFC3339, "2023-01-14T00:47:57.060267Z")
+	want.CreatedOn = &createdOn
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
 func TestGetRegionalHostname(t *testing.T) {
 	setup()
 	defer teardown()
@@ -158,6 +239,41 @@ func TestGetRegionalHostname(t *testing.T) {
 	want := RegionalHostname{
 		RegionKey: "ca",
 		Hostname:  regionalHostname,
+		CreatedOn: &createdOn,
+	}
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, actual)
+	}
+}
+
+func TestGetRegionalHostnameWithRouting(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+		  "result": {
+			  "hostname": "%s",
+			  "region_key": "ca",
+			  "routing": "dns",
+			  "created_on": "2023-01-14T00:47:57.060267Z"
+		  },
+		  "success": true,
+		  "errors": [],
+		  "messages": []
+		}`, regionalHostname)
+	}
+
+	mux.HandleFunc("/zones/"+testZoneID+"/addressing/regional_hostnames/"+regionalHostname, handler)
+
+	actual, err := client.GetDataLocalizationRegionalHostname(context.Background(), ZoneIdentifier(testZoneID), regionalHostname)
+	createdOn, _ := time.Parse(time.RFC3339, "2023-01-14T00:47:57.060267Z")
+	want := RegionalHostname{
+		Hostname:  regionalHostname,
+		RegionKey: "ca",
+		Routing:   "dns",
 		CreatedOn: &createdOn,
 	}
 	if assert.NoError(t, err) {


### PR DESCRIPTION
We're (slowly) introducing a new field into the Regional Hostnames API. It's optional and will be null/empty for most cases.
Motivation here is to get an updated schema into the Cloudflare terraform provider.

## Description

Nothing complicated here, just a new field. The docs on https://developers.cloudflare.com/api will be out momentarily.

## Has your change been tested?

I've left the existing tests unchanged and added some new tests that include the new field.

## Types of changes

What sort of change does your code introduce/modify?

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
