### PR TITLE
Fix disabling redact PII on logging settings

### DIFF
--- a/teams_accounts.go
+++ b/teams_accounts.go
@@ -132,7 +132,7 @@ type TeamsAccountLoggingConfiguration struct {
 
 type TeamsLoggingSettings struct {
 	LoggingSettingsByRuleType map[TeamsRuleType]TeamsAccountLoggingConfiguration `json:"settings_by_rule_type"`
-	RedactPii                 bool                                               `json:"redact_pii,omitempty"`
+	RedactPii                 *bool                                              `json:"redact_pii,omitempty"`
 }
 
 type TeamsDeviceSettings struct {

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTeamsAccount(t *testing.T) {

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -114,7 +114,7 @@ func TestTeamsAccountConfiguration(t *testing.T) {
 			Antivirus: &TeamsAntivirus{
 				EnabledDownloadPhase: true,
 				NotificationSettings: &TeamsNotificationSettings{
-					Enabled:    &trueValue,
+					Enabled:    BoolPtr(true),
 					Message:    "msg",
 					SupportURL: "https://hi.com",
 				},
@@ -233,7 +233,7 @@ func TestTeamsAccountGetLoggingConfiguration(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, actual, TeamsLoggingSettings{
-			RedactPii: &trueValue,
+			RedactPii: BoolPtr(true),
 			LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
 				TeamsDnsRuleType: {LogAll: false, LogBlocks: true},
 			},
@@ -259,7 +259,7 @@ func TestTeamsAccountUpdateLoggingConfiguration(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/logging", handler)
 
 	actual, err := client.TeamsAccountUpdateLoggingConfiguration(context.Background(), testAccountID, TeamsLoggingSettings{
-		RedactPii: &trueValue,
+		RedactPii: BoolPtr(true),
 		LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
 			TeamsDnsRuleType: {
 				LogAll:    false,
@@ -276,7 +276,7 @@ func TestTeamsAccountUpdateLoggingConfiguration(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, actual, TeamsLoggingSettings{
-			RedactPii: &trueValue,
+			RedactPii: BoolPtr(true),
 			LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
 				TeamsDnsRuleType:  {LogAll: false, LogBlocks: true},
 				TeamsHttpRuleType: {LogAll: true, LogBlocks: false},
@@ -308,7 +308,7 @@ func TestTeamsAccountDisableRedactPIILoggingConfiguration(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/logging", handler)
 
 	_, err := client.TeamsAccountUpdateLoggingConfiguration(context.Background(), testAccountID, TeamsLoggingSettings{
-		RedactPii: &falseValue,
+		RedactPii: BoolPtr(false),
 		LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
 			TeamsDnsRuleType: {
 				LogAll:    false,

--- a/teams_accounts_test.go
+++ b/teams_accounts_test.go
@@ -2,7 +2,9 @@ package cloudflare
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
 
@@ -231,7 +233,7 @@ func TestTeamsAccountGetLoggingConfiguration(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, actual, TeamsLoggingSettings{
-			RedactPii: true,
+			RedactPii: &trueValue,
 			LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
 				TeamsDnsRuleType: {LogAll: false, LogBlocks: true},
 			},
@@ -257,7 +259,7 @@ func TestTeamsAccountUpdateLoggingConfiguration(t *testing.T) {
 	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/logging", handler)
 
 	actual, err := client.TeamsAccountUpdateLoggingConfiguration(context.Background(), testAccountID, TeamsLoggingSettings{
-		RedactPii: true,
+		RedactPii: &trueValue,
 		LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
 			TeamsDnsRuleType: {
 				LogAll:    false,
@@ -274,7 +276,7 @@ func TestTeamsAccountUpdateLoggingConfiguration(t *testing.T) {
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, actual, TeamsLoggingSettings{
-			RedactPii: true,
+			RedactPii: &trueValue,
 			LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
 				TeamsDnsRuleType:  {LogAll: false, LogBlocks: true},
 				TeamsHttpRuleType: {LogAll: true, LogBlocks: false},
@@ -282,6 +284,54 @@ func TestTeamsAccountUpdateLoggingConfiguration(t *testing.T) {
 			},
 		})
 	}
+}
+
+func TestTeamsAccountDisableRedactPIILoggingConfiguration(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
+
+		request := readJson(t, r)
+		require.False(t, request["redact_pii"].(bool))
+
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{
+			"success": true,
+			"errors": [],
+			"messages": [],
+			"result": {"settings_by_rule_type":{"dns":{"log_all":false,"log_blocks":true}, "http":{"log_all":true,"log_blocks":false}, "l4": {"log_all": false, "log_blocks": true}},"redact_pii":true}
+		}`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/gateway/logging", handler)
+
+	_, err := client.TeamsAccountUpdateLoggingConfiguration(context.Background(), testAccountID, TeamsLoggingSettings{
+		RedactPii: &falseValue,
+		LoggingSettingsByRuleType: map[TeamsRuleType]TeamsAccountLoggingConfiguration{
+			TeamsDnsRuleType: {
+				LogAll:    false,
+				LogBlocks: true,
+			},
+			TeamsHttpRuleType: {
+				LogAll: true,
+			},
+			TeamsL4RuleType: {
+				LogBlocks: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func readJson(t *testing.T, r *http.Request) map[string]interface{} {
+	var result map[string]interface{}
+	decoder := json.NewDecoder(r.Body)
+	defer r.Body.Close()
+	err := decoder.Decode(&result)
+	require.NoError(t, err)
+	return result
 }
 
 func TestTeamsAccountGetDeviceConfiguration(t *testing.T) {


### PR DESCRIPTION
## Description

Trying to disable redact PII on the logging
settings would have no effect because the logging
settings object would be marshaled without the
`redact_pii` field which result in the default
value being used, which is `true` in this case.

To fix this, the `redact_pii` is now included
even set to `false` when the logging settings
object is marshaled.

## Has your change been tested?

Besides the automated test, the change was
manually validated by using the lib to call
the API to make the change that was causing
problems.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
