### PR TITLE
FLPROD-796: Fixing wrong response type for snippet update endpoint

### DIFF
--- a/.changelog/3596.txt
+++ b/.changelog/3596.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Wrong response type for Snippet update endpoint
+snippets: fix response type for `UpdateZoneSnippet`
 ```

--- a/.changelog/3596.txt
+++ b/.changelog/3596.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Wrong response type for Snippet update endpoint
+```

--- a/snippets.go
+++ b/snippets.go
@@ -134,7 +134,7 @@ func snippetMultipartBody(request SnippetRequest) (string, *bytes.Buffer, error)
 	return mw.Boundary(), body, nil
 }
 
-func (api *API) UpdateZoneSnippet(ctx context.Context, rc *ResourceContainer, params SnippetRequest) ([]Snippet, error) {
+func (api *API) UpdateZoneSnippet(ctx context.Context, rc *ResourceContainer, params SnippetRequest) (*Snippet, error) {
 	if rc.Identifier == "" {
 		return nil, ErrMissingZoneID
 	}
@@ -153,7 +153,7 @@ func (api *API) UpdateZoneSnippet(ctx context.Context, rc *ResourceContainer, pa
 		return nil, err
 	}
 
-	result := SnippetsResponse{}
+	result := SnippetResponse{}
 	if err := json.Unmarshal(res, &result); err != nil {
 		return nil, fmt.Errorf("%s: %w", errUnmarshalError, err)
 	}

--- a/snippets_rules.go
+++ b/snippets_rules.go
@@ -26,7 +26,7 @@ func (api *API) ListZoneSnippetsRules(ctx context.Context, rc *ResourceContainer
 		return nil, ErrMissingZoneID
 	}
 
-	uri := buildURI(fmt.Sprintf("/zones/%s/snippets/rules", rc.Identifier), nil)
+	uri := buildURI(fmt.Sprintf("/zones/%s/snippets/snippet_rules", rc.Identifier), nil)
 	res, err := api.makeRequestContext(ctx, http.MethodGet, uri, nil)
 	if err != nil {
 		return nil, err
@@ -45,7 +45,7 @@ func (api *API) UpdateZoneSnippetsRules(ctx context.Context, rc *ResourceContain
 		return nil, ErrMissingZoneID
 	}
 
-	uri := fmt.Sprintf("/zones/%s/snippets/rules", rc.Identifier)
+	uri := fmt.Sprintf("/zones/%s/snippets/snippet_rules", rc.Identifier)
 
 	payload, err := json.Marshal(params)
 	if err != nil {

--- a/snippets_rules_test.go
+++ b/snippets_rules_test.go
@@ -38,7 +38,7 @@ func TestSnippetsRules(t *testing.T) {
       "messages": []
     }`)
 	}
-	mux.HandleFunc("/zones/"+testZoneID+"/snippets/rules", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/snippets/snippet_rules", handler)
 
 	want := []SnippetRule{
 		{
@@ -93,7 +93,7 @@ func TestUpdateSnippetsRules(t *testing.T) {
     }`)
 	}
 
-	mux.HandleFunc("/zones/"+testZoneID+"/snippets/rules", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/snippets/snippet_rules", handler)
 	toUpdate := []SnippetRule{
 		{
 			Expression:  "true",

--- a/snippets_test.go
+++ b/snippets_test.go
@@ -116,18 +116,12 @@ func TestUpdateSnippets(t *testing.T) {
 		assert.Equal(t, http.MethodPut, r.Method, "Expected method 'PUT', got %s", r.Method)
 		w.Header().Set("content-type", "application/json")
 		fmt.Fprint(w, `{
-      "result": [
+      "result":
 		{
 			"snippet_name": "some_id_1",
 			"created_on":"0001-01-01T00:00:00Z",
 			"modified_on":"0001-01-01T00:00:00Z"
 	  	},
-		{
-			"snippet_name": "some_id_2",
-			"created_on":"0001-01-01T00:00:00Z",
-			"modified_on":"0001-01-01T00:00:00Z"
-	  	}
-	  ],
       "success": true,
       "errors": [],
       "messages": []
@@ -149,17 +143,10 @@ func TestUpdateSnippets(t *testing.T) {
 			},
 		},
 	}
-	want := []Snippet{
-		{
-			SnippetName: "some_id_1",
-			CreatedOn:   &time.Time{},
-			ModifiedOn:  &time.Time{},
-		},
-		{
-			SnippetName: "some_id_2",
-			CreatedOn:   &time.Time{},
-			ModifiedOn:  &time.Time{},
-		},
+	want := &Snippet{
+		SnippetName: "some_id_1",
+		CreatedOn:   &time.Time{},
+		ModifiedOn:  &time.Time{},
 	}
 	zoneActual, err := client.UpdateZoneSnippet(context.Background(), ZoneIdentifier(testZoneID), toUpdate)
 	if assert.NoError(t, err) {


### PR DESCRIPTION
Update (PUT) endpoint returns a single object and not a list of objects. Also fixed wrong endpoint name.