### PR TITLE
AUTH-6588 Replace Access app SelfHostedDomains with Destinations

### DIFF
--- a/.changelog/3667.txt
+++ b/.changelog/3667.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+access: Add `DomainType` field to Access applications.
+```
+
+```release-note:breaking-change
+access: Remove the deprecated `SelfHostedDomains` field from Access applications. Use `Destinations` instead.
+```

--- a/access_application.go
+++ b/access_application.go
@@ -26,6 +26,18 @@ const (
 	Infrastructure AccessApplicationType = "infrastructure"
 )
 
+type AccessDestinationType string
+
+const (
+	AccessDestinationPublic  AccessDestinationType = "public"
+	AccessDestinationPrivate AccessDestinationType = "private"
+)
+
+type AccessDestination struct {
+	Type AccessDestinationType `json:"type"`
+	URI  string                `json:"uri"`
+}
+
 // AccessApplication represents an Access application.
 type AccessApplication struct {
 	GatewayRules             []AccessApplicationGatewayRule       `json:"gateway_rules,omitempty"`
@@ -34,7 +46,8 @@ type AccessApplication struct {
 	LogoURL                  string                               `json:"logo_url,omitempty"`
 	AUD                      string                               `json:"aud,omitempty"`
 	Domain                   string                               `json:"domain"`
-	SelfHostedDomains        []string                             `json:"self_hosted_domains"`
+	DomainType               AccessDestinationType                `json:"domain_type,omitempty"`
+	Destinations             []AccessDestination                  `json:"destinations"`
 	Type                     AccessApplicationType                `json:"type,omitempty"`
 	SessionDuration          string                               `json:"session_duration,omitempty"`
 	SameSiteCookieAttribute  string                               `json:"same_site_cookie_attribute,omitempty"`
@@ -288,6 +301,7 @@ type CreateAccessApplicationParams struct {
 	CustomDenyURL            string                               `json:"custom_deny_url,omitempty"`
 	CustomNonIdentityDenyURL string                               `json:"custom_non_identity_deny_url,omitempty"`
 	Domain                   string                               `json:"domain"`
+	DomainType               AccessDestinationType                `json:"domain_type,omitempty"`
 	EnableBindingCookie      *bool                                `json:"enable_binding_cookie,omitempty"`
 	GatewayRules             []AccessApplicationGatewayRule       `json:"gateway_rules,omitempty"`
 	HttpOnlyCookieAttribute  *bool                                `json:"http_only_cookie_attribute,omitempty"`
@@ -297,7 +311,7 @@ type CreateAccessApplicationParams struct {
 	PrivateAddress           string                               `json:"private_address"`
 	SaasApplication          *SaasApplication                     `json:"saas_app,omitempty"`
 	SameSiteCookieAttribute  string                               `json:"same_site_cookie_attribute,omitempty"`
-	SelfHostedDomains        []string                             `json:"self_hosted_domains"`
+	Destinations             []AccessDestination                  `json:"destinations"`
 	ServiceAuth401Redirect   *bool                                `json:"service_auth_401_redirect,omitempty"`
 	SessionDuration          string                               `json:"session_duration,omitempty"`
 	SkipInterstitial         *bool                                `json:"skip_interstitial,omitempty"`
@@ -324,6 +338,7 @@ type UpdateAccessApplicationParams struct {
 	CustomDenyURL            string                               `json:"custom_deny_url,omitempty"`
 	CustomNonIdentityDenyURL string                               `json:"custom_non_identity_deny_url,omitempty"`
 	Domain                   string                               `json:"domain"`
+	DomainType               AccessDestinationType                `json:"domain_type,omitempty"`
 	EnableBindingCookie      *bool                                `json:"enable_binding_cookie,omitempty"`
 	GatewayRules             []AccessApplicationGatewayRule       `json:"gateway_rules,omitempty"`
 	HttpOnlyCookieAttribute  *bool                                `json:"http_only_cookie_attribute,omitempty"`
@@ -333,7 +348,7 @@ type UpdateAccessApplicationParams struct {
 	PrivateAddress           string                               `json:"private_address"`
 	SaasApplication          *SaasApplication                     `json:"saas_app,omitempty"`
 	SameSiteCookieAttribute  string                               `json:"same_site_cookie_attribute,omitempty"`
-	SelfHostedDomains        []string                             `json:"self_hosted_domains"`
+	Destinations             []AccessDestination                  `json:"destinations"`
 	ServiceAuth401Redirect   *bool                                `json:"service_auth_401_redirect,omitempty"`
 	SessionDuration          string                               `json:"session_duration,omitempty"`
 	SkipInterstitial         *bool                                `json:"skip_interstitial,omitempty"`

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -34,6 +34,7 @@ func TestAccessApplications(t *testing.T) {
 					"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 					"name": "Admin Site",
 					"domain": "test.example.com/admin",
+					"domain_type": "public",
 					"type": "self_hosted",
 					"session_duration": "24h",
 					"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
@@ -93,6 +94,7 @@ func TestAccessApplications(t *testing.T) {
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 		Name:                     "Admin Site",
 		Domain:                   "test.example.com/admin",
+		DomainType:               AccessDestinationPublic,
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AllowedIdps:              []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
@@ -163,7 +165,11 @@ func TestAccessApplication(t *testing.T) {
 				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 				"name": "Admin Site",
 				"domain": "test.example.com/admin",
-				"self_hosted_domains": ["test.example.com/admin", "test.example.com/admin2"],
+				"domain_type": "public",
+				"destinations": [
+					{"type": "public", "uri": "test.example.com/admin"},
+					{"type": "public", "uri": "test.example.com/admin2"}
+				],
 				"type": "self_hosted",
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
@@ -207,13 +213,17 @@ func TestAccessApplication(t *testing.T) {
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 
 	want := AccessApplication{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		CreatedAt:                &createdAt,
-		UpdatedAt:                &updatedAt,
-		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		CreatedAt:  &createdAt,
+		UpdatedAt:  &updatedAt,
+		AUD:        "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AllowedIdps:              []string{"f174e90a-fafe-4643-bbbc-4a0ed4fc8415"},
@@ -281,7 +291,11 @@ func TestCreateAccessApplications(t *testing.T) {
 				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 				"name": "Admin Site",
 				"domain": "test.example.com/admin",
-				"self_hosted_domains": ["test.example.com/admin", "test.example.com/admin2"],
+				"domain_type": "public",
+				"destinations": [
+					{"type": "public", "uri": "test.example.com/admin"},
+					{"type": "public", "uri": "test.example.com/admin2"}
+				],
 				"type": "self_hosted",
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
@@ -323,10 +337,14 @@ func TestCreateAccessApplications(t *testing.T) {
 	createdAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	updatedAt, _ := time.Parse(time.RFC3339, "2014-01-01T05:20:00.12345Z")
 	fullAccessApplication := AccessApplication{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
@@ -366,6 +384,7 @@ func TestCreateAccessApplications(t *testing.T) {
 	actual, err := client.CreateAccessApplication(context.Background(), AccountIdentifier(testAccountID), CreateAccessApplicationParams{
 		Name:            "Admin Site",
 		Domain:          "test.example.com/admin",
+		DomainType:      AccessDestinationPublic,
 		SessionDuration: "24h",
 		Policies:        []string{"699d98642c564d2e855e9661899b7252"},
 	})
@@ -379,6 +398,7 @@ func TestCreateAccessApplications(t *testing.T) {
 	actual, err = client.CreateAccessApplication(context.Background(), ZoneIdentifier(testZoneID), CreateAccessApplicationParams{
 		Name:            "Admin Site",
 		Domain:          "test.example.com/admin",
+		DomainType:      AccessDestinationPublic,
 		SessionDuration: "24h",
 		Policies:        []string{"699d98642c564d2e855e9661899b7252"},
 	})
@@ -406,7 +426,11 @@ func TestUpdateAccessApplication(t *testing.T) {
 				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 				"name": "Admin Site",
 				"domain": "test.example.com/admin",
-				"self_hosted_domains": ["test.example.com/admin", "test.example.com/admin2"],
+				"domain_type": "public",
+				"destinations": [
+					{"type": "public", "uri": "test.example.com/admin"},
+					{"type": "public", "uri": "test.example.com/admin2"}
+				],
 				"type": "self_hosted",
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
@@ -446,10 +470,14 @@ func TestUpdateAccessApplication(t *testing.T) {
 	}
 
 	fullAccessApplication := AccessApplication{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
@@ -485,10 +513,14 @@ func TestUpdateAccessApplication(t *testing.T) {
 	}
 
 	params := UpdateAccessApplicationParams{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
@@ -519,10 +551,14 @@ func TestUpdateAccessApplication(t *testing.T) {
 	mux.HandleFunc("/zones/"+testZoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
 
 	actual, err = client.UpdateAccessApplication(context.Background(), ZoneIdentifier(testZoneID), UpdateAccessApplicationParams{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
@@ -566,7 +602,11 @@ func TestUpdateAccessApplicationOmitPolicies(t *testing.T) {
 				"aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 				"name": "Admin Site",
 				"domain": "test.example.com/admin",
-				"self_hosted_domains": ["test.example.com/admin", "test.example.com/admin2"],
+				"domain_type": "public",
+				"destinations": [
+					{"type": "public", "uri": "test.example.com/admin"},
+					{"type": "public", "uri": "test.example.com/admin2"}
+				],
 				"type": "self_hosted",
 				"session_duration": "24h",
 				"allowed_idps": ["f174e90a-fafe-4643-bbbc-4a0ed4fc8415"],
@@ -606,10 +646,14 @@ func TestUpdateAccessApplicationOmitPolicies(t *testing.T) {
 	}
 
 	fullAccessApplication := AccessApplication{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
@@ -645,10 +689,14 @@ func TestUpdateAccessApplicationOmitPolicies(t *testing.T) {
 	}
 
 	params := UpdateAccessApplicationParams{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
@@ -678,10 +726,14 @@ func TestUpdateAccessApplicationOmitPolicies(t *testing.T) {
 	mux.HandleFunc("/zones/"+testZoneID+"/access/apps/480f4f69-1a28-4fdd-9240-1ed29f0ac1db", handler)
 
 	actual, err = client.UpdateAccessApplication(context.Background(), ZoneIdentifier(testZoneID), UpdateAccessApplicationParams{
-		ID:                       "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
-		Name:                     "Admin Site",
-		Domain:                   "test.example.com/admin",
-		SelfHostedDomains:        []string{"test.example.com/admin", "test.example.com/admin2"},
+		ID:         "480f4f69-1a28-4fdd-9240-1ed29f0ac1db",
+		Name:       "Admin Site",
+		Domain:     "test.example.com/admin",
+		DomainType: AccessDestinationPublic,
+		Destinations: []AccessDestination{
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
+			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
 		AUD:                      "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
@@ -789,6 +841,7 @@ func TestAccessApplicationWithCORS(t *testing.T) {
         "aud": "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
         "name": "Admin Site",
         "domain": "test.example.com/admin",
+				"domain_type": "public",
         "type": "self_hosted",
         "session_duration": "24h",
         "cors_headers": {
@@ -816,6 +869,7 @@ func TestAccessApplicationWithCORS(t *testing.T) {
 		AUD:             "737646a56ab1df6ec9bddc7e5ca84eaf3b0768850f3ffb5d74f1534911fe3893",
 		Name:            "Admin Site",
 		Domain:          "test.example.com/admin",
+		DomainType:      AccessDestinationPublic,
 		Type:            "self_hosted",
 		SessionDuration: "24h",
 		CorsHeaders: &AccessApplicationCorsHeaders{


### PR DESCRIPTION
<!-- 
Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points. 
-->

## Description

Access team is deprecating the `self_hosted_domains` field for apps in favor of a new `destinations` field to give us more flexibility in defining different types of domains. This PR adds the new field and removes the old one. I hate to do a breaking change, but it's pretty much always incorrect to send both fields if you mean to change just one, so I think that the toil is worth avoiding the footgun.

Also adds the `domain_type` field. Now that they can be either private or public, we needed a way to indicate the type of the "primary" domain.

<!--
Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].
-->
## Has your change been tested?

Tests pass! And I used the library to manually create/read/update apps.

<!--
Explain how the change has been tested and what you ran to confirm your
change affects other parts of the code. Automated tests are generally
expected and changes without tests should explain why they aren't
required.
-->

## Types of changes

What sort of change does your code introduce/modify?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
