### PR TITLE
ZTIA-355: Adds allow_email_alias connection rule boolean to access infra policy payload

### DIFF
--- a/.changelog/3675.txt
+++ b/.changelog/3675.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Adds allow_email_alias connection rule boolean to access infra policy payload
+```

--- a/access_infrastructure_application.go
+++ b/access_infrastructure_application.go
@@ -14,7 +14,8 @@ type AccessInfrastructureTargetContext struct {
 }
 
 type AccessInfrastructureConnectionRulesSSH struct {
-	Usernames []string `json:"usernames"`
+	Usernames       []string `json:"usernames"`
+	AllowEmailAlias *bool    `json:"allow_email_alias"`
 }
 
 type AccessInfrastructureConnectionRules struct {

--- a/access_infrastructure_application_test.go
+++ b/access_infrastructure_application_test.go
@@ -32,7 +32,8 @@ var (
 		Require: []any{},
 		InfrastructureConnectionRules: &AccessInfrastructureConnectionRules{
 			SSH: &AccessInfrastructureConnectionRulesSSH{
-				Usernames: []string{"devuser"},
+				Usernames:       []string{"devuser"},
+				AllowEmailAlias: BoolPtr(true),
 			},
 		},
 	}
@@ -161,7 +162,8 @@ func TestInfrastructureApplication_Create(t *testing.T) {
 						"require": [],
 						"connection_rules": {
 							"ssh": {
-								"usernames": [ "devuser" ]
+								"usernames": [ "devuser" ],
+								"allow_email_alias": true
 							}
 						},
 						"uid": "8dd6af47-a80b-48cb-89c1-f39299ebf096",
@@ -239,7 +241,8 @@ func TestInfrastructureApplication_Update(t *testing.T) {
 						"require": [],
 						"connection_rules": {
 							"ssh": {
-								"usernames": [ "devuser" ]
+								"usernames": [ "devuser" ],
+								"allow_email_alias": true
 							}
 						},
 						"uid": "8dd6af47-a80b-48cb-89c1-f39299ebf096",
@@ -317,7 +320,8 @@ func TestInfrastructureApplication_Get(t *testing.T) {
 						"require": [],
 						"connection_rules": {
 							"ssh": {
-								"usernames": [ "devuser" ]
+								"usernames": [ "devuser" ],
+								"allow_email_alias": true
 							}
 						},
 						"uid": "8dd6af47-a80b-48cb-89c1-f39299ebf096",

--- a/access_policy_test.go
+++ b/access_policy_test.go
@@ -57,7 +57,8 @@ var (
 		},
 		InfrastructureConnectionRules: &AccessInfrastructureConnectionRules{
 			SSH: &AccessInfrastructureConnectionRulesSSH{
-				Usernames: []string{"root", "ec2-user"},
+				Usernames:       []string{"root", "ec2-user"},
+				AllowEmailAlias: BoolPtr(true),
 			},
 		},
 	}
@@ -123,7 +124,8 @@ func TestAccessPolicies(t *testing.T) {
 				],
 				"connection_rules": {
 					"ssh": {
-						"usernames": ["root", "ec2-user"]
+						"usernames": ["root", "ec2-user"],
+						"allow_email_alias": true
 					}
 				}
 			  }
@@ -227,7 +229,8 @@ func TestAccessPolicy(t *testing.T) {
 				],
 				"connection_rules": {
 					"ssh": {
-						"usernames": ["root", "ec2-user"]
+						"usernames": ["root", "ec2-user"],
+						"allow_email_alias": true
 					}
 				}
 			}
@@ -325,7 +328,8 @@ func TestCreateAccessPolicy(t *testing.T) {
 				],
 				"connection_rules": {
 					"ssh": {
-						"usernames": ["root", "ec2-user"]
+						"usernames": ["root", "ec2-user"],
+						"allow_email_alias": true
 					}
 				}
 			}
@@ -367,7 +371,8 @@ func TestCreateAccessPolicy(t *testing.T) {
 		},
 		InfrastructureConnectionRules: &AccessInfrastructureConnectionRules{
 			SSH: &AccessInfrastructureConnectionRulesSSH{
-				Usernames: []string{"root", "ec2-user"},
+				Usernames:       []string{"root", "ec2-user"},
+				AllowEmailAlias: BoolPtr(true),
 			},
 		},
 	}
@@ -442,7 +447,8 @@ func TestCreateAccessPolicyAuthContextRule(t *testing.T) {
 		},
 		InfrastructureConnectionRules: &AccessInfrastructureConnectionRules{
 			SSH: &AccessInfrastructureConnectionRulesSSH{
-				Usernames: []string{"root", "ec2-user"},
+				Usernames:       []string{"root", "ec2-user"},
+				AllowEmailAlias: BoolPtr(true),
 			},
 		},
 	}
@@ -495,7 +501,8 @@ func TestCreateAccessPolicyAuthContextRule(t *testing.T) {
 				],
 				"connection_rules": {
 					"ssh": {
-						"usernames": ["root", "ec2-user"]
+						"usernames": ["root", "ec2-user"],
+						"allow_email_alias": true
 					}
 				}
 			}
@@ -591,7 +598,8 @@ func TestUpdateAccessPolicy(t *testing.T) {
 		},
 		InfrastructureConnectionRules: &AccessInfrastructureConnectionRules{
 			SSH: &AccessInfrastructureConnectionRulesSSH{
-				Usernames: []string{"root", "ec2-user"},
+				Usernames:       []string{"root", "ec2-user"},
+				AllowEmailAlias: BoolPtr(true),
 			},
 		},
 	}
@@ -647,7 +655,8 @@ func TestUpdateAccessPolicy(t *testing.T) {
 				],
 				"connection_rules": {
 					"ssh": {
-						"usernames": ["root", "ec2-user"]
+						"usernames": ["root", "ec2-user"],
+						"allow_email_alias": true
 					}
 				}
 			}

--- a/turnstile.go
+++ b/turnstile.go
@@ -35,7 +35,7 @@ type CreateTurnstileWidgetParams struct {
 }
 
 type UpdateTurnstileWidgetParams struct {
-	SiteKey      string   `json:"-"`
+	SiteKey      string    `json:"-"`
 	Name         *string   `json:"name,omitempty"`
 	Domains      *[]string `json:"domains,omitempty"`
 	Mode         *string   `json:"mode,omitempty"`


### PR DESCRIPTION
## Description
Adds allow_email_alias connection rule boolean to access infra policy payload.
This boolean enables SSH users to connect to accounts that have the same name as their email prefix.

## Has your change been tested?
Unit tests have been updated.

## Types of changes

What sort of change does your code introduce/modify?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
