### PR TITLE
Remove phase SBFM from rulesets

### DIFF
--- a/.changelog/3824.txt
+++ b/.changelog/3824.txt
@@ -1,0 +1,3 @@
+```release-note:note
+rulesets: remove `http_request_sbfm` phase
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -35,7 +35,6 @@ const (
 	RulesetPhaseHTTPRequestOrigin            RulesetPhase = "http_request_origin"
 	RulesetPhaseHTTPRequestRedirect          RulesetPhase = "http_request_redirect"
 	RulesetPhaseHTTPRequestSanitize          RulesetPhase = "http_request_sanitize"
-	RulesetPhaseHTTPRequestSBFM              RulesetPhase = "http_request_sbfm"
 	RulesetPhaseHTTPRequestTransform         RulesetPhase = "http_request_transform"
 	RulesetPhaseHTTPResponseCompression      RulesetPhase = "http_response_compression"
 	RulesetPhaseHTTPResponseFirewallManaged  RulesetPhase = "http_response_firewall_managed"
@@ -104,7 +103,6 @@ func RulesetPhaseValues() []string {
 		string(RulesetPhaseHTTPRequestOrigin),
 		string(RulesetPhaseHTTPRequestRedirect),
 		string(RulesetPhaseHTTPRequestSanitize),
-		string(RulesetPhaseHTTPRequestSBFM),
 		string(RulesetPhaseHTTPRequestTransform),
 		string(RulesetPhaseHTTPResponseCompression),
 		string(RulesetPhaseHTTPResponseFirewallManaged),


### PR DESCRIPTION
We now longer allow configuring SBFM phase rulesets with the rulesets API. They can only be configured with the bot management API. We have sent emails to customers about this change asking them to switch from the ruleset resource to the bot management resource in terraform.

## Description

Rules are added to rulesets before they are deployed at the edge. So we want customers to only configure the rules once they have been deployed and in a way that has been tested. 

## Has your change been tested?

This PR only removes a phase from the rulesets resource.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
