### PR TITLE
AUTH-6690 Add more fields for access application private destinations

### DIFF
--- a/.changelog/3829.txt
+++ b/.changelog/3829.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+access_application: added more fields to private destinations
+```

--- a/access_application.go
+++ b/access_application.go
@@ -35,7 +35,18 @@ const (
 
 type AccessDestination struct {
 	Type AccessDestinationType `json:"type"`
-	URI  string                `json:"uri"`
+	// URI is required and only used for public destinations.
+	URI string `json:"uri,omitempty"`
+	// Hostname can only be used for private destinations.
+	Hostname string `json:"hostname,omitempty"`
+	// CIDR can only be used for private destinations.
+	CIDR string `json:"cidr,omitempty"`
+	// PortRange can only be used for private destinations.
+	PortRange string `json:"port_range,omitempty"`
+	// L4Protocol can only be used for private destinations.
+	L4Protocol string `json:"l4_protocol,omitempty"`
+	// VnetID can only be used for private destinations.
+	VnetID string `json:"vnet_id,omitempty"`
 }
 
 // AccessApplication represents an Access application.

--- a/access_application_test.go
+++ b/access_application_test.go
@@ -294,7 +294,14 @@ func TestCreateAccessApplications(t *testing.T) {
 				"domain_type": "public",
 				"destinations": [
 					{"type": "public", "uri": "test.example.com/admin"},
-					{"type": "public", "uri": "test.example.com/admin2"}
+					{"type": "private", "hostname": "test.private.domain"},
+					{
+						"type": "private",
+						"cidr": "192.168.1.0/24",
+						"port_range": "8080-8081",
+						"vnet_id": "e69219cb-095a-4839-a352-b25b3d43aaac",
+						"l4_protocol": "udp"
+					}
 				],
 				"type": "self_hosted",
 				"session_duration": "24h",
@@ -342,8 +349,21 @@ func TestCreateAccessApplications(t *testing.T) {
 		Domain:     "test.example.com/admin",
 		DomainType: AccessDestinationPublic,
 		Destinations: []AccessDestination{
-			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
-			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+			{
+				Type: AccessDestinationPublic,
+				URI:  "test.example.com/admin",
+			},
+			{
+				Type:     AccessDestinationPrivate,
+				Hostname: "test.private.domain",
+			},
+			{
+				Type:       AccessDestinationPrivate,
+				CIDR:       "192.168.1.0/24",
+				PortRange:  "8080-8081",
+				VnetID:     "e69219cb-095a-4839-a352-b25b3d43aaac",
+				L4Protocol: "udp",
+			},
 		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
@@ -429,7 +449,14 @@ func TestUpdateAccessApplication(t *testing.T) {
 				"domain_type": "public",
 				"destinations": [
 					{"type": "public", "uri": "test.example.com/admin"},
-					{"type": "public", "uri": "test.example.com/admin2"}
+					{"type": "private", "hostname": "test.private.domain"},
+					{
+						"type": "private",
+						"cidr": "192.168.1.0/24",
+						"port_range": "8080-8081",
+						"vnet_id": "e69219cb-095a-4839-a352-b25b3d43aaac",
+						"l4_protocol": "udp"
+					}
 				],
 				"type": "self_hosted",
 				"session_duration": "24h",
@@ -476,7 +503,14 @@ func TestUpdateAccessApplication(t *testing.T) {
 		DomainType: AccessDestinationPublic,
 		Destinations: []AccessDestination{
 			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
-			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+			{Type: AccessDestinationPrivate, Hostname: "test.private.domain"},
+			{
+				Type:       AccessDestinationPrivate,
+				CIDR:       "192.168.1.0/24",
+				PortRange:  "8080-8081",
+				VnetID:     "e69219cb-095a-4839-a352-b25b3d43aaac",
+				L4Protocol: "udp",
+			},
 		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
@@ -519,7 +553,14 @@ func TestUpdateAccessApplication(t *testing.T) {
 		DomainType: AccessDestinationPublic,
 		Destinations: []AccessDestination{
 			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
-			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+			{Type: AccessDestinationPrivate, Hostname: "test.private.domain"},
+			{
+				Type:       AccessDestinationPrivate,
+				CIDR:       "192.168.1.0/24",
+				PortRange:  "8080-8081",
+				VnetID:     "e69219cb-095a-4839-a352-b25b3d43aaac",
+				L4Protocol: "udp",
+			},
 		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",
@@ -557,7 +598,14 @@ func TestUpdateAccessApplication(t *testing.T) {
 		DomainType: AccessDestinationPublic,
 		Destinations: []AccessDestination{
 			{Type: AccessDestinationPublic, URI: "test.example.com/admin"},
-			{Type: AccessDestinationPublic, URI: "test.example.com/admin2"},
+			{Type: AccessDestinationPrivate, Hostname: "test.private.domain"},
+			{
+				Type:       AccessDestinationPrivate,
+				CIDR:       "192.168.1.0/24",
+				PortRange:  "8080-8081",
+				VnetID:     "e69219cb-095a-4839-a352-b25b3d43aaac",
+				L4Protocol: "udp",
+			},
 		},
 		Type:                     "self_hosted",
 		SessionDuration:          "24h",


### PR DESCRIPTION
Before launching this feature in GA, the team decided to split the URI field for private destinations in more fine-grained fields.
This decision was made after realizing that customers want more ways of defining private destinations that a single URI string can express.


## Description

<!--
Describe your changes in detail through motivation and context. Why is
this change required? What problem does it solve? If it fixes an open
issue, link to the issue using GitHub's closing issues keywords[1].
-->
## Has your change been tested?

I've pointed my local TF provider to my local cloudflare-go setup and tested manually against my staging account.

## Screenshots (if appropriate):

## Types of changes

What sort of change does your code introduce/modify?

- [ X ] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas) 
      and relies on stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
