### PR TITLE
Add branding flag to SSL object

### DIFF
--- a/.changelog/3901.txt
+++ b/.changelog/3901.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+custom_hostname: add support for `cloudflare_branding` SSL flag
+```

--- a/custom_hostname.go
+++ b/custom_hostname.go
@@ -78,9 +78,10 @@ type CustomHostnameSSL struct {
 	// Deprecated: use ValidationRecords.
 	// If there a single validation record, this will equal ValidationRecords[0] for backwards compatibility.
 	SSLValidationRecord
-	ValidationRecords []SSLValidationRecord `json:"validation_records,omitempty"`
-	ValidationErrors  []SSLValidationError  `json:"validation_errors,omitempty"`
-	BundleMethod      string                `json:"bundle_method,omitempty"`
+	ValidationRecords  []SSLValidationRecord `json:"validation_records,omitempty"`
+	ValidationErrors   []SSLValidationError  `json:"validation_errors,omitempty"`
+	BundleMethod       string                `json:"bundle_method,omitempty"`
+	CloudflareBranding *bool                 `json:"cloudflare_branding,omitempty"`
 }
 
 // CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.

--- a/custom_hostname_test.go
+++ b/custom_hostname_test.go
@@ -428,7 +428,7 @@ func TestCustomHostname_CreateCustomHostname_CloudflareBrandingSSL(t *testing.T)
 			"status": "pending_validation",
 			"method": "http",
 			"type": "dv",
-			"wildcard": "false",
+			"wildcard": false,
 			"certificate_authority": "google"
 		},
 		"status": "pending",
@@ -445,6 +445,7 @@ func TestCustomHostname_CreateCustomHostname_CloudflareBrandingSSL(t *testing.T)
 		  "http_body": "38ddbedc-6cc3-4a4c-af67-9c5b02344ce0"
 		},
 		"created_at": "2020-02-06T18:11:23.531995Z"
+	}
 }`)
 	})
 
@@ -458,9 +459,11 @@ func TestCustomHostname_CreateCustomHostname_CloudflareBrandingSSL(t *testing.T)
 			Hostname:           "app.example.com",
 			CustomOriginServer: "example.app.com",
 			SSL: &CustomHostnameSSL{
-				Type:   "http",
-				Method: "cname",
-				Status: "pending_validation",
+				Type:                 "dv",
+				Method:               "http",
+				Status:               "pending_validation",
+				Wildcard:             BoolPtr(false),
+				CertificateAuthority: "google",
 			},
 			Status:             "pending",
 			VerificationErrors: []string{"None of the A or AAAA records are owned by this account and the pre-generated ownership verification token was not found."},


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Adding Cloudflare Branding flag to SSL object to support setting that SSL value if hostname is greater than 64 characters:

https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/reference/troubleshooting/#hostnames-over-64-characters

## Has your change been tested?
Add new test and it passes
 
## Screenshots (if appropriate):
## Types of changes
What sort of change does your code introduce/modify?
 
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:
* [x]  My code follows the code style of this project.
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x]  I have added tests to cover my changes.
* [x]  All new and existing tests passed.
* [x]  This change is using publicly documented in [cloudflare/api-schemas](https://github.com/cloudflare/api-schemas)
and relies on stable APIs.