### PR TITLE
(Fix) - Issue #3843: Correct PermissionGroups Type in TokenPolicyParam

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudflare/cloudflare-go/v4
 go 1.23
 
 require (
-	github.com/tidwall/gjson v1.14.4
+	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/cloudflare-go/v4
 
-go 1.21
+go 1.23
 
 require (
 	github.com/tidwall/gjson v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -1280,7 +1280,7 @@ type TokenPolicyParam struct {
 	// Allow or deny operations against the resources.
 	Effect param.Field[TokenPolicyEffect] `json:"effect,required"`
 	// A set of permission groups that are specified to the policy.
-	PermissionGroups param.Field[[]TokenPolicyPermissionGroupParam] `json:"permission_groups,required"`
+	PermissionGroups param.Field[[]TokenPolicyPermissionGroup] `json:"permission_groups,required"`
 	// A list of resource names that the policy applies to.
 	Resources param.Field[map[string]string] `json:"resources,required"`
 }

--- a/user/token_test.go
+++ b/user/token_test.go
@@ -34,17 +34,24 @@ func TestTokenNewWithOptionalParams(t *testing.T) {
 		Name: cloudflare.F("readonly token"),
 		Policies: cloudflare.F([]shared.TokenPolicyParam{{
 			Effect: cloudflare.F(shared.TokenPolicyEffectAllow),
-			PermissionGroups: cloudflare.F([]shared.TokenPolicyPermissionGroupParam{{
-				Meta: cloudflare.F(shared.TokenPolicyPermissionGroupsMetaParam{
-					Key:   cloudflare.F("key"),
-					Value: cloudflare.F("value"),
-				}),
-			}, {
-				Meta: cloudflare.F(shared.TokenPolicyPermissionGroupsMetaParam{
-					Key:   cloudflare.F("key"),
-					Value: cloudflare.F("value"),
-				}),
-			}}),
+			PermissionGroups: cloudflare.F([]shared.TokenPolicyPermissionGroup{
+				{
+					ID: "id",
+					Meta: shared.TokenPolicyPermissionGroupsMeta{
+						Key:   "key",
+						Value: "value",
+					},
+					Name: "name",
+				},
+				{
+					ID: "id",
+					Meta: shared.TokenPolicyPermissionGroupsMeta{
+						Key:   "key",
+						Value: "value",
+					},
+					Name: "name",
+				},
+			}),
 			Resources: cloudflare.F(map[string]string{
 				"com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43": "*",
 				"com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4": "*",
@@ -90,17 +97,24 @@ func TestTokenUpdateWithOptionalParams(t *testing.T) {
 				Name: cloudflare.F("readonly token"),
 				Policies: cloudflare.F([]shared.TokenPolicyParam{{
 					Effect: cloudflare.F(shared.TokenPolicyEffectAllow),
-					PermissionGroups: cloudflare.F([]shared.TokenPolicyPermissionGroupParam{{
-						Meta: cloudflare.F(shared.TokenPolicyPermissionGroupsMetaParam{
-							Key:   cloudflare.F("key"),
-							Value: cloudflare.F("value"),
-						}),
-					}, {
-						Meta: cloudflare.F(shared.TokenPolicyPermissionGroupsMetaParam{
-							Key:   cloudflare.F("key"),
-							Value: cloudflare.F("value"),
-						}),
-					}}),
+					PermissionGroups: cloudflare.F([]shared.TokenPolicyPermissionGroup{
+						{
+							ID: "id",
+							Meta: shared.TokenPolicyPermissionGroupsMeta{
+								Key:   "key",
+								Value: "value",
+							},
+							Name: "name",
+						},
+						{
+							ID: "id",
+							Meta: shared.TokenPolicyPermissionGroupsMeta{
+								Key:   "key",
+								Value: "value",
+							},
+							Name: "name",
+						},
+					}),
 					Resources: cloudflare.F(map[string]string{
 						"com.cloudflare.api.account.zone.22b1de5f1c0e4b3ea97bb1e963b06a43": "*",
 						"com.cloudflare.api.account.zone.eb78d65290b24279ba6f44721b3ea3c4": "*",


### PR DESCRIPTION
## Changes being requested

File: `/shared/shared.go`
Type: `TokenPolicyParam`
Field: `PermissionGroups`
Edit:  Change `TokenPolicyPermissionGroupParam` to `TokenPolicyPermissionGroup`

```
Current:  PermissionGroups param.Field[[]TokenPolicyPermissionGroupParam] `json:"permission_groups,required"`
New:      PermissionGroups param.Field[[]TokenPolicyPermissionGroup] `json:"permission_groups,required"`
```

## Test Update

File: `token_test.go`
Functions: `TestTokenNewWithOptionalParams` & `TestTokenUpdateWithOptionalParams`

Existing Implementation:

```go
PermissionGroups: cloudflare.F([]shared.TokenPolicyPermissionGroupParam{{
				Meta: cloudflare.F(shared.TokenPolicyPermissionGroupsMetaParam{
					Key:   cloudflare.F("key"),
					Value: cloudflare.F("value"),
				}),
			}, {
				Meta: cloudflare.F(shared.TokenPolicyPermissionGroupsMetaParam{
					Key:   cloudflare.F("key"),
					Value: cloudflare.F("value"),
				}),
			}}),
```

Updated Implementation:

```go
PermissionGroups: cloudflare.F([]shared.TokenPolicyPermissionGroup{
				{
					ID: "id",
					Meta: shared.TokenPolicyPermissionGroupsMeta{
						Key:   "key",
						Value: "value",
					},
					Name: "name",
				},
				{
					ID: "id",
					Meta: shared.TokenPolicyPermissionGroupsMeta{
						Key:   "key",
						Value: "value",
					},
					Name: "name",
				},
			}),
```

## Additional context & links

This corrects an issue preventing API requests from completing, as the API expects an ID field; however, the current implementation/version of the SDK only allows for the use of the `Meta` field.

I also updated the test to reflect the requested update.

I have successfully utilized this update in my own project  to request an API token. 

```go
...
	// Request a new Cloudflare API token
	generatedToken, err := client.User.Tokens.New(ctx, user.TokenNewParams{
		Name: cloudflare.F(tokenName),
		Policies: cloudflare.F([]shared.TokenPolicyParam{{
			Effect: cloudflare.F(shared.TokenPolicyEffectAllow),
			PermissionGroups: cloudflare.F([]shared.TokenPolicyPermissionGroup{
				{
					ID: "c8fed203ed3043cba015a93ad1616f1f",
					Name: "Zone Read",
				},
				{
					ID: "4755a26eedb94da69e1066d98aa820be",
					Name: "DNS Write",
				},
			}),
			Resources: cloudflare.F(map[string]string{
				"com.cloudflare.api.account.zone." + zoneID: "*",
			}),
		}}),
	})
...
```