### PR TITLE
feat(client): add support for defining versions

### DIFF
--- a/option/requestoption.go
+++ b/option/requestoption.go
@@ -22,6 +22,16 @@ import (
 // [README]: https://pkg.go.dev/github.com/cloudflare/cloudflare-go/v4#readme-requestoptions
 type RequestOption = func(*requestconfig.RequestConfig) error
 
+// WithAPIVersion returns a RequestOption that defines the API version the client is attempting
+// to use. While any value can be set here, invalid values are ignored and will recieve the
+// default value of today.
+func WithAPIVersion(value string) RequestOption {
+	return func(r *requestconfig.RequestConfig) error {
+		r.Request.Header.Set("api-version", value)
+		return nil
+	}
+}
+
 // WithBaseURL returns a RequestOption that sets the BaseURL for the client.
 func WithBaseURL(base string) RequestOption {
 	u, err := url.Parse(base)


### PR DESCRIPTION
Updates the client to allow defining the desired API version at the top and method level.