### PR TITLE
Add maintenance status and triage meetings to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,12 @@ This package generally follows [SemVer](https://semver.org/spec/v2.0.0.html) con
 1. Changes to library internals which are technically public but not intended or documented for external use. 
 1. Changes that we do not expect to impact the vast majority of users in practice.
 
+## Maintenance
+
+This SDK is actively maintained, however, many issues are tracked outside of GitHub on internal Cloudflare systems. Members of the community are welcome to join and discuss your issues during our twice monthly triage meetings. For urgent issues, please contact [Cloudflare support](https://www.support.cloudflare.com/s/?language=en_US). 
+
+* [Community triage meeting](https://calendar.google.com/calendar/embed?src=c_dbf6ce250643f2e60f806d28f3fc09a9de24cbe0ab3ffb699838303d2adfc9e4%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+
 ## Contributing
 
 See [the contributing documentation](./CONTRIBUTING.md).


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Adds a new section to the readme which describes the maintenance status of the project and describes our triage process. 

## Additional context & links
