### PR TITLE
feat: add range function support for auto-pagers

### DIFF
--- a/packages/pagination/range.go
+++ b/packages/pagination/range.go
@@ -1,0 +1,18 @@
+//go:build go1.23
+
+package pagination
+
+import "iter"
+
+// Range return an iterator suitable for use with the Go 1.23+ range-functions
+// feature. Iterating over an auto-pager then enables the simplified
+// `for n := pager.Range() {}` syntax.
+func (r *V4PagePaginationArrayAutoPager[T]) Range() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for r.Next() {
+			if !yield(r.Current()) {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds a "Range()" method to V4PagePaginationArrayAutoPager[T] instances that enables the use of the Go 1.23 range functions feature.

This enables a paginator to be used with more modern syntax:

```go
for record := pager.Range() {
}

// instead of

for pager.Next() {
    record := pager.Current()
}
```

This addition uses Go build tags to ensure that it can co-exist happily with the generated code, and only become available when used in a compatible codebase. Since this is generated, I looked to see if there was an easy way to submit this idea upstream to Stainless, but there wasn't anything obvious.

I don't see this as a critical addition. It just adapts the already good auto pager into the relatively new `Seq[T]` idiom. There are additional functions being added that take advantage of this interface (see `slices`) that make this additionally interesting.

It can be used as-is (although I'd appreciate suggestions on adding some testing to this if so), but you may prefer suggesting this to the Stainless crew for upstream addition.

## Additional context & links

- [Go blog on range functions](https://go.dev/blog/range-functions)

Note also that the only thing that requires Go 1.23+ is the `iter.Seq[T]` type. The `Range` method could also be defined without reference to this:

```go
func (r *V4PagePaginationArrayAutoPager[T]) Range() func(yield func(T) bool) {
  // body elided
}
```

No version constraint is required here, but its utility in earlier versions of Go is questionable.