### PR TITLE
fix: correctly handle sending multipart/form-data requests with JSON

### DIFF
--- a/snippets/snippet.go
+++ b/snippets/snippet.go
@@ -234,7 +234,7 @@ type SnippetUpdateParams struct {
 func (r SnippetUpdateParams) MarshalMultipart() (data []byte, contentType string, err error) {
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
-	err = apiform.MarshalRoot(r, writer)
+	err = apiform.MarshalRootWithJSON(r, writer)
 	if err != nil {
 		writer.Close()
 		return nil, "", err

--- a/workers/scriptcontent.go
+++ b/workers/scriptcontent.go
@@ -101,7 +101,7 @@ type ScriptContentUpdateParams struct {
 func (r ScriptContentUpdateParams) MarshalMultipart() (data []byte, contentType string, err error) {
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
-	err = apiform.MarshalRoot(r, writer)
+	err = apiform.MarshalRootWithJSON(r, writer)
 	if err != nil {
 		writer.Close()
 		return nil, "", err

--- a/workers/scriptscriptandversionsetting.go
+++ b/workers/scriptscriptandversionsetting.go
@@ -3766,7 +3766,7 @@ type ScriptScriptAndVersionSettingEditParams struct {
 func (r ScriptScriptAndVersionSettingEditParams) MarshalMultipart() (data []byte, contentType string, err error) {
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
-	err = apiform.MarshalRoot(r, writer)
+	err = apiform.MarshalRootWithJSON(r, writer)
 	if err != nil {
 		writer.Close()
 		return nil, "", err

--- a/workers_for_platforms/dispatchnamespacescriptcontent.go
+++ b/workers_for_platforms/dispatchnamespacescriptcontent.go
@@ -111,7 +111,7 @@ type DispatchNamespaceScriptContentUpdateParams struct {
 func (r DispatchNamespaceScriptContentUpdateParams) MarshalMultipart() (data []byte, contentType string, err error) {
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
-	err = apiform.MarshalRoot(r, writer)
+	err = apiform.MarshalRootWithJSON(r, writer)
 	if err != nil {
 		writer.Close()
 		return nil, "", err

--- a/workers_for_platforms/dispatchnamespacescriptsetting.go
+++ b/workers_for_platforms/dispatchnamespacescriptsetting.go
@@ -3781,7 +3781,7 @@ type DispatchNamespaceScriptSettingEditParams struct {
 func (r DispatchNamespaceScriptSettingEditParams) MarshalMultipart() (data []byte, contentType string, err error) {
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
-	err = apiform.MarshalRoot(r, writer)
+	err = apiform.MarshalRootWithJSON(r, writer)
 	if err != nil {
 		writer.Close()
 		return nil, "", err


### PR DESCRIPTION
This PR includes a missing option to treat non-file parts of `multipart/form-data` requests as JSON as expected by several API endpoints.

Affected SDK methods:
- `client.Snippets.Update()`
- `client.Workers.Scripts.Content.Update()`
- `client.Workers.Scripts.ScriptAndVersionSettings.Edit()`
- `client.WorkersForPlatforms.Dispatch.Namespaces.Scripts.Content.Update()`
- `client.WorkersForPlatforms.Dispatch.Namespaces.Scripts.Settings.Edit()`

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Additional context & links
Fixes #4174

Refs https://github.com/cloudflare/cloudflare-typescript/pull/2671
Refs https://github.com/cloudflare/cloudflare-python/pull/2674