### PR TITLE
fix(build): remove duplicate function in kv resource

### DIFF
--- a/kv/namespacevalue.go
+++ b/kv/namespacevalue.go
@@ -178,21 +178,6 @@ type NamespaceValueUpdateParams struct {
 func (r NamespaceValueUpdateParams) MarshalMultipart() (data []byte, contentType string, err error) {
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
-	err = apiform.MarshalRoot(r, writer)
-	if err != nil {
-		writer.Close()
-		return nil, "", err
-	}
-	err = writer.Close()
-	if err != nil {
-		return nil, "", err
-	}
-	return buf.Bytes(), writer.FormDataContentType(), nil
-}
-
-func (r NamespaceValueUpdateParams) MarshalMultipart() (data []byte, contentType string, err error) {
-	buf := bytes.NewBuffer(nil)
-	writer := multipart.NewWriter(buf)
 	err = apiform.MarshalRootWithJSON(r, writer)
 	if err != nil {
 		writer.Close()


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

Looks like a duplicate function `NamespaceValueUpdateParams.MarshalMultipart` was kept, likely as part of a conflict resolution. The kept version preserves a custom fix for the multipart handling. This change removes the generated function instead.
