### PR TITLE
Fix marshaling of `workers.AssetUploadNewParams`

### DIFF
--- a/workers/assetupload.go
+++ b/workers/assetupload.go
@@ -91,7 +91,7 @@ type AssetUploadNewParams struct {
 func (r AssetUploadNewParams) MarshalMultipart() (data []byte, contentType string, err error) {
 	buf := bytes.NewBuffer(nil)
 	writer := multipart.NewWriter(buf)
-	err = apiform.MarshalRoot(r, writer)
+	err = apiform.MarshalRoot(r.Body, writer)
 	if err != nil {
 		writer.Close()
 		return nil, "", err


### PR DESCRIPTION
Fixes #4196 
