### PR TITLE
feat(requestconfig): more resilient rate limit handling

### DIFF
--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -161,7 +161,8 @@ func NewRequestConfig(ctx context.Context, method string, u string, body interfa
 		req.Header.Add(k, v)
 	}
 	cfg := RequestConfig{
-		MaxRetries: 2,
+		// Increased from 2 to 10 for better rate limit handling
+		MaxRetries: 10,
 		Context:    ctx,
 		Request:    req,
 		HTTPClient: http.DefaultClient,
@@ -369,8 +370,11 @@ func retryDelay(res *http.Response, retryCount int) time.Duration {
 		return retryAfterDelay
 	}
 
-	maxDelay := 8 * time.Second
-	delay := time.Duration(0.5 * float64(time.Second) * math.Pow(2, float64(retryCount)))
+	// Increased for better rate limit handling:
+	// - maxDelay increased from 8s to 30s to match common rate limit windows
+	// - base multiplier increased from 0.5 to 2.0 for longer waits
+	maxDelay := 30 * time.Second
+	delay := time.Duration(2.0 * float64(time.Second) * math.Pow(2, float64(retryCount)))
 	if delay > maxDelay {
 		delay = maxDelay
 	}


### PR DESCRIPTION
Terraform apply fails immediately when hitting Cloudflare API rate limits (429 errors), despite having retry logic in place. With large terraform configurations (e.g., 28+ resources), the provider exhausts its retry budget within ~1.5 seconds and exits with errors.

  Current behavior:
  - MaxRetries: 2 (3 total attempts)
  - Backoff delays: ~0.4s, ~0.8s
  - Total retry window: ~1.5 seconds

This is insufficient for sustained rate limiting scenarios where the API needs more time to allow requests through.

Solution

Increased retry attempts and exponential backoff parameters to handle rate limits more gracefully:

Changes:
  - MaxRetries: 2 → 10 (11 total attempts)
  - Base backoff multiplier: 0.5s → 2.0s
  - Max backoff delay: 8s → 30s

New behavior:
  - Retry delays: ~1.5s, ~3s, ~6s, ~12s, ~24s, then ~30s (capped)
  - Total retry window: ~3 minutes
  - Still honors Retry-After headers when provided by the API