### PR TITLE
fix: fix browser_rendering tests

### DIFF
--- a/browser_rendering/json_test.go
+++ b/browser_rendering/json_test.go
@@ -31,7 +31,7 @@ func TestJsonNewWithOptionalParams(t *testing.T) {
 	_, err := client.BrowserRendering.Json.New(context.TODO(), browser_rendering.JsonNewParams{
 		AccountID: cloudflare.F("account_id"),
 		Body: browser_rendering.JsonNewParamsBodyObject{
-			URL:           cloudflare.F("https://www.example.com/"),
+			HTML:          cloudflare.F("x"),
 			ActionTimeout: cloudflare.F(120000.000000),
 			AddScriptTag: cloudflare.F([]browser_rendering.JsonNewParamsBodyObjectAddScriptTag{{
 				ID:      cloudflare.F("id"),

--- a/browser_rendering/link_test.go
+++ b/browser_rendering/link_test.go
@@ -30,7 +30,7 @@ func TestLinkNewWithOptionalParams(t *testing.T) {
 	_, err := client.BrowserRendering.Links.New(context.TODO(), browser_rendering.LinkNewParams{
 		AccountID: cloudflare.F("account_id"),
 		Body: browser_rendering.LinkNewParamsBodyObject{
-			URL:           cloudflare.F("https://www.example.com/"),
+			HTML:          cloudflare.F("x"),
 			ActionTimeout: cloudflare.F(120000.000000),
 			AddScriptTag: cloudflare.F([]browser_rendering.LinkNewParamsBodyObjectAddScriptTag{{
 				ID:      cloudflare.F("id"),

--- a/browser_rendering/pdf_test.go
+++ b/browser_rendering/pdf_test.go
@@ -32,7 +32,7 @@ func TestPDFNewWithOptionalParams(t *testing.T) {
 	resp, err := client.BrowserRendering.PDF.New(context.TODO(), browser_rendering.PDFNewParams{
 		AccountID: cloudflare.F("account_id"),
 		Body: browser_rendering.PDFNewParamsBodyObject{
-			URL:           cloudflare.F("https://www.example.com/"),
+			HTML:          cloudflare.F("x"),
 			ActionTimeout: cloudflare.F(120000.000000),
 			AddScriptTag: cloudflare.F([]browser_rendering.PDFNewParamsBodyObjectAddScriptTag{{
 				ID:      cloudflare.F("id"),

--- a/browser_rendering/scrape_test.go
+++ b/browser_rendering/scrape_test.go
@@ -33,7 +33,7 @@ func TestScrapeNewWithOptionalParams(t *testing.T) {
 			Elements: cloudflare.F([]browser_rendering.ScrapeNewParamsBodyObjectElement{{
 				Selector: cloudflare.F("h1"),
 			}}),
-			URL:           cloudflare.F("https://www.example.com/"),
+			HTML:          cloudflare.F("x"),
 			ActionTimeout: cloudflare.F(120000.000000),
 			AddScriptTag: cloudflare.F([]browser_rendering.ScrapeNewParamsBodyObjectAddScriptTag{{
 				ID:      cloudflare.F("id"),

--- a/browser_rendering/screenshot_test.go
+++ b/browser_rendering/screenshot_test.go
@@ -30,7 +30,7 @@ func TestScreenshotNewWithOptionalParams(t *testing.T) {
 	_, err := client.BrowserRendering.Screenshot.New(context.TODO(), browser_rendering.ScreenshotNewParams{
 		AccountID: cloudflare.F("account_id"),
 		Body: browser_rendering.ScreenshotNewParamsBodyObject{
-			URL:           cloudflare.F("https://www.example.com/"),
+			HTML:          cloudflare.F("x"),
 			ActionTimeout: cloudflare.F(120000.000000),
 			AddScriptTag: cloudflare.F([]browser_rendering.ScreenshotNewParamsBodyObjectAddScriptTag{{
 				ID:      cloudflare.F("id"),

--- a/browser_rendering/snapshot_test.go
+++ b/browser_rendering/snapshot_test.go
@@ -30,7 +30,7 @@ func TestSnapshotNewWithOptionalParams(t *testing.T) {
 	_, err := client.BrowserRendering.Snapshot.New(context.TODO(), browser_rendering.SnapshotNewParams{
 		AccountID: cloudflare.F("account_id"),
 		Body: browser_rendering.SnapshotNewParamsBodyObject{
-			URL:           cloudflare.F("https://www.example.com/"),
+			HTML:          cloudflare.F("x"),
 			ActionTimeout: cloudflare.F(120000.000000),
 			AddScriptTag: cloudflare.F([]browser_rendering.SnapshotNewParamsBodyObjectAddScriptTag{{
 				ID:      cloudflare.F("id"),


### PR DESCRIPTION
Curiously the `URL` field was removed in v6.6.0, but the codegen'd tests were never updated.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
