### PR TITLE
feat(zero_trust): add LastSeenAt field to ServiceToken

### DIFF
--- a/zero_trust/accessservicetoken.go
+++ b/zero_trust/accessservicetoken.go
@@ -270,6 +270,8 @@ type ServiceToken struct {
 	// default is 1 year in hours (8760h).
 	Duration  string    `json:"duration"`
 	ExpiresAt time.Time `json:"expires_at" format:"date-time"`
+	// The date and time the service token was last used.
+	LastSeenAt time.Time `json:"last_seen_at" format:"date-time"`
 	// The name of the service token.
 	Name string           `json:"name"`
 	JSON serviceTokenJSON `json:"-"`
@@ -281,6 +283,7 @@ type serviceTokenJSON struct {
 	ClientID    apijson.Field
 	Duration    apijson.Field
 	ExpiresAt   apijson.Field
+	LastSeenAt  apijson.Field
 	Name        apijson.Field
 	raw         string
 	ExtraFields map[string]apijson.Field

--- a/zero_trust/accessservicetoken.go
+++ b/zero_trust/accessservicetoken.go
@@ -270,7 +270,6 @@ type ServiceToken struct {
 	// default is 1 year in hours (8760h).
 	Duration  string    `json:"duration"`
 	ExpiresAt time.Time `json:"expires_at" format:"date-time"`
-	// The date and time the service token was last used.
 	LastSeenAt time.Time `json:"last_seen_at" format:"date-time"`
 	// The name of the service token.
 	Name string           `json:"name"`


### PR DESCRIPTION
## Summary

The Cloudflare API returns a `last_seen_at` field for service tokens, but the auto-generated v6 SDK `ServiceToken` struct is missing it. This field was [previously added to the v0 SDK](https://github.com/cloudflare/cloudflare-go/pull/3838), but the v6 SDK (generated from the OpenAPI spec) still omits it.

This PR adds:
- `LastSeenAt time.Time` field to the `ServiceToken` struct with `json:"last_seen_at" format:"date-time"` tags
- Corresponding `LastSeenAt apijson.Field` to the `serviceTokenJSON` metadata struct

This follows the same pattern as the existing `ExpiresAt` field.

## Context

The `last_seen_at` field is returned by the Cloudflare API for service tokens and is useful for identifying stale/unused tokens. Without this field in the SDK, consumers must work around the omission with custom structs and raw JSON re-unmarshaling.

Ref: v0 fix in #3838