### PR TITLE
build(url_scanner): fix recursive type reference

### DIFF
--- a/url_scanner/scan.go
+++ b/url_scanner/scan.go
@@ -1647,7 +1647,7 @@ func (r scanGetResponseMetaProcessorsRobotsTXTDataJSON) RawJSON() string {
 }
 
 type ScanGetResponseMetaProcessorsRobotsTXTDataRules struct {
-	Star ScanGetResponseMetaProcessorsRobotsTXTDataRules     `json:"*,required"`
+	Star *ScanGetResponseMetaProcessorsRobotsTXTDataRules    `json:"*,required"`
 	JSON scanGetResponseMetaProcessorsRobotsTXTDataRulesJSON `json:"-"`
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- Change the Star field to a pointer to break the direct self-reference that caused a build failure.

## Test Output
```
  ⎿  === RUN   TestResponseGet
     --- PASS: TestResponseGet (0.02s)
     === RUN   TestScanNewWithOptionalParams
     --- PASS: TestScanNewWithOptionalParams (0.02s)
     === RUN   TestScanListWithOptionalParams
     --- PASS: TestScanListWithOptionalParams (0.02s)
     === RUN   TestScanBulkNewWithOptionalParams
     --- PASS: TestScanBulkNewWithOptionalParams (0.02s)
     === RUN   TestScanDOM
     --- PASS: TestScanDOM (0.02s)
     === RUN   TestScanGet
         scan_test.go:147: TODO: investigate broken test
     --- SKIP: TestScanGet (0.00s)
     === RUN   TestScanHAR
     --- PASS: TestScanHAR (0.02s)
     === RUN   TestScanScreenshotWithOptionalParams
     --- PASS: TestScanScreenshotWithOptionalParams (0.00s)
     PASS
     ok         github.com/cloudflare/cloudflare-go/v6/url_scanner      0.995s
```