### PR TITLE
Include Origin field in Custom Hostname creation request

### DIFF
--- a/custom_hostnames/customhostname.go
+++ b/custom_hostnames/customhostname.go
@@ -2218,7 +2218,10 @@ type CustomHostnameNewParams struct {
 	ZoneID param.Field[string] `path:"zone_id,required"`
 	// The custom hostname that will point to your hostname via CNAME.
 	Hostname param.Field[string] `json:"hostname,required"`
+	// The custom origin that will used in custom hostname
+	CustomOriginServer param.Field[string] `json:"custom_origin_server"`
 	// Unique key/value metadata for this hostname. These are per-hostname (customer)
+
 	// settings.
 	CustomMetadata param.Field[map[string]string] `json:"custom_metadata"`
 	// SSL properties used when creating the custom hostname.

--- a/custom_hostnames/customhostname_test.go
+++ b/custom_hostnames/customhostname_test.go
@@ -29,8 +29,9 @@ func TestCustomHostnameNewWithOptionalParams(t *testing.T) {
 		option.WithAPIEmail("user@example.com"),
 	)
 	_, err := client.CustomHostnames.New(context.TODO(), custom_hostnames.CustomHostnameNewParams{
-		ZoneID:   cloudflare.F("023e105f4ecef8ad9ca31a8372d0c353"),
-		Hostname: cloudflare.F("app.example.com"),
+		ZoneID:             cloudflare.F("023e105f4ecef8ad9ca31a8372d0c353"),
+		Hostname:           cloudflare.F("app.example.com"),
+		CustomOriginServer: cloudflare.F("origin.example.com"),
 		CustomMetadata: cloudflare.F(map[string]string{
 			"foo": "string",
 		}),


### PR DESCRIPTION
This PR addresses the following issue:
https://github.com/cloudflare/cloudflare-go/issues/4204

It adds support for specifying the Origin field during the creation of a Custom Hostname.

Please consider merging this fix.