### PR TITLE
fix: add check for transport errors, pass error in retry logic

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -4,9 +4,12 @@ package cloudflare_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -296,5 +299,201 @@ func TestContextDeadline(t *testing.T) {
 		if diff := time.Since(deadline); diff < -30*time.Millisecond || 30*time.Millisecond < diff {
 			t.Fatalf("client did not return within 30ms of context deadline, got %s", diff)
 		}
+	}
+}
+
+// TestRetryOnUnexpectedEOF verifies that io.ErrUnexpectedEOF triggers retries.
+// This test validates the fix for APIX-435 where transport-level errors like
+// "unexpected EOF" should be retried automatically.
+func TestRetryOnUnexpectedEOF(t *testing.T) {
+	retryCountHeaders := make([]string, 0)
+	attemptCount := 0
+
+	client := cloudflare.NewClient(
+		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
+		option.WithAPIEmail("user@example.com"),
+		option.WithMaxRetries(3), // Reduce retries for faster test
+		option.WithHTTPClient(&http.Client{
+			Transport: &closureTransport{
+				fn: func(req *http.Request) (*http.Response, error) {
+					retryCountHeaders = append(retryCountHeaders, req.Header.Get("X-Stainless-Retry-Count"))
+					attemptCount++
+
+					// Fail first 2 attempts with unexpected EOF, succeed on 3rd
+					if attemptCount < 3 {
+						return nil, io.ErrUnexpectedEOF
+					}
+
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"result":{"id":"test","name":"example.com"},"success":true}`)),
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+					}, nil
+				},
+			},
+		}),
+	)
+
+	_, err := client.Zones.New(context.Background(), zones.ZoneNewParams{
+		Account: cloudflare.F(zones.ZoneNewParamsAccount{
+			ID: cloudflare.F("023e105f4ecef8ad9ca31a8372d0c353"),
+		}),
+		Name: cloudflare.F("example.com"),
+		Type: cloudflare.F(zones.TypeFull),
+	})
+
+	if err != nil {
+		t.Errorf("Expected request to succeed after retries, got error: %v", err)
+	}
+
+	if attemptCount != 3 {
+		t.Errorf("Expected 3 attempts, got %d", attemptCount)
+	}
+
+	expectedRetryCountHeaders := []string{"0", "1", "2"}
+	if !reflect.DeepEqual(retryCountHeaders, expectedRetryCountHeaders) {
+		t.Errorf("Expected %v retry count headers, got %v", expectedRetryCountHeaders, retryCountHeaders)
+	}
+}
+
+// TestNoRetryOnContextCanceled verifies that context.Canceled does NOT trigger retries.
+// This ensures that intentional cancellations are respected and not retried.
+func TestNoRetryOnContextCanceled(t *testing.T) {
+	retryCountHeaders := make([]string, 0)
+	attemptCount := 0
+
+	client := cloudflare.NewClient(
+		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
+		option.WithAPIEmail("user@example.com"),
+		option.WithHTTPClient(&http.Client{
+			Transport: &closureTransport{
+				fn: func(req *http.Request) (*http.Response, error) {
+					retryCountHeaders = append(retryCountHeaders, req.Header.Get("X-Stainless-Retry-Count"))
+					attemptCount++
+					return nil, context.Canceled
+				},
+			},
+		}),
+	)
+
+	_, err := client.Zones.New(context.Background(), zones.ZoneNewParams{
+		Account: cloudflare.F(zones.ZoneNewParamsAccount{
+			ID: cloudflare.F("023e105f4ecef8ad9ca31a8372d0c353"),
+		}),
+		Name: cloudflare.F("example.com"),
+		Type: cloudflare.F(zones.TypeFull),
+	})
+
+	if err == nil {
+		t.Error("Expected context.Canceled error, got nil")
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Expected context.Canceled error, got: %v", err)
+	}
+
+	if attemptCount != 1 {
+		t.Errorf("Expected exactly 1 attempt (no retries), got %d", attemptCount)
+	}
+
+	expectedRetryCountHeaders := []string{"0"}
+	if !reflect.DeepEqual(retryCountHeaders, expectedRetryCountHeaders) {
+		t.Errorf("Expected %v retry count headers, got %v", expectedRetryCountHeaders, retryCountHeaders)
+	}
+}
+
+// TestNoRetryOnContextDeadlineExceeded verifies that context.DeadlineExceeded does NOT trigger retries.
+// This ensures that timeout errors are respected and not retried.
+func TestNoRetryOnContextDeadlineExceeded(t *testing.T) {
+	retryCountHeaders := make([]string, 0)
+	attemptCount := 0
+
+	client := cloudflare.NewClient(
+		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
+		option.WithAPIEmail("user@example.com"),
+		option.WithHTTPClient(&http.Client{
+			Transport: &closureTransport{
+				fn: func(req *http.Request) (*http.Response, error) {
+					retryCountHeaders = append(retryCountHeaders, req.Header.Get("X-Stainless-Retry-Count"))
+					attemptCount++
+					return nil, context.DeadlineExceeded
+				},
+			},
+		}),
+	)
+
+	_, err := client.Zones.New(context.Background(), zones.ZoneNewParams{
+		Account: cloudflare.F(zones.ZoneNewParamsAccount{
+			ID: cloudflare.F("023e105f4ecef8ad9ca31a8372d0c353"),
+		}),
+		Name: cloudflare.F("example.com"),
+		Type: cloudflare.F(zones.TypeFull),
+	})
+
+	if err == nil {
+		t.Error("Expected context.DeadlineExceeded error, got nil")
+	}
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Expected context.DeadlineExceeded error, got: %v", err)
+	}
+
+	if attemptCount != 1 {
+		t.Errorf("Expected exactly 1 attempt (no retries), got %d", attemptCount)
+	}
+
+	expectedRetryCountHeaders := []string{"0"}
+	if !reflect.DeepEqual(retryCountHeaders, expectedRetryCountHeaders) {
+		t.Errorf("Expected %v retry count headers, got %v", expectedRetryCountHeaders, retryCountHeaders)
+	}
+}
+
+// TestRetryExhaustsMaxRetriesOnTransportError verifies that transport errors
+// are retried up to MaxRetries and then fail with the original error.
+// This validates that retry exhaustion works correctly for APIX-435.
+func TestRetryExhaustsMaxRetriesOnTransportError(t *testing.T) {
+	retryCountHeaders := make([]string, 0)
+	attemptCount := 0
+
+	client := cloudflare.NewClient(
+		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
+		option.WithAPIEmail("user@example.com"),
+		option.WithMaxRetries(3), // Use 3 retries for faster test
+		option.WithHTTPClient(&http.Client{
+			Transport: &closureTransport{
+				fn: func(req *http.Request) (*http.Response, error) {
+					retryCountHeaders = append(retryCountHeaders, req.Header.Get("X-Stainless-Retry-Count"))
+					attemptCount++
+					// Always return unexpected EOF to exhaust retries
+					return nil, io.ErrUnexpectedEOF
+				},
+			},
+		}),
+	)
+
+	_, err := client.Zones.New(context.Background(), zones.ZoneNewParams{
+		Account: cloudflare.F(zones.ZoneNewParamsAccount{
+			ID: cloudflare.F("023e105f4ecef8ad9ca31a8372d0c353"),
+		}),
+		Name: cloudflare.F("example.com"),
+		Type: cloudflare.F(zones.TypeFull),
+	})
+
+	if err == nil {
+		t.Error("Expected io.ErrUnexpectedEOF error, got nil")
+	}
+
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("Expected io.ErrUnexpectedEOF error, got: %v", err)
+	}
+
+	// Should make initial attempt + 3 retries = 4 total attempts
+	if attemptCount != 4 {
+		t.Errorf("Expected 4 attempts (initial + 3 retries), got %d", attemptCount)
+	}
+
+	expectedRetryCountHeaders := []string{"0", "1", "2", "3"}
+	if !reflect.DeepEqual(retryCountHeaders, expectedRetryCountHeaders) {
+		t.Errorf("Expected %v retry count headers, got %v", expectedRetryCountHeaders, retryCountHeaders)
 	}
 }

--- a/internal/requestconfig/requestconfig.go
+++ b/internal/requestconfig/requestconfig.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -245,7 +246,18 @@ func applyMiddleware(middleware middleware, next middlewareNext) middlewareNext 
 	}
 }
 
-func shouldRetry(req *http.Request, res *http.Response) bool {
+func shouldRetry(req *http.Request, res *http.Response, err error) bool {
+	// Retry on transport-level errors (unexpected EOF, connection drops, etc.)
+	// These errors occur during network I/O and should be retried automatically.
+	if err != nil {
+		// Don't retry on intentional cancellations or deadline exceeded
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false
+		}
+		// Retry on any other error (connection errors, EOF, network issues)
+		return true
+	}
+
 	// If there is no way to recover the Body, then we shouldn't retry.
 	if req.Body != nil && req.GetBody == nil {
 		return false
@@ -455,7 +467,7 @@ func (cfg *RequestConfig) Execute() (err error) {
 		if ctx != nil && ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if !shouldRetry(cfg.Request, res) || retryCount >= cfg.MaxRetries {
+		if !shouldRetry(cfg.Request, res, err) || retryCount >= cfg.MaxRetries {
 			break
 		}
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Customers using terraform provider v5.16/5.17 experienced intermittent failures with "error reading response body: unexpected EOF" during plan operations. These network levels transport errors should be retried. 

This adds retry logic to check for transport-level errors (EOF, connection drops).

## Additional context & links
