### PR TITLE
shared: fix 'occured' -> 'occurred' in audit log doc comment

### DIFF
--- a/shared/shared.go
+++ b/shared/shared.go
@@ -31,7 +31,7 @@ type AuditLog struct {
 	OldValue string           `json:"oldValue"`
 	Owner    AuditLogOwner    `json:"owner"`
 	Resource AuditLogResource `json:"resource"`
-	// A UTC RFC3339 timestamp that specifies when the action being logged occured.
+	// A UTC RFC3339 timestamp that specifies when the action being logged occurred.
 	When time.Time    `json:"when" format:"date-time"`
 	JSON auditLogJSON `json:"-"`
 }


### PR DESCRIPTION
Comment in `shared/shared.go` line 34 reads `when the action being logged occured`. Fixed to `occurred`. Comment-only change.