### PR TITLE
chore: sync codegen from staging-next (2026-04-20)

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 2192
 openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare%2Fcloudflare-3d7d43f051a510c54ae71adb4b85cbb422565a40942cde4de0c3f8eb6ba8023b.yml
 openapi_spec_hash: e85824f16c3ba923a34e514c06dac7cd
-config_hash: 8e0db73307b1b4985e9be894257425dd
+config_hash: 02fbdebd82a78d34dd6d005f1d2ad28c


### PR DESCRIPTION
## Codegen Sync: staging-next -> next

Synced from `staging-next` (5440e42) as of 2026-04-20. **All 9 resources were excluded** due to test failures or breaking changes. Only `.stats.yml` metadata survives.

### Excluded Resources

| Resource | Category | Root Cause |
|----------|----------|------------|
| custom_pages | test-fail | `TestCustomPageUpdateWithOptionalParams` -- mock server rejected request shape |
| security_center | test-fail | `TestInsightListWithOptionalParams` -- mock server rejected request shape |
| vulnerability_scanner | test-fail | `TestScanNew` -- new resource, mock server rejected request shape |
| waiting_rooms | test-fail | `TestWaitingRoomListWithOptionalParams` -- mock server rejected request shape |
| ai_search | breaking-change | Removed `OrderBy`/`OrderByDirection` from `TokenListParams`; added Namespace sub-service |
| magic_network_monitoring | breaking-change | Removed `Bandwidth` field from `RuleNewParams`/`RuleUpdateParams`/`RuleEditParams` |
| pipelines | breaking-change | `DeleteV1`/`Sinks.Delete`/`Streams.Delete` changed return value count (1 -> 2) |
| secrets_store | breaking-change | Removed `Body` field and `StoreNewParamsBody` type from `StoreNewParams` |
| stream | breaking-change | Removed fields from `ClipNewParams`, `DownloadNewParams`, `StreamNewParams`, `WatermarkNewParams`, `WebhookUpdateParams` |

### Shared Changes

- Updated `.stats.yml` codegen metadata

### Notes

- 4 resources failed Prism mock server tests (request shape mismatch)
- 5 resources passed mock tests but introduced breaking changes (old tests from `next` don't compile against new source)
- All 9 resources were excluded and fully reverted to `origin/next` state
- Breaking changes suggest upstream OpenAPI spec changes removed or restructured request parameters

### Validation

- `go build ./...` -- PASS
- `./scripts/lint` -- PASS
- `./scripts/detect-breaking-changes origin/next` -- PASS