### PR TITLE
docs: add v6.10.0 changelog and migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,205 @@
 
 Full Changelog: [v6.9.0...v6.10.0](https://github.com/cloudflare/cloudflare-go/compare/v6.9.0...v6.10.0)
 
-### Features
+In this release, you'll see a number of breaking changes. This is primarily due to changes in OpenAPI definitions, which our libraries are based off of, and codegen updates that we rely on to read those OpenAPI definitions and produce our SDK libraries.
 
-* chore: remove account_id and zone_id client options ([#4271](https://github.com/cloudflare/cloudflare-go/issues/4271)) ([249ec88](https://github.com/cloudflare/cloudflare-go/commit/249ec88a144c1a1fd00d9b3bd07d54e6d8d4701d))
-* feat(iam): add user_groups and user_group_members terraform resources ([#4267](https://github.com/cloudflare/cloudflare-go/issues/4267)) ([41fb6d3](https://github.com/cloudflare/cloudflare-go/commit/41fb6d32b6bbe9d6fdb091e143557a98fb748863))
+## Please ensure you read through the list of changes below before moving to this version - this will help you understand any down or upstream issues it may cause to your environments.
 
+---
 
-### Chores
+## Breaking Changes
 
-* **api:** update composite API spec ([#4270](https://github.com/cloudflare/cloudflare-go/issues/4270)) ([8b6f7bc](https://github.com/cloudflare/cloudflare-go/commit/8b6f7bc6cc9dd94bf2ceb84096520635bf7e1c54))
-* sync codegen from staging-next (2026-04-17) ([#4262](https://github.com/cloudflare/cloudflare-go/issues/4262)) ([7138b06](https://github.com/cloudflare/cloudflare-go/commit/7138b069af7dcb2c9121faf2ed0167cf73420087))
+See the [v6.10.0 Migration Guide](./docs/migration-guides/v6.10.0-migration-guide.md) for before/after code examples and actions needed for each change.
+
+### Abuse Reports - Registrar WHOIS Report Field Removals
+
+Several fields have been removed from `AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReportRegWhoRequest`:
+
+- `RegWhoGoodFaithAffirmation`
+- `RegWhoLawfulProcessingAgreement`
+- `RegWhoLegalBasis`
+- `RegWhoRequestType`
+- `RegWhoRequestedDataElements`
+
+### AI Search - Instance Params Restructured
+
+The `InstanceNewParams` and `InstanceUpdateParams` types have been significantly restructured. Many fields have been moved or removed:
+
+- `InstanceNewParams.TokenID`, `Type`, `CreatedFromAISearchWizard`, `WorkerDomain` removed
+- `InstanceUpdateParams` — most configuration fields removed (including `IndexMethod`, `IndexingOptions`, `MaxNumResults`, `Metadata`, `Paused`, `PublicEndpointParams`, `Reranking`, `RerankingModel`, `RetrievalOptions`, `RewriteModel`, `RewriteQuery`, `ScoreThreshold`, `SourceParams`, `Summarization`, `SummarizationModel`, `SystemPromptAISearch`, `SystemPromptIndexSummarization`, `SystemPromptRewriteQuery`, `TokenID`, `CreatedFromAISearchWizard`, `WorkerDomain`)
+- `InstanceSearchParams.Messages` field removed along with `InstanceSearchParamsMessage` and `InstanceSearchParamsMessagesRole` types
+
+### AI Search - InstanceItem Service Removed
+
+The `InstanceItemService` type has been removed. The items sub-resource at `client.AISearch.Instances.Items` no longer exists in the non-namespace path. Use `client.AISearch.Namespaces.Instances.Items` instead.
+
+### AI Search - Token Types Removed
+
+The following types have been removed from the `ai_search` package:
+
+- `TokenDeleteResponse`
+- `TokenListParams` (and associated `TokenListParamsOrderBy`, `TokenListParamsOrderByDirection`)
+
+### Email Security - Investigate Move Return Type Change
+
+The `Investigate.Move.New()` method now returns a raw slice instead of a paginated wrapper:
+
+- `New()` returns `*[]InvestigateMoveNewResponse` instead of `*pagination.SinglePage[InvestigateMoveNewResponse]`
+- `NewAutoPaging()` method removed
+
+### Hyperdrive - Config Params Restructured
+
+The `ConfigEditParams` type lost its `MTLS` and `Name` fields. The `HyperdriveMTLSParam` type lost `MTLS` and `Host` fields. The `Host` field on origin config changed from `param.Field[string]` to a plain `string`.
+
+### IAM - UserGroupMember Params and Return Types Changed
+
+The `UserGroupMemberNewParams` struct has been restructured and the `New()` method now returns a paginated response:
+
+- `UserGroupMemberNewParams.Body` renamed to `UserGroupMemberNewParams.Members`
+- `UserGroupMemberNewParamsBody` renamed to `UserGroupMemberNewParamsMember`
+- `UserGroupMemberUpdateParams.Body` renamed to `UserGroupMemberUpdateParams.Members`
+- `UserGroupMemberUpdateParamsBody` renamed to `UserGroupMemberUpdateParamsMember`
+- `UserGroups.Members.New()` returns `*pagination.SinglePage[UserGroupMemberNewResponse]` instead of `*UserGroupMemberNewResponse`
+
+### IAM - UserGroup List Direction Type Changed
+
+The `UserGroupListParams.Direction` field changed from `param.Field[string]` to `param.Field[UserGroupListParamsDirection]` (typed enum with `asc`/`desc` values).
+
+### Pipelines - Delete Methods Now Return Typed Responses
+
+Several delete methods across Pipelines now return typed responses instead of bare `error`:
+
+- `Pipelines.DeleteV1()` returns `(*PipelineDeleteV1Response, error)` instead of `error`
+- `Pipelines.Sinks.Delete()` returns `(*SinkDeleteResponse, error)` instead of `error`
+- `Pipelines.Streams.Delete()` returns `(*StreamDeleteResponse, error)` instead of `error`
+
+### Queues - Message Response Types Removed
+
+The following response envelope types have been removed:
+
+- `MessageBulkPushResponseSuccess`
+- `MessagePushResponseSuccess`
+- `MessageAckResponse` fields `RetryCount` and `Warnings` removed
+
+### Secrets Store - Pagination Wrapper Removal and Type Changes
+
+Methods now return direct types instead of `SinglePage` wrappers, and several internal types have been removed. Associated `AutoPaging` methods have also been removed:
+
+- `Stores.New()` returns `*StoreNewResponse` instead of `*pagination.SinglePage[StoreNewResponse]`
+- `Stores.NewAutoPaging()` method removed
+- `Stores.Secrets.BulkDelete()` returns `*StoreSecretBulkDeleteResponse` instead of `*pagination.SinglePage[StoreSecretBulkDeleteResponse]`
+- `Stores.Secrets.BulkDeleteAutoPaging()` method removed
+- Removed types: `StoreDeleteResponse`, `StoreDeleteResponseEnvelopeResultInfo`, `StoreSecretDeleteResponse`, `StoreSecretDeleteResponseStatus`, `StoreSecretBulkDeleteResponse` (old shape), `StoreSecretBulkDeleteResponseStatus`, `StoreSecretDeleteResponseEnvelopeResultInfo`
+- `StoreNewParams` restructured (old `StoreNewParamsBody` removed)
+- `StoreSecretBulkDeleteParams` restructured
+
+### Stream - AudioTracks Return Type Change
+
+The `AudioTracks.Get()` method now returns a dedicated response type instead of a paginated list. The `GetAutoPaging()` method has been removed:
+
+- `Get()` returns `*AudioTrackGetResponse` instead of `*pagination.SinglePage[Audio]`
+- `GetAutoPaging()` method removed
+
+### Stream - Clip Type Removal and Return Type Change
+
+The `Clip.New()` method now returns the shared `Video` type. The following types have been entirely removed:
+
+- `Clip`, `ClipPlayback`, `ClipStatus`, `ClipWatermark`
+
+### Stream - Copy and Clip Params Field Removals
+
+- `ClipNewParams.MaxDurationSeconds`, `ThumbnailTimestampPct`, `Watermark` removed
+- `CopyNewParams.ThumbnailTimestampPct`, `Watermark` removed
+
+### Stream - Download and Webhook Changes
+
+- `DownloadNewResponseStatus` type removed
+- `WebhookUpdateResponse` and `WebhookGetResponse` changed from `interface{}` type aliases to full struct types
+
+### Zero Trust - Access AI Control MCP Portal Union Types Removed
+
+The following union interface types have been removed:
+
+- `AccessAIControlMcpPortalListResponseServersUpdatedPromptsUnion`
+- `AccessAIControlMcpPortalListResponseServersUpdatedToolsUnion`
+- `AccessAIControlMcpPortalReadResponseServersUpdatedPromptsUnion`
+- `AccessAIControlMcpPortalReadResponseServersUpdatedToolsUnion`
+
+---
+
+## Features
+
+### Vulnerability Scanner (`client.VulnerabilityScanner`)
+
+- **NEW SERVICE**: Full vulnerability scanning management
+    - `CredentialSets` - CRUD for credential sets (`New`, `Update`, `List`, `Delete`, `Edit`, `Get`)
+        - `Credentials` - Manage credentials within sets (`New`, `Update`, `List`, `Delete`, `Edit`, `Get`)
+    - `Scans` - Create and manage vulnerability scans (`New`, `List`, `Get`)
+    - `TargetEnvironments` - Manage scan target environments (`New`, `Update`, `List`, `Delete`, `Edit`, `Get`)
+
+### AI Search - Namespaces (`client.AISearch.Namespaces`)
+
+- **NEW SERVICE**: Namespace-scoped AI Search management
+    - `New()`, `Update()`, `List()`, `Delete()`, `ChatCompletions()`, `Read()`, `Search()`
+    - `Instances` - Namespace-scoped instances (`New`, `Update`, `List`, `Delete`, `ChatCompletions`, `Read`, `Search`, `Stats`)
+        - `Jobs` - Instance job management (`New`, `Update`, `List`, `Get`, `Logs`)
+        - `Items` - Instance item management (`List`, `Delete`, `Chunks`, `NewOrUpdate`, `Download`, `Get`, `Logs`, `Sync`, `Upload`)
+
+### Browser Rendering - Devtools (`client.BrowserRendering.Devtools`)
+
+- **NEW SERVICE**: DevTools protocol browser control
+    - `Session` - List and get devtools sessions
+    - `Browser` - Browser lifecycle management (`New`, `Delete`, `Connect`, `Launch`, `Protocol`, `Version`)
+        - `Page` - Get page by target ID
+        - `Targets` - Manage browser targets (`New`, `List`, `Activate`, `Get`)
+
+### Registrar (`client.Registrar`)
+
+- **NEW**: Domain check and search endpoints
+    - `Check()` - POST `/accounts/{account_id}/registrar/domain-check`
+    - `Search()` - GET `/accounts/{account_id}/registrar/domain-search`
+- **NEW**: Registration management (`client.Registrar.Registrations`)
+    - `New()`, `List()`, `Edit()`, `Get()`
+- `RegistrationStatus.Get()` - Get registration workflow status
+- `UpdateStatus.Get()` - Get update workflow status
+
+### Cache - Origin Cloud Regions (`client.Cache.OriginCloudRegions`)
+
+- **NEW SERVICE**: Manage origin cloud region configurations
+    - `New()`, `List()`, `Delete()`, `BulkDelete()`, `BulkEdit()`, `Edit()`, `Get()`, `SupportedRegions()`
+
+### Zero Trust - DLP Settings (`client.ZeroTrust.DLP.Settings`)
+
+- **NEW SERVICE**: DLP settings management
+    - `Update()`, `Delete()`, `Edit()`, `Get()`
+
+### Radar
+
+- `AgentReadiness.Summary()` - Agent readiness summary by dimension
+- `AI.MarkdownForAgents.Summary()` - Markdown-for-agents summary
+- `AI.MarkdownForAgents.Timeseries()` - Markdown-for-agents timeseries
+
+### IAM (`client.IAM`)
+
+- `UserGroups.Members.Get()` - Get details of a specific member in a user group
+- `UserGroups.Members.NewAutoPaging()` - Auto-paging variant for adding members
+- `UserGroups.NewParams.Policies` changed from required to optional
+
+### Bot Management
+
+- `ContentBotsProtection` field added to `BotFightModeConfiguration` and `SubscriptionConfiguration` (block/disabled)
+
+---
+
+## Deprecations
+
+None in this release.
+
+---
+
+## Bug Fixes
+
+- **Testing**: CONTRIBUTING.md updated to reference [steady](https://github.com/dgellow/steady) instead of Prism for running tests against OpenAPI specs
 
 ## 6.9.0 (2026-04-01)
 

--- a/docs/migration-guides/v6.10.0-migration-guide.md
+++ b/docs/migration-guides/v6.10.0-migration-guide.md
@@ -1,0 +1,579 @@
+# v6.10.0 Migration Guide
+
+## Breaking Changes
+
+### `Abuse Reports`
+
+#### 1. Registrar WHOIS Report field removals
+
+**What changed:**
+Several `RegWho*` fields have been removed from `AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReportRegWhoRequest`.
+
+**Impact:**
+Code that sets these fields when filing registrar WHOIS abuse reports will no longer compile.
+
+**Removed Fields:**
+- `RegWhoGoodFaithAffirmation`
+- `RegWhoLawfulProcessingAgreement`
+- `RegWhoLegalBasis`
+- `RegWhoRequestType`
+- `RegWhoRequestedDataElements`
+
+**Before (v6.9.0):**
+```go
+params := abuse_reports.AbuseReportNewParams{
+    Body: abuse_reports.AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReport{
+        RegWhoRequest: cloudflare.F(abuse_reports.AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReportRegWhoRequest{
+            RegWhoGoodFaithAffirmation:      cloudflare.F(true),
+            RegWhoLawfulProcessingAgreement: cloudflare.F(true),
+            RegWhoLegalBasis:                cloudflare.F("legitimate_interest"),
+            RegWhoRequestType:               cloudflare.F(abuse_reports.AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReportRegWhoRequestRegWhoRequestTypeRegistrant),
+            RegWhoRequestedDataElements:     cloudflare.F([]abuse_reports.AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReportRegWhoRequestRegWhoRequestedDataElement{...}),
+        }),
+    },
+}
+```
+
+**After (v6.10.0):**
+```go
+params := abuse_reports.AbuseReportNewParams{
+    Body: abuse_reports.AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReport{
+        RegWhoRequest: cloudflare.F(abuse_reports.AbuseReportNewParamsBodyAbuseReportsRegistrarWhoisReportRegWhoRequest{
+            // RegWho* fields have been removed
+        }),
+    },
+}
+```
+
+**Actions Needed:**
+1. Remove all uses of `RegWhoGoodFaithAffirmation`, `RegWhoLawfulProcessingAgreement`, `RegWhoLegalBasis`, `RegWhoRequestType`, and `RegWhoRequestedDataElements` from WHOIS report params
+
+---
+
+### `AI Search`
+
+#### 1. Instance params restructured
+
+**What changed:**
+The `InstanceNewParams` and `InstanceUpdateParams` types have been significantly restructured. Many configuration fields have been moved or removed as AI Search now uses namespace-scoped instances.
+
+**Impact:**
+Code that sets instance configuration fields directly on `InstanceNewParams` or `InstanceUpdateParams` will no longer compile.
+
+**Removed from `InstanceNewParams`:**
+- `TokenID`, `Type`, `CreatedFromAISearchWizard`, `WorkerDomain`
+
+**Removed from `InstanceUpdateParams`:**
+- `IndexMethod`, `IndexingOptions`, `MaxNumResults`, `Metadata`, `Paused`, `PublicEndpointParams`, `Reranking`, `RerankingModel`, `RetrievalOptions`, `RewriteModel`, `RewriteQuery`, `ScoreThreshold`, `SourceParams`, `Summarization`, `SummarizationModel`, `SystemPromptAISearch`, `SystemPromptIndexSummarization`, `SystemPromptRewriteQuery`, `TokenID`, `CreatedFromAISearchWizard`, `WorkerDomain`
+
+**Removed from `InstanceSearchParams`:**
+- `Messages` field removed, along with `InstanceSearchParamsMessage` and `InstanceSearchParamsMessagesRole` types
+
+**Before (v6.9.0):**
+```go
+instance, err := client.AISearch.Instances.New(ctx, ai_search.InstanceNewParams{
+    AccountID: cloudflare.F("account-id"),
+    Name:      cloudflare.F("my-instance"),
+    TokenID:   cloudflare.F("token-id"),
+    Type:      cloudflare.F(ai_search.InstanceNewParamsTypeCrawler),
+})
+```
+
+**After (v6.10.0):**
+```go
+// Use namespace-scoped instances instead
+instance, err := client.AISearch.Namespaces.Instances.New(ctx, "namespace-id", ai_search.NamespaceInstanceNewParams{
+    AccountID: cloudflare.F("account-id"),
+    Name:      cloudflare.F("my-instance"),
+})
+```
+
+**Actions Needed:**
+1. Remove all uses of removed fields from `InstanceNewParams` and `InstanceUpdateParams`
+2. Migrate to namespace-scoped instance APIs at `client.AISearch.Namespaces.Instances` where possible
+
+---
+
+#### 2. InstanceItem service removed
+
+**What changed:**
+The `InstanceItemService` type has been entirely removed. The items sub-resource at `client.AISearch.Instances.Items` no longer exists.
+
+**Impact:**
+Code using `client.AISearch.Instances.Items` will no longer compile.
+
+**Before (v6.9.0):**
+```go
+// Items were accessed via the non-namespace path
+items, err := client.AISearch.Instances.Items.List(ctx, "instance-id", ai_search.InstanceItemListParams{
+    AccountID: cloudflare.F("account-id"),
+})
+```
+
+**After (v6.10.0):**
+```go
+// Use the namespace-scoped items path instead
+items, err := client.AISearch.Namespaces.Instances.Items.List(ctx, "namespace-id", "instance-id", ai_search.NamespaceInstanceItemListParams{
+    AccountID: cloudflare.F("account-id"),
+})
+```
+
+**Actions Needed:**
+1. Migrate all `client.AISearch.Instances.Items` usage to `client.AISearch.Namespaces.Instances.Items`
+
+---
+
+#### 3. Token types removed
+
+**What changed:**
+The `TokenDeleteResponse` and `TokenListParams` types (along with `TokenListParamsOrderBy` and `TokenListParamsOrderByDirection`) have been removed from the `ai_search` package.
+
+**Impact:**
+Code referencing these types will no longer compile.
+
+**Actions Needed:**
+1. Remove all references to `TokenDeleteResponse`, `TokenListParams`, `TokenListParamsOrderBy`, and `TokenListParamsOrderByDirection`
+
+---
+
+### `Email Security`
+
+#### 1. Investigate Move return type change
+
+**What changed:**
+The `Investigate.Move.New()` method now returns a raw slice instead of a paginated wrapper. The `NewAutoPaging()` method has been removed.
+
+**Impact:**
+Code that iterates over the paginated response or uses auto-paging will no longer compile.
+
+**Before (v6.9.0):**
+```go
+page, err := client.EmailSecurity.Investigate.Move.New(ctx, "postfix-id", email_security.InvestigateMoveNewParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// page was *pagination.SinglePage[InvestigateMoveNewResponse]
+for _, item := range page.Result {
+    fmt.Println(item)
+}
+
+// Auto-paging was available
+pager := client.EmailSecurity.Investigate.Move.NewAutoPaging(ctx, "postfix-id", params)
+```
+
+**After (v6.10.0):**
+```go
+items, err := client.EmailSecurity.Investigate.Move.New(ctx, "postfix-id", email_security.InvestigateMoveNewParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// items is now *[]InvestigateMoveNewResponse
+for _, item := range *items {
+    fmt.Println(item)
+}
+
+// NewAutoPaging() has been removed
+```
+
+**Actions Needed:**
+1. Update return type from `*pagination.SinglePage[InvestigateMoveNewResponse]` to `*[]InvestigateMoveNewResponse`
+2. Remove all uses of `NewAutoPaging()`
+3. Iterate directly over the slice instead of using `.Result`
+
+---
+
+### `Hyperdrive`
+
+#### 1. Config params restructured
+
+**What changed:**
+The `ConfigEditParams` type lost its `MTLS` and `Name` fields. The `HyperdriveMTLSParam` type lost its `MTLS` and `Host` fields. The `Host` field on origin config changed from `param.Field[string]` to a plain `string`.
+
+**Impact:**
+Code that sets `MTLS` or `Name` on `ConfigEditParams`, or accesses `Host` as a `param.Field` on origin config, will no longer compile.
+
+**Before (v6.9.0):**
+```go
+_, err := client.Hyperdrive.Configs.Edit(ctx, "config-id", hyperdrive.ConfigEditParams{
+    AccountID: cloudflare.F("account-id"),
+    Name:      cloudflare.F("my-config"),
+    MTLS:      cloudflare.F(hyperdrive.ConfigEditParamsMTLS{...}),
+})
+```
+
+**After (v6.10.0):**
+```go
+_, err := client.Hyperdrive.Configs.Edit(ctx, "config-id", hyperdrive.ConfigEditParams{
+    AccountID: cloudflare.F("account-id"),
+    // Name and MTLS fields have been removed from ConfigEditParams
+})
+```
+
+**Actions Needed:**
+1. Remove uses of `Name` and `MTLS` from `ConfigEditParams`
+2. Update any code that accesses `Host` as a `param.Field[string]` on `HyperdriveMTLSParam`
+
+---
+
+### `Pipelines`
+
+#### 1. Delete methods now return typed responses
+
+**What changed:**
+Several delete methods across Pipelines now return typed responses instead of bare `error`.
+
+| Method | Before | After |
+|--------|--------|-------|
+| `Pipelines.DeleteV1()` | `error` | `(*PipelineDeleteV1Response, error)` |
+| `Pipelines.Sinks.Delete()` | `error` | `(*SinkDeleteResponse, error)` |
+| `Pipelines.Streams.Delete()` | `error` | `(*StreamDeleteResponse, error)` |
+
+**Impact:**
+Code that only captures `error` from these methods will need to capture the new response value.
+
+**Before (v6.9.0):**
+```go
+err := client.Pipelines.DeleteV1(ctx, "pipeline-id", pipelines.PipelineDeleteV1Params{
+    AccountID: cloudflare.F("account-id"),
+})
+
+err = client.Pipelines.Sinks.Delete(ctx, "sink-id", pipelines.SinkDeleteParams{
+    AccountID: cloudflare.F("account-id"),
+})
+
+err = client.Pipelines.Streams.Delete(ctx, "stream-id", pipelines.StreamDeleteParams{
+    AccountID: cloudflare.F("account-id"),
+})
+```
+
+**After (v6.10.0):**
+```go
+resp, err := client.Pipelines.DeleteV1(ctx, "pipeline-id", pipelines.PipelineDeleteV1Params{
+    AccountID: cloudflare.F("account-id"),
+})
+
+sinkResp, err := client.Pipelines.Sinks.Delete(ctx, "sink-id", pipelines.SinkDeleteParams{
+    AccountID: cloudflare.F("account-id"),
+})
+
+streamResp, err := client.Pipelines.Streams.Delete(ctx, "stream-id", pipelines.StreamDeleteParams{
+    AccountID: cloudflare.F("account-id"),
+})
+```
+
+**Actions Needed:**
+1. Add a response variable to all `DeleteV1()`, `Sinks.Delete()`, and `Streams.Delete()` calls
+2. Use `_` if you don't need the response: `_, err := client.Pipelines.DeleteV1(...)`
+
+---
+
+### `Queues`
+
+#### 1. Message response types removed
+
+**What changed:**
+The `MessageBulkPushResponseSuccess` and `MessagePushResponseSuccess` types have been removed. The `MessageAckResponse` type has lost its `RetryCount` and `Warnings` fields.
+
+**Impact:**
+Code referencing these types or fields will no longer compile.
+
+**Actions Needed:**
+1. Remove all references to `MessageBulkPushResponseSuccess` and `MessagePushResponseSuccess`
+2. Remove accesses to `RetryCount` and `Warnings` on `MessageAckResponse`
+
+---
+
+### `Secrets Store`
+
+#### 1. Pagination wrapper removal and type changes
+
+**What changed:**
+`Stores.New()` and `Stores.Secrets.BulkDelete()` now return direct types instead of `SinglePage` wrappers. Several internal types have been removed or restructured.
+
+| Method | Before | After |
+|--------|--------|-------|
+| `Stores.New()` | `*pagination.SinglePage[StoreNewResponse]` | `*StoreNewResponse` |
+| `Stores.Secrets.BulkDelete()` | `*pagination.SinglePage[StoreSecretBulkDeleteResponse]` | `*StoreSecretBulkDeleteResponse` |
+
+**Removed Types:**
+- `StoreDeleteResponse` (old shape), `StoreDeleteResponseEnvelopeResultInfo`
+- `StoreSecretDeleteResponse`, `StoreSecretDeleteResponseStatus`
+- `StoreSecretBulkDeleteResponse` (old shape), `StoreSecretBulkDeleteResponseStatus`
+- `StoreSecretDeleteResponseEnvelopeResultInfo`
+- `StoreNewParamsBody`
+
+**Before (v6.9.0):**
+```go
+page, err := client.SecretsStore.Stores.New(ctx, secrets_store.StoreNewParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// page was *pagination.SinglePage[StoreNewResponse]
+for _, store := range page.Result {
+    fmt.Println(store.ID)
+}
+
+bulkPage, err := client.SecretsStore.Stores.Secrets.BulkDelete(ctx, "store-id", secrets_store.StoreSecretBulkDeleteParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// bulkPage was *pagination.SinglePage[StoreSecretBulkDeleteResponse]
+```
+
+**After (v6.10.0):**
+```go
+store, err := client.SecretsStore.Stores.New(ctx, secrets_store.StoreNewParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// store is now *StoreNewResponse directly
+fmt.Println(store.ID)
+
+bulkResp, err := client.SecretsStore.Stores.Secrets.BulkDelete(ctx, "store-id", secrets_store.StoreSecretBulkDeleteParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// bulkResp is now *StoreSecretBulkDeleteResponse directly
+```
+
+**Actions Needed:**
+1. Update `Stores.New()` callers to use the direct `*StoreNewResponse` instead of iterating over `.Result`
+2. Update `Stores.Secrets.BulkDelete()` callers similarly
+3. Remove all references to removed types listed above
+
+---
+
+### `Stream`
+
+#### 1. AudioTracks return type change
+
+**What changed:**
+The `AudioTracks.Get()` method now returns a dedicated `*AudioTrackGetResponse` instead of a paginated `*pagination.SinglePage[Audio]`. The `GetAutoPaging()` method has been removed.
+
+**Before (v6.9.0):**
+```go
+page, err := client.Stream.AudioTracks.Get(ctx, "video-id", stream.AudioTrackGetParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// page was *pagination.SinglePage[Audio]
+for _, track := range page.Result {
+    fmt.Println(track)
+}
+
+// Auto-paging was available
+pager := client.Stream.AudioTracks.GetAutoPaging(ctx, "video-id", params)
+```
+
+**After (v6.10.0):**
+```go
+resp, err := client.Stream.AudioTracks.Get(ctx, "video-id", stream.AudioTrackGetParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// resp is now *AudioTrackGetResponse
+
+// GetAutoPaging() has been removed
+```
+
+**Actions Needed:**
+1. Update callers to use `*AudioTrackGetResponse` instead of iterating over `SinglePage[Audio]`
+2. Remove all uses of `GetAutoPaging()`
+
+---
+
+#### 2. Clip type removal and return type change
+
+**What changed:**
+The `Clip.New()` method now returns `*Video` instead of `*Clip`. The entire `Clip` type and its associated types have been removed.
+
+**Removed Types:**
+- `Clip`, `ClipPlayback`, `ClipStatus`, `ClipWatermark`
+
+**Before (v6.9.0):**
+```go
+clip, err := client.Stream.Clip.New(ctx, stream.ClipNewParams{
+    AccountID:      cloudflare.F("account-id"),
+    ClippedFromVideoUID: cloudflare.F("video-uid"),
+    StartTimeSeconds:    cloudflare.F(int64(0)),
+    EndTimeSeconds:      cloudflare.F(int64(30)),
+    MaxDurationSeconds:  cloudflare.F(int64(60)),
+    Watermark:           cloudflare.F(stream.ClipNewParamsWatermark{...}),
+})
+// clip was *Clip
+status := clip.Status  // ClipStatus
+```
+
+**After (v6.10.0):**
+```go
+video, err := client.Stream.Clip.New(ctx, stream.ClipNewParams{
+    AccountID:      cloudflare.F("account-id"),
+    ClippedFromVideoUID: cloudflare.F("video-uid"),
+    StartTimeSeconds:    cloudflare.F(int64(0)),
+    EndTimeSeconds:      cloudflare.F(int64(30)),
+    // MaxDurationSeconds, ThumbnailTimestampPct, Watermark have been removed
+})
+// video is now *Video
+```
+
+**Actions Needed:**
+1. Replace all references to `*stream.Clip` with `*stream.Video`
+2. Replace references to `ClipPlayback`, `ClipStatus`, `ClipWatermark` with the corresponding `Video` types
+3. Remove uses of `MaxDurationSeconds`, `ThumbnailTimestampPct`, and `Watermark` from `ClipNewParams`
+
+---
+
+#### 3. Copy params field removals
+
+**What changed:**
+The `CopyNewParams` type has lost its `ThumbnailTimestampPct` and `Watermark` fields.
+
+**Actions Needed:**
+1. Remove uses of `ThumbnailTimestampPct` and `Watermark` from `CopyNewParams`
+
+---
+
+#### 4. Download and Webhook changes
+
+**What changed:**
+- `DownloadNewResponseStatus` type removed
+- `WebhookUpdateResponse` and `WebhookGetResponse` changed from `interface{}` type aliases to full struct types
+
+**Actions Needed:**
+1. Remove references to `DownloadNewResponseStatus`
+2. Update code that type-asserts `WebhookUpdateResponse` or `WebhookGetResponse` as `interface{}` -- they are now typed structs
+
+---
+
+### `IAM`
+
+#### 1. UserGroupMember params renamed and New() return type changed
+
+**What changed:**
+The `Body` field on `UserGroupMemberNewParams` and `UserGroupMemberUpdateParams` has been renamed to `Members`. The associated body types have been renamed from `*ParamsBody` to `*ParamsMember`. Additionally, `UserGroups.Members.New()` now returns a paginated response.
+
+**Impact:**
+Code that sets the `Body` field, references the old param body types, or uses the `New()` return value directly will no longer compile.
+
+**Renamed Types:**
+
+| Before | After |
+|--------|-------|
+| `UserGroupMemberNewParamsBody` | `UserGroupMemberNewParamsMember` |
+| `UserGroupMemberUpdateParamsBody` | `UserGroupMemberUpdateParamsMember` |
+
+**Return Type Change:**
+
+| Method | Before | After |
+|--------|--------|-------|
+| `UserGroups.Members.New()` | `*UserGroupMemberNewResponse` | `*pagination.SinglePage[UserGroupMemberNewResponse]` |
+
+**Before (v6.9.0):**
+```go
+import (
+    cloudflare "github.com/cloudflare/cloudflare-go/v6"
+    "github.com/cloudflare/cloudflare-go/v6/iam"
+    "github.com/cloudflare/cloudflare-go/v6/option"
+)
+
+client, _ := cloudflare.NewClient(option.WithAPIToken("..."))
+
+member, err := client.IAM.UserGroups.Members.New(ctx, "group-id", iam.UserGroupMemberNewParams{
+    AccountID: cloudflare.F("account-id"),
+    Body: []iam.UserGroupMemberNewParamsBody{
+        {ID: cloudflare.F("member-id-1")},
+        {ID: cloudflare.F("member-id-2")},
+    },
+})
+// member was *UserGroupMemberNewResponse
+```
+
+**After (v6.10.0):**
+```go
+import (
+    cloudflare "github.com/cloudflare/cloudflare-go/v6"
+    "github.com/cloudflare/cloudflare-go/v6/iam"
+    "github.com/cloudflare/cloudflare-go/v6/option"
+)
+
+client, _ := cloudflare.NewClient(option.WithAPIToken("..."))
+
+page, err := client.IAM.UserGroups.Members.New(ctx, "group-id", iam.UserGroupMemberNewParams{
+    AccountID: cloudflare.F("account-id"),
+    Members: []iam.UserGroupMemberNewParamsMember{
+        {ID: cloudflare.F("member-id-1")},
+        {ID: cloudflare.F("member-id-2")},
+    },
+})
+// page is now *pagination.SinglePage[UserGroupMemberNewResponse]
+for _, member := range page.Result {
+    fmt.Println(member.ID)
+}
+```
+
+**Actions Needed:**
+1. Rename `.Body` to `.Members` on all `UserGroupMemberNewParams` and `UserGroupMemberUpdateParams` usages
+2. Rename `UserGroupMemberNewParamsBody` to `UserGroupMemberNewParamsMember`
+3. Rename `UserGroupMemberUpdateParamsBody` to `UserGroupMemberUpdateParamsMember`
+4. Update `New()` callers to handle paginated `*pagination.SinglePage[UserGroupMemberNewResponse]` instead of `*UserGroupMemberNewResponse`
+
+---
+
+#### 2. UserGroup List Direction type changed
+
+**What changed:**
+The `Direction` field on `UserGroupListParams` changed from `param.Field[string]` to `param.Field[UserGroupListParamsDirection]` (a typed enum).
+
+**Impact:**
+Code that passes a raw string to `Direction` will no longer compile.
+
+**Before (v6.9.0):**
+```go
+groups, err := client.IAM.UserGroups.List(ctx, iam.UserGroupListParams{
+    AccountID: cloudflare.F("account-id"),
+    Direction: cloudflare.F("desc"),
+})
+```
+
+**After (v6.10.0):**
+```go
+groups, err := client.IAM.UserGroups.List(ctx, iam.UserGroupListParams{
+    AccountID: cloudflare.F("account-id"),
+    Direction: cloudflare.F(iam.UserGroupListParamsDirectionDesc),
+})
+```
+
+**Actions Needed:**
+1. Replace string values `"asc"` / `"desc"` with `iam.UserGroupListParamsDirectionAsc` / `iam.UserGroupListParamsDirectionDesc`
+
+---
+
+### `Zero Trust`
+
+#### 1. Access AI Control MCP Portal union types removed
+
+**What changed:**
+The following union interface types have been removed:
+
+- `AccessAIControlMcpPortalListResponseServersUpdatedPromptsUnion`
+- `AccessAIControlMcpPortalListResponseServersUpdatedToolsUnion`
+- `AccessAIControlMcpPortalReadResponseServersUpdatedPromptsUnion`
+- `AccessAIControlMcpPortalReadResponseServersUpdatedToolsUnion`
+
+**Impact:**
+Code that type-asserts against these union interfaces will no longer compile.
+
+**Actions Needed:**
+1. Remove all references to the removed union types
+2. Check the updated response types for the new structure of `Prompts` and `Tools` fields
+
+---
+
+## Summary
+
+The v6.10.0 release includes breaking changes across multiple services:
+
+1. **Abuse Reports** - Removed `RegWho*` fields from registrar WHOIS report params
+2. **AI Search** - Instance params significantly restructured; `InstanceItemService` removed; token types removed
+3. **Email Security** - `Investigate.Move.New()` return type changed from paginated to raw slice; `NewAutoPaging()` removed
+4. **Hyperdrive** - `ConfigEditParams` lost `MTLS` and `Name` fields; origin `Host` type changed
+5. **IAM** - `UserGroupMemberNewParams.Body` renamed to `.Members`; `New()` return type changed to paginated; `UserGroupListParams.Direction` changed to typed enum
+6. **Pipelines** - Delete methods now return typed responses instead of bare `error`
+7. **Queues** - Message push response success types and ack response fields removed
+8. **Secrets Store** - Pagination wrappers removed from `Stores.New()` and `Secrets.BulkDelete()`; multiple internal types removed
+9. **Stream** - `Clip` type removed (use `Video`); `AudioTracks.Get()` depaginated; `ClipNewParams` and `CopyNewParams` fields removed; webhook response types changed
+10. **Zero Trust** - Access AI Control MCP Portal union interface types removed
+
+Please review all changes above and update your code accordingly before upgrading to v6.10.0.


### PR DESCRIPTION
## Summary

- Replace auto-generated sparse changelog with full v6.10.0 release notes
- Add migration guide with before/after code examples for all breaking changes

## Why this PR

The auto-generated release-please changelog only captured commit subjects. This replaces it with detailed release notes covering:

- 15 breaking change categories across 10 services
- 7 new API resources/services
- Client-level improvements (AccountID/ZoneID defaults)
- Migration guide at `docs/migration-guides/v6.10.0-migration-guide.md`

## Breaking Changes Documented

- **Abuse Reports** - `RegWho*` fields removed from WHOIS report params
- **AI Search** - instance params restructured; `InstanceItemService` removed; token types removed
- **Email Security** - `Investigate.Move.New()` return type changed; `NewAutoPaging()` removed
- **Hyperdrive** - `ConfigEditParams` restructured; `Host` field type changed
- **IAM** - `UserGroupMemberNewParams.Body` renamed to `.Members`; `*ParamsBody` types renamed
- **Pipelines** - delete methods now return typed responses instead of bare `error`
- **Queues** - message response types removed; `MessageAckResponse` fields removed
- **Secrets Store** - pagination wrappers removed; internal types removed
- **Stream** - `Clip` type removed (use `Video`); `AudioTracks.Get()` depaginated; param fields removed
- **Zero Trust** - Access AI Control MCP Portal union types removed

## New Features Documented

- **Vulnerability Scanner** - full CRUD for credential sets, scans, target environments
- **AI Search Namespaces** - namespace-scoped instances, jobs, items
- **Browser Rendering Devtools** - sessions, browser control, targets
- **Registrar Registrations** - domain registration management, check, search
- **Cache Origin Cloud Regions** - origin cloud region configurations
- **Zero Trust DLP Settings** - DLP settings CRUD
- **Radar** - agent readiness, AI markdown-for-agents

## Files

- `CHANGELOG.md` - full 6.10.0 release notes (replaces sparse auto-generated entry)
- `docs/migration-guides/v6.10.0-migration-guide.md` - before/after Go code examples for each breaking change