### PR TITLE
ci(detect-breaking-changes): per-job contents: read

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   detect_breaking_changes:
+    permissions:
+      contents: read
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
     if: false # bypass for major version bump with breaking changes


### PR DESCRIPTION
Per-job `permissions: contents: read` on `detect-breaking-changes.yml`. The workflow only reads the PR's history and runs `./scripts/detect-breaking-changes` against the base SHA — no API writes.

Matches the per-job style already used in `ci.yml` (`contents: read` + `id-token: write`) and leaves `semgrep.yml` untouched. YAML validated.