### PR TITLE
ci: make test and detect-breaking-changes jobs non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
   test:
     timeout-minutes: 30
     name: test
+    continue-on-error: true
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -9,7 +9,7 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    if: false # bypass for major version bump with breaking changes
+    continue-on-error: true
     steps:
       - name: Calculate fetch-depth
         run: |


### PR DESCRIPTION
## Summary

Make the `test` and `detect-breaking-changes` CI jobs non-blocking by adding `continue-on-error: true`. The jobs still run and report results, but failures no longer fail CI overall.

These jobs are informational for release readiness and should not gate merges on the `next` branch.

## Changes

- `ci.yml`: added `continue-on-error: true` to the `test` job
- `detect-breaking-changes.yml`: replaced `if: false` with `continue-on-error: true` so the job actually runs but does not block (was previously fully disabled)

Refs: [APIX-852](https://jira.cfdata.org/browse/APIX-852)