### PR TITLE
Add asset_name to RulesetRuleActionParameters

### DIFF
--- a/.changelog/asset-name.txt
+++ b/.changelog/asset-name.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+rulesets: add `asset_name` to `RulesetRuleActionParameters` for `http_custom_errors` `serve_error` rules
+```

--- a/rulesets.go
+++ b/rulesets.go
@@ -231,6 +231,7 @@ type RulesetRuleActionParameters struct {
 	Content                  string                                            `json:"content,omitempty"`
 	ContentType              string                                            `json:"content_type,omitempty"`
 	StatusCode               uint16                                            `json:"status_code,omitempty"`
+	AssetName                string                                            `json:"asset_name,omitempty"`
 	RespectStrongETags       *bool                                             `json:"respect_strong_etags,omitempty"`
 	CacheKey                 *RulesetRuleActionParametersCacheKey              `json:"cache_key,omitempty"`
 	OriginCacheControl       *bool                                             `json:"origin_cache_control,omitempty"`

--- a/rulesets_test.go
+++ b/rulesets_test.go
@@ -655,6 +655,87 @@ func TestGetRuleset_CompressResponse(t *testing.T) {
 	}
 }
 
+func TestGetRuleset_ServeError(t *testing.T) {
+	setup()
+	defer teardown()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method, "Expected method 'GET', got %s", r.Method)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprint(w, `{
+      "result": {
+        "id": "70339d97bdb34195bbf054b1ebe81f76",
+        "name": "default",
+        "description": "Custom error responses",
+        "kind": "zone",
+        "version": "1",
+        "rules": [
+          {
+            "id": "78723a9e0c7c4c6dbec5684cb766231d",
+            "version": "1",
+            "action": "serve_error",
+            "action_parameters": {
+              "asset_name": "default_serve_error_page",
+              "content_type": "text/html",
+              "status_code": 530
+            },
+            "description": "Serve custom error asset",
+            "last_updated": "2020-12-18T09:28:09.655749Z",
+            "ref": "272936dc447b41fe976255ff6b768ec0",
+            "enabled": true
+          }
+        ],
+        "last_updated": "2020-12-18T09:28:09.655749Z",
+        "phase": "http_custom_errors"
+      },
+      "success": true,
+      "errors": [],
+      "messages": []
+    }`)
+	}
+
+	mux.HandleFunc("/accounts/"+testAccountID+"/rulesets/b232b534beea4e00a21dcbb7a8a545e9", handler)
+	mux.HandleFunc("/zones/"+testZoneID+"/rulesets/b232b534beea4e00a21dcbb7a8a545e9", handler)
+
+	lastUpdated, _ := time.Parse(time.RFC3339, "2020-12-18T09:28:09.655749Z")
+
+	rules := []RulesetRule{{
+		ID:      "78723a9e0c7c4c6dbec5684cb766231d",
+		Version: StringPtr("1"),
+		Action:  string(RulesetRuleActionServeError),
+		ActionParameters: &RulesetRuleActionParameters{
+			AssetName:   "default_serve_error_page",
+			ContentType: "text/html",
+			StatusCode:  530,
+		},
+		Description: "Serve custom error asset",
+		LastUpdated: &lastUpdated,
+		Ref:         "272936dc447b41fe976255ff6b768ec0",
+		Enabled:     BoolPtr(true),
+	}}
+
+	want := Ruleset{
+		ID:          "70339d97bdb34195bbf054b1ebe81f76",
+		Name:        "default",
+		Description: "Custom error responses",
+		Kind:        string(RulesetKindZone),
+		Version:     StringPtr("1"),
+		LastUpdated: &lastUpdated,
+		Phase:       string(RulesetPhaseHTTPCustomErrors),
+		Rules:       rules,
+	}
+
+	zoneActual, err := client.GetRuleset(context.Background(), ZoneIdentifier(testZoneID), "b232b534beea4e00a21dcbb7a8a545e9")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, zoneActual)
+	}
+
+	accountActual, err := client.GetRuleset(context.Background(), AccountIdentifier(testAccountID), "b232b534beea4e00a21dcbb7a8a545e9")
+	if assert.NoError(t, err) {
+		assert.Equal(t, want, accountActual)
+	}
+}
+
 func TestCreateRuleset(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adds the asset_name field to RulesetRuleActionParameters so that http_custom_errors phase rules using the serve_error action correctly round-trip the asset_name attribute returned by the Cloudflare API.

Without this field, the typed struct silently drops asset_name during JSON decode, causing downstream tools (e.g. cf-terraforming) to emit configurations that diverge from the live ruleset and produce drift on subsequent applies.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
