### PR TITLE
Expose URL scanner task errors

### DIFF
--- a/url_scanner/scan.go
+++ b/url_scanner/scan.go
@@ -5262,6 +5262,7 @@ type ScanGetResponseTask struct {
 	ApexDomain    string                     `json:"apexDomain" api:"required"`
 	Domain        string                     `json:"domain" api:"required"`
 	DOMURL        string                     `json:"domURL" api:"required"`
+	Errors        []ScanGetResponseTaskError `json:"errors"`
 	Method        string                     `json:"method" api:"required"`
 	Options       ScanGetResponseTaskOptions `json:"options" api:"required"`
 	ReportURL     string                     `json:"reportURL" api:"required"`
@@ -5281,6 +5282,7 @@ type scanGetResponseTaskJSON struct {
 	ApexDomain    apijson.Field
 	Domain        apijson.Field
 	DOMURL        apijson.Field
+	Errors        apijson.Field
 	Method        apijson.Field
 	Options       apijson.Field
 	ReportURL     apijson.Field
@@ -5300,6 +5302,27 @@ func (r *ScanGetResponseTask) UnmarshalJSON(data []byte) (err error) {
 }
 
 func (r scanGetResponseTaskJSON) RawJSON() string {
+	return r.raw
+}
+
+type ScanGetResponseTaskError struct {
+	Message string                       `json:"message"`
+	JSON    scanGetResponseTaskErrorJSON `json:"-"`
+}
+
+// scanGetResponseTaskErrorJSON contains the JSON metadata for the struct
+// [ScanGetResponseTaskError]
+type scanGetResponseTaskErrorJSON struct {
+	Message     apijson.Field
+	raw         string
+	ExtraFields map[string]apijson.Field
+}
+
+func (r *ScanGetResponseTaskError) UnmarshalJSON(data []byte) (err error) {
+	return apijson.UnmarshalRoot(data, r)
+}
+
+func (r scanGetResponseTaskErrorJSON) RawJSON() string {
 	return r.raw
 }
 

--- a/url_scanner/scan_test.go
+++ b/url_scanner/scan_test.go
@@ -5,6 +5,7 @@ package url_scanner_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -17,6 +18,41 @@ import (
 	"github.com/cloudflare/cloudflare-go/v7/option"
 	"github.com/cloudflare/cloudflare-go/v7/url_scanner"
 )
+
+func TestScanGetResponseTaskErrorsUnmarshal(t *testing.T) {
+	raw := []byte(`{
+		"task": {
+			"errors": [
+				{
+					"message": "DNS lookup failed",
+					"type": "dns"
+				}
+			]
+		}
+	}`)
+
+	var response url_scanner.ScanGetResponse
+	if err := json.Unmarshal(raw, &response); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if len(response.Task.Errors) != 1 {
+		t.Fatalf("expected one task error, got %d", len(response.Task.Errors))
+	}
+
+	taskError := response.Task.Errors[0]
+	if taskError.Message != "DNS lookup failed" {
+		t.Fatalf("expected task error message to be exposed, got %q", taskError.Message)
+	}
+
+	if _, ok := taskError.JSON.ExtraFields["type"]; !ok {
+		t.Fatalf("expected unknown task error fields to remain available")
+	}
+
+	if response.Task.JSON.Errors.IsMissing() {
+		t.Fatalf("expected task errors JSON metadata to be present")
+	}
+}
 
 func TestScanNewWithOptionalParams(t *testing.T) {
 	baseURL := "http://localhost:4010"


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Expose the URL Scanner scan task `errors` array on `ScanGetResponseTask`, matching the API docs/model surface for URL scanner tasks and fixing #4313.

The new `ScanGetResponseTaskError` type exposes the `message` field and preserves unknown error fields through the usual JSON metadata path, so callers can still inspect extra API-provided detail.

## Additional context & links

- Issue: https://github.com/cloudflare/cloudflare-go/issues/4313
- Source reference: https://developers.cloudflare.com/api/go/resources/url_scanner/ lists `URLScannerTask.Errors []URLScannerTaskError` for URL Scanner tasks.

Verification:
- `go test ./url_scanner -run TestScanGetResponseTaskErrorsUnmarshal -count=1`
- `git diff --check`

I also tried `go test ./url_scanner -count=1`, but the generated/mock-server suite did not complete in this local Windows environment before timeout.

This was implemented with Codex assistance, with the patch kept focused on the missing response field and regression coverage.