### PR TITLE
chore: pin CI actions to commit SHAs, update scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,14 @@ jobs:
       github.repository == 'stainless-sdks/cloudflare-go' &&
       (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get GitHub OIDC Token
         if: |-
           github.repository == 'stainless-sdks/cloudflare-go' &&
           !startsWith(github.ref, 'refs/heads/stl/')
         id: github-oidc
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: core.setOutput('github_token', await core.getIDToken());
 
@@ -53,10 +53,10 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
 
@@ -68,10 +68,10 @@ jobs:
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
 

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -14,13 +14,13 @@ jobs:
         run: |
           echo "FETCH_DEPTH=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Ensure we can check out the pull request base in the script below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: ./go.mod
 

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -4,7 +4,7 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ] && [ "$SKIP_BREW" != "1" ] && [ -t 0 ]; then
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ] && [ "${SKIP_BREW:-}" != "1" ] && [ -t 0 ]; then
   brew bundle check >/dev/null 2>&1 || {
     echo -n "==> Install Homebrew dependencies? (y/N): "
     read -r response

--- a/scripts/detect-breaking-changes
+++ b/scripts/detect-breaking-changes
@@ -23,6 +23,7 @@ TEST_PATHS=(
 	organizations/organizationprofile_test.go
 	organizations/member_test.go
 	organizations/logaudit_test.go
+	organizations/billingusage_test.go
 	origin_ca_certificates/origincacertificate_test.go
 	ips/ip_test.go
 	memberships/membership_test.go
@@ -238,6 +239,8 @@ TEST_PATHS=(
 	addressing/prefixbgpprefix_test.go
 	addressing/prefixadvertisementstatus_test.go
 	addressing/prefixdelegation_test.go
+	dls/region_test.go
+	dls/regionalserviceprefixbinding_test.go
 	audit_logs/auditlog_test.go
 	billing/profile_test.go
 	billing/usage_test.go


### PR DESCRIPTION
## CI and Scripts Updates

Syncs CI workflow and script changes from `staging-next`.

### Changes

**GitHub Actions SHA pinning** (supply-chain security)
- `actions/checkout@v6` -> `@de0fac2e...` (v6.0.2)
- `actions/setup-go@v5` -> `@40f1582b...` (v5.6.0)
- `actions/github-script@v8` -> `@ed597411...` (v8.0.0)

**`scripts/bootstrap`**
- Fix unbound variable: `$SKIP_BREW` -> `${SKIP_BREW:-}`

**`scripts/detect-breaking-changes`**
- Add test paths for `dls` and `organizations/billingusage`