### PR TITLE
Sync staged changes (curated) 

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 2291
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare/cloudflare-547b90ad7d0427ca983d8a0b98065f83601e0ddb8ac09acb443568c75298e696.yml
-openapi_spec_hash: 57877498326f4d42df3a07aa14c272a1
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/cloudflare/cloudflare-fff3a3fba3bbd526bc26811f8857484e5439a8f2036173813290798061db3ec1.yml
+openapi_spec_hash: fcbb1d06511fd70c310313541db5984d
 config_hash: af64aebd155c327064f15fb62f55c6fc

--- a/abuse_reports/aliases.go
+++ b/abuse_reports/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/accounts/aliases.go
+++ b/accounts/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/acm/aliases.go
+++ b/acm/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/acm/customtruststore.go
+++ b/acm/customtruststore.go
@@ -369,7 +369,7 @@ type CustomTrustStoreListParams struct {
 	ZoneID param.Field[string] `path:"zone_id" api:"required"`
 	// Limit to the number of records returned.
 	Limit param.Field[int64] `query:"limit"`
-	// Offset the results
+	// Offset the results.
 	Offset param.Field[int64] `query:"offset"`
 	// Page number of paginated results.
 	Page param.Field[float64] `query:"page"`

--- a/addressing/aliases.go
+++ b/addressing/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ai/aliases.go
+++ b/ai/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ai_audit/aliases.go
+++ b/ai_audit/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ai_gateway/aliases.go
+++ b/ai_gateway/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ai_search/aliases.go
+++ b/ai_search/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ai_security/aliases.go
+++ b/ai_security/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/alerting/aliases.go
+++ b/alerting/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/aliases.go
+++ b/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/api_gateway/aliases.go
+++ b/api_gateway/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/argo/aliases.go
+++ b/argo/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/audit_logs/aliases.go
+++ b/audit_logs/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/billing/aliases.go
+++ b/billing/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/bot_management/aliases.go
+++ b/bot_management/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/botnet_feed/aliases.go
+++ b/botnet_feed/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/brand_protection/aliases.go
+++ b/brand_protection/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/browser_rendering/aliases.go
+++ b/browser_rendering/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/cache/aliases.go
+++ b/cache/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/calls/aliases.go
+++ b/calls/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/certificate_authorities/aliases.go
+++ b/certificate_authorities/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/certificate_authorities/hostnameassociation.go
+++ b/certificate_authorities/hostnameassociation.go
@@ -36,7 +36,7 @@ func NewHostnameAssociationService(opts ...option.RequestOption) (r *HostnameAss
 	return
 }
 
-// Replace Hostname Associations
+// Replace Hostname Associations.
 func (r *HostnameAssociationService) Update(ctx context.Context, params HostnameAssociationUpdateParams, opts ...option.RequestOption) (res *HostnameAssociationUpdateResponse, err error) {
 	var env HostnameAssociationUpdateResponseEnvelope
 	opts = slices.Concat(r.Options, opts)
@@ -53,7 +53,7 @@ func (r *HostnameAssociationService) Update(ctx context.Context, params Hostname
 	return res, nil
 }
 
-// List Hostname Associations
+// List Hostname Associations.
 func (r *HostnameAssociationService) Get(ctx context.Context, params HostnameAssociationGetParams, opts ...option.RequestOption) (res *HostnameAssociationGetResponse, err error) {
 	var env HostnameAssociationGetResponseEnvelope
 	opts = slices.Concat(r.Options, opts)

--- a/client_certificates/aliases.go
+++ b/client_certificates/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/client_certificates/clientcertificate.go
+++ b/client_certificates/clientcertificate.go
@@ -38,7 +38,7 @@ func NewClientCertificateService(opts ...option.RequestOption) (r *ClientCertifi
 	return
 }
 
-// Create a new API Shield mTLS Client Certificate
+// Create a new API Shield mTLS Client Certificate.
 func (r *ClientCertificateService) New(ctx context.Context, params ClientCertificateNewParams, opts ...option.RequestOption) (res *ClientCertificate, err error) {
 	var env ClientCertificateNewResponseEnvelope
 	opts = slices.Concat(r.Options, opts)
@@ -56,7 +56,7 @@ func (r *ClientCertificateService) New(ctx context.Context, params ClientCertifi
 }
 
 // List all of your Zone's API Shield mTLS Client Certificates by Status and/or
-// using Pagination
+// using Pagination.
 func (r *ClientCertificateService) List(ctx context.Context, params ClientCertificateListParams, opts ...option.RequestOption) (res *pagination.V4PagePaginationArray[ClientCertificate], err error) {
 	var raw *http.Response
 	opts = slices.Concat(r.Options, opts)
@@ -79,7 +79,7 @@ func (r *ClientCertificateService) List(ctx context.Context, params ClientCertif
 }
 
 // List all of your Zone's API Shield mTLS Client Certificates by Status and/or
-// using Pagination
+// using Pagination.
 func (r *ClientCertificateService) ListAutoPaging(ctx context.Context, params ClientCertificateListParams, opts ...option.RequestOption) *pagination.V4PagePaginationArrayAutoPager[ClientCertificate] {
 	return pagination.NewV4PagePaginationArrayAutoPager(r.List(ctx, params, opts...))
 }
@@ -128,7 +128,7 @@ func (r *ClientCertificateService) Edit(ctx context.Context, clientCertificateID
 	return res, nil
 }
 
-// Get Details for a single mTLS API Shield Client Certificate
+// Get Details for a single mTLS API Shield Client Certificate.
 func (r *ClientCertificateService) Get(ctx context.Context, clientCertificateID string, query ClientCertificateGetParams, opts ...option.RequestOption) (res *ClientCertificate, err error) {
 	var env ClientCertificateGetResponseEnvelope
 	opts = slices.Concat(r.Options, opts)
@@ -152,40 +152,41 @@ func (r *ClientCertificateService) Get(ctx context.Context, clientCertificateID 
 type ClientCertificate struct {
 	// Identifier.
 	ID string `json:"id"`
-	// The Client Certificate PEM
+	// The Client Certificate PEM.
 	Certificate string `json:"certificate"`
-	// Certificate Authority used to issue the Client Certificate
+	// Certificate Authority used to issue the Client Certificate.
 	CertificateAuthority ClientCertificateCertificateAuthority `json:"certificate_authority"`
-	// Common Name of the Client Certificate
+	// Common Name of the Client Certificate.
 	CommonName string `json:"common_name"`
-	// Country, provided by the CSR
+	// Country, provided by the CSR.
 	Country string `json:"country"`
 	// The Certificate Signing Request (CSR). Must be newline-encoded.
 	Csr string `json:"csr"`
-	// Date that the Client Certificate expires
+	// Date that the Client Certificate expires.
 	ExpiresOn string `json:"expires_on"`
-	// Unique identifier of the Client Certificate
+	// Unique identifier of the Client Certificate.
 	FingerprintSha256 string `json:"fingerprint_sha256"`
-	// Date that the Client Certificate was issued by the Certificate Authority
+	// Date that the Client Certificate was issued by the Certificate Authority.
 	IssuedOn string `json:"issued_on"`
-	// Location, provided by the CSR
+	// Location, provided by the CSR.
 	Location string `json:"location"`
-	// Organization, provided by the CSR
+	// Organization, provided by the CSR.
 	Organization string `json:"organization"`
-	// Organizational Unit, provided by the CSR
+	// Organizational Unit, provided by the CSR.
 	OrganizationalUnit string `json:"organizational_unit"`
 	// The serial number on the created Client Certificate.
 	SerialNumber string `json:"serial_number"`
 	// The type of hash used for the Client Certificate..
 	Signature string `json:"signature"`
-	// Subject Key Identifier
+	// Subject Key Identifier.
 	Ski string `json:"ski"`
-	// State, provided by the CSR
+	// State, provided by the CSR.
 	State string `json:"state"`
 	// Client Certificates may be active or revoked, and the pending_reactivation or
-	// pending_revocation represent in-progress asynchronous transitions
+	// pending_revocation represent in-progress asynchronous transitions.
 	Status custom_certificates.Status `json:"status"`
-	// The number of days the Client Certificate will be valid after the issued_on date
+	// The number of days the Client Certificate will be valid after the issued_on
+	// date.
 	ValidityDays int64                 `json:"validity_days"`
 	JSON         clientCertificateJSON `json:"-"`
 }
@@ -223,7 +224,7 @@ func (r clientCertificateJSON) RawJSON() string {
 	return r.raw
 }
 
-// Certificate Authority used to issue the Client Certificate
+// Certificate Authority used to issue the Client Certificate.
 type ClientCertificateCertificateAuthority struct {
 	ID   string                                    `json:"id"`
 	Name string                                    `json:"name"`
@@ -252,7 +253,8 @@ type ClientCertificateNewParams struct {
 	ZoneID param.Field[string] `path:"zone_id" api:"required"`
 	// The Certificate Signing Request (CSR). Must be newline-encoded.
 	Csr param.Field[string] `json:"csr" api:"required"`
-	// The number of days the Client Certificate will be valid after the issued_on date
+	// The number of days the Client Certificate will be valid after the issued_on
+	// date.
 	ValidityDays param.Field[int64] `json:"validity_days" api:"required"`
 }
 
@@ -404,7 +406,7 @@ type ClientCertificateListParams struct {
 	ZoneID param.Field[string] `path:"zone_id" api:"required"`
 	// Limit to the number of records returned.
 	Limit param.Field[int64] `query:"limit"`
-	// Offset the results
+	// Offset the results.
 	Offset param.Field[int64] `query:"offset"`
 	// Page number of paginated results.
 	Page param.Field[float64] `query:"page"`

--- a/cloud_connector/aliases.go
+++ b/cloud_connector/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/cloudforce_one/aliases.go
+++ b/cloudforce_one/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/connectivity/aliases.go
+++ b/connectivity/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/content_scanning/aliases.go
+++ b/content_scanning/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/custom_certificates/aliases.go
+++ b/custom_certificates/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/custom_certificates/customcertificate.go
+++ b/custom_certificates/customcertificate.go
@@ -315,7 +315,7 @@ func (r GeoRestrictionsParam) MarshalJSON() (data []byte, err error) {
 }
 
 // Client Certificates may be active or revoked, and the pending_reactivation or
-// pending_revocation represent in-progress asynchronous transitions
+// pending_revocation represent in-progress asynchronous transitions.
 type Status string
 
 const (
@@ -367,7 +367,7 @@ type CustomCertificateNewParams struct {
 	BundleMethod param.Field[custom_hostnames.BundleMethod] `json:"bundle_method"`
 	// The identifier for the Custom CSR that was used.
 	CustomCsrID param.Field[string] `json:"custom_csr_id"`
-	// The environment to deploy the certificate to, defaults to production
+	// The environment to deploy the certificate to, defaults to production.
 	Deploy param.Field[CustomCertificateNewParamsDeploy] `json:"deploy"`
 	// Specify the region where your private key can be held locally for optimal TLS
 	// performance. HTTPS connections to any excluded data center will still be fully
@@ -401,7 +401,7 @@ func (r CustomCertificateNewParams) MarshalJSON() (data []byte, err error) {
 	return apijson.MarshalRoot(r)
 }
 
-// The environment to deploy the certificate to, defaults to production
+// The environment to deploy the certificate to, defaults to production.
 type CustomCertificateNewParamsDeploy string
 
 const (
@@ -786,7 +786,7 @@ type CustomCertificateEditParams struct {
 	Certificate param.Field[string] `json:"certificate"`
 	// The identifier for the Custom CSR that was used.
 	CustomCsrID param.Field[string] `json:"custom_csr_id"`
-	// The environment to deploy the certificate to, defaults to production
+	// The environment to deploy the certificate to, defaults to production.
 	Deploy param.Field[CustomCertificateEditParamsDeploy] `json:"deploy"`
 	// Specify the region where your private key can be held locally for optimal TLS
 	// performance. HTTPS connections to any excluded data center will still be fully
@@ -817,7 +817,7 @@ func (r CustomCertificateEditParams) MarshalJSON() (data []byte, err error) {
 	return apijson.MarshalRoot(r)
 }
 
-// The environment to deploy the certificate to, defaults to production
+// The environment to deploy the certificate to, defaults to production.
 type CustomCertificateEditParamsDeploy string
 
 const (

--- a/custom_hostnames/aliases.go
+++ b/custom_hostnames/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/custom_hostnames/certificatepackcertificate.go
+++ b/custom_hostnames/certificatepackcertificate.go
@@ -235,7 +235,7 @@ type CertificatePackCertificateUpdateResponseSSL struct {
 	// the shortest chain and newest intermediates. And the force bundle verifies the
 	// chain, but does not otherwise modify it.
 	BundleMethod BundleMethod `json:"bundle_method"`
-	// The Certificate Authority that will issue the certificate
+	// The Certificate Authority that will issue the certificate.
 	CertificateAuthority shared.CertificateCA `json:"certificate_authority"`
 	// If a custom uploaded certificate is used.
 	CustomCertificate string `json:"custom_certificate"`

--- a/custom_hostnames/customhostname.go
+++ b/custom_hostnames/customhostname.go
@@ -353,7 +353,7 @@ type CustomHostnameNewResponseSSL struct {
 	// the shortest chain and newest intermediates. And the force bundle verifies the
 	// chain, but does not otherwise modify it.
 	BundleMethod BundleMethod `json:"bundle_method"`
-	// The Certificate Authority that will issue the certificate
+	// The Certificate Authority that will issue the certificate.
 	CertificateAuthority shared.CertificateCA `json:"certificate_authority"`
 	// If a custom uploaded certificate is used.
 	CustomCertificate string `json:"custom_certificate"`
@@ -847,7 +847,7 @@ type CustomHostnameListResponseSSL struct {
 	// the shortest chain and newest intermediates. And the force bundle verifies the
 	// chain, but does not otherwise modify it.
 	BundleMethod BundleMethod `json:"bundle_method"`
-	// The Certificate Authority that will issue the certificate
+	// The Certificate Authority that will issue the certificate.
 	CertificateAuthority shared.CertificateCA `json:"certificate_authority"`
 	// If a custom uploaded certificate is used.
 	CustomCertificate string `json:"custom_certificate"`
@@ -1363,7 +1363,7 @@ type CustomHostnameEditResponseSSL struct {
 	// the shortest chain and newest intermediates. And the force bundle verifies the
 	// chain, but does not otherwise modify it.
 	BundleMethod BundleMethod `json:"bundle_method"`
-	// The Certificate Authority that will issue the certificate
+	// The Certificate Authority that will issue the certificate.
 	CertificateAuthority shared.CertificateCA `json:"certificate_authority"`
 	// If a custom uploaded certificate is used.
 	CustomCertificate string `json:"custom_certificate"`
@@ -1857,7 +1857,7 @@ type CustomHostnameGetResponseSSL struct {
 	// the shortest chain and newest intermediates. And the force bundle verifies the
 	// chain, but does not otherwise modify it.
 	BundleMethod BundleMethod `json:"bundle_method"`
-	// The Certificate Authority that will issue the certificate
+	// The Certificate Authority that will issue the certificate.
 	CertificateAuthority shared.CertificateCA `json:"certificate_authority"`
 	// If a custom uploaded certificate is used.
 	CustomCertificate string `json:"custom_certificate"`
@@ -2236,12 +2236,12 @@ type CustomHostnameNewParamsSSL struct {
 	// the shortest chain and newest intermediates. And the force bundle verifies the
 	// chain, but does not otherwise modify it.
 	BundleMethod param.Field[BundleMethod] `json:"bundle_method"`
-	// The Certificate Authority that will issue the certificate
+	// The Certificate Authority that will issue the certificate.
 	CertificateAuthority param.Field[shared.CertificateCA] `json:"certificate_authority"`
 	// Whether or not to add Cloudflare Branding for the order. This will add a
-	// subdomain of sni.cloudflaressl.com as the Common Name if set to true
+	// subdomain of sni.cloudflaressl.com as the Common Name if set to true.
 	CloudflareBranding param.Field[bool] `json:"cloudflare_branding"`
-	// Array of custom certificate and key pairs (1 or 2 pairs allowed)
+	// Array of custom certificate and key pairs (1 or 2 pairs allowed).
 	CustomCERTBundle param.Field[[]CustomHostnameNewParamsSSLCustomCERTBundle] `json:"custom_cert_bundle"`
 	// If a custom uploaded certificate is used.
 	CustomCertificate param.Field[string] `json:"custom_certificate"`
@@ -2633,7 +2633,7 @@ func (r CustomHostnameListParamsOrder) IsKnown() bool {
 }
 
 // Whether to filter hostnames based on if they have SSL enabled.
-type CustomHostnameListParamsSSL float64
+type CustomHostnameListParamsSSL int64
 
 const (
 	CustomHostnameListParamsSSL0 CustomHostnameListParamsSSL = 0
@@ -2718,12 +2718,12 @@ type CustomHostnameEditParamsSSL struct {
 	// the shortest chain and newest intermediates. And the force bundle verifies the
 	// chain, but does not otherwise modify it.
 	BundleMethod param.Field[BundleMethod] `json:"bundle_method"`
-	// The Certificate Authority that will issue the certificate
+	// The Certificate Authority that will issue the certificate.
 	CertificateAuthority param.Field[shared.CertificateCA] `json:"certificate_authority"`
 	// Whether or not to add Cloudflare Branding for the order. This will add a
-	// subdomain of sni.cloudflaressl.com as the Common Name if set to true
+	// subdomain of sni.cloudflaressl.com as the Common Name if set to true.
 	CloudflareBranding param.Field[bool] `json:"cloudflare_branding"`
-	// Array of custom certificate and key pairs (1 or 2 pairs allowed)
+	// Array of custom certificate and key pairs (1 or 2 pairs allowed).
 	CustomCERTBundle param.Field[[]CustomHostnameEditParamsSSLCustomCERTBundle] `json:"custom_cert_bundle"`
 	// If a custom uploaded certificate is used.
 	CustomCertificate param.Field[string] `json:"custom_certificate"`

--- a/custom_nameservers/aliases.go
+++ b/custom_nameservers/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/custom_pages/aliases.go
+++ b/custom_pages/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/d1/aliases.go
+++ b/d1/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/dcv_delegation/aliases.go
+++ b/dcv_delegation/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ddos_protection/aliases.go
+++ b/ddos_protection/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/diagnostics/aliases.go
+++ b/diagnostics/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/dls/aliases.go
+++ b/dls/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/dns/aliases.go
+++ b/dns/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/dns_firewall/aliases.go
+++ b/dns_firewall/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/durable_objects/aliases.go
+++ b/durable_objects/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/email_routing/aliases.go
+++ b/email_routing/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/email_security/aliases.go
+++ b/email_security/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/email_sending/aliases.go
+++ b/email_sending/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/filters/aliases.go
+++ b/filters/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/firewall/aliases.go
+++ b/firewall/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/fraud/aliases.go
+++ b/fraud/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/google_tag_gateway/aliases.go
+++ b/google_tag_gateway/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/healthchecks/aliases.go
+++ b/healthchecks/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/hostnames/aliases.go
+++ b/hostnames/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/hostnames/settingtls.go
+++ b/hostnames/settingtls.go
@@ -120,11 +120,11 @@ type Setting struct {
 	// path:
 	//
 	//   - `ciphers`: an array of allowed cipher suite strings in BoringSSL format (e.g.,
-	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 	//   - `min_tls_version`: a string indicating the minimum TLS version — one of
-	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`)
+	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`).
 	//   - `http2`: a string indicating whether HTTP/2 is enabled — `"on"` or `"off"`
-	//     (e.g., `"on"`)
+	//     (e.g., `"on"`).
 	Value SettingValueUnion `json:"value"`
 	JSON  settingJSON       `json:"-"`
 }
@@ -152,11 +152,11 @@ func (r settingJSON) RawJSON() string {
 // path:
 //
 //   - `ciphers`: an array of allowed cipher suite strings in BoringSSL format (e.g.,
-//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 //   - `min_tls_version`: a string indicating the minimum TLS version — one of
-//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`)
+//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`).
 //   - `http2`: a string indicating whether HTTP/2 is enabled — `"on"` or `"off"`
-//     (e.g., `"on"`)
+//     (e.g., `"on"`).
 //
 // Union satisfied by [SettingValueString] or [SettingValueArray].
 type SettingValueUnion interface {
@@ -209,11 +209,11 @@ func (r SettingValueArray) implementsSettingValueUnion() {}
 // path:
 //
 //   - `ciphers`: an array of allowed cipher suite strings in BoringSSL format (e.g.,
-//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 //   - `min_tls_version`: a string indicating the minimum TLS version — one of
-//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`)
+//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`).
 //   - `http2`: a string indicating whether HTTP/2 is enabled — `"on"` or `"off"`
-//     (e.g., `"on"`)
+//     (e.g., `"on"`).
 //
 // Satisfied by [hostnames.SettingValueString], [hostnames.SettingValueArrayParam].
 type SettingValueUnionParam interface {
@@ -237,11 +237,11 @@ type SettingTLSDeleteResponse struct {
 	// path:
 	//
 	//   - `ciphers`: an array of allowed cipher suite strings in BoringSSL format (e.g.,
-	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 	//   - `min_tls_version`: a string indicating the minimum TLS version — one of
-	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`)
+	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`).
 	//   - `http2`: a string indicating whether HTTP/2 is enabled — `"on"` or `"off"`
-	//     (e.g., `"on"`)
+	//     (e.g., `"on"`).
 	Value SettingValueUnion            `json:"value"`
 	JSON  settingTLSDeleteResponseJSON `json:"-"`
 }
@@ -279,11 +279,11 @@ type SettingTLSGetResponse struct {
 	// path:
 	//
 	//   - `ciphers`: an array of allowed cipher suite strings in BoringSSL format (e.g.,
-	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 	//   - `min_tls_version`: a string indicating the minimum TLS version — one of
-	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`)
+	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`).
 	//   - `http2`: a string indicating whether HTTP/2 is enabled — `"on"` or `"off"`
-	//     (e.g., `"on"`)
+	//     (e.g., `"on"`).
 	Value SettingValueUnion         `json:"value"`
 	JSON  settingTLSGetResponseJSON `json:"-"`
 }
@@ -315,11 +315,11 @@ type SettingTLSUpdateParams struct {
 	// path:
 	//
 	//   - `ciphers`: an array of allowed cipher suite strings in BoringSSL format (e.g.,
-	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+	//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 	//   - `min_tls_version`: a string indicating the minimum TLS version — one of
-	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`)
+	//     `"1.0"`, `"1.1"`, `"1.2"`, or `"1.3"` (e.g., `"1.2"`).
 	//   - `http2`: a string indicating whether HTTP/2 is enabled — `"on"` or `"off"`
-	//     (e.g., `"on"`)
+	//     (e.g., `"on"`).
 	Value param.Field[SettingValueUnionParam] `json:"value" api:"required"`
 }
 
@@ -330,10 +330,10 @@ func (r SettingTLSUpdateParams) MarshalJSON() (data []byte, err error) {
 // The TLS Setting name. The value type depends on the setting:
 //
 //   - `ciphers`: value is an array of cipher suite strings (e.g.,
-//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 //   - `min_tls_version`: value is a TLS version string (`"1.0"`, `"1.1"`, `"1.2"`,
-//     or `"1.3"`)
-//   - `http2`: value is `"on"` or `"off"`
+//     or `"1.3"`).
+//   - `http2`: value is `"on"` or `"off"`.
 type SettingTLSUpdateParamsSettingID string
 
 const (
@@ -497,10 +497,10 @@ type SettingTLSDeleteParams struct {
 // The TLS Setting name. The value type depends on the setting:
 //
 //   - `ciphers`: value is an array of cipher suite strings (e.g.,
-//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 //   - `min_tls_version`: value is a TLS version string (`"1.0"`, `"1.1"`, `"1.2"`,
-//     or `"1.3"`)
-//   - `http2`: value is `"on"` or `"off"`
+//     or `"1.3"`).
+//   - `http2`: value is `"on"` or `"off"`.
 type SettingTLSDeleteParamsSettingID string
 
 const (
@@ -664,10 +664,10 @@ type SettingTLSGetParams struct {
 // The TLS Setting name. The value type depends on the setting:
 //
 //   - `ciphers`: value is an array of cipher suite strings (e.g.,
-//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`)
+//     `["ECDHE-RSA-AES128-GCM-SHA256", "AES128-GCM-SHA256"]`).
 //   - `min_tls_version`: value is a TLS version string (`"1.0"`, `"1.1"`, `"1.2"`,
-//     or `"1.3"`)
-//   - `http2`: value is `"on"` or `"off"`
+//     or `"1.3"`).
+//   - `http2`: value is `"on"` or `"off"`.
 type SettingTLSGetParamsSettingID string
 
 const (

--- a/hyperdrive/aliases.go
+++ b/hyperdrive/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/iam/aliases.go
+++ b/iam/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/images/aliases.go
+++ b/images/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/intel/aliases.go
+++ b/intel/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ips/aliases.go
+++ b/ips/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/keyless_certificates/aliases.go
+++ b/keyless_certificates/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/keyless_certificates/keylesscertificate.go
+++ b/keyless_certificates/keylesscertificate.go
@@ -168,7 +168,7 @@ type KeylessCertificate struct {
 	Port float64 `json:"port" api:"required"`
 	// Status of the Keyless SSL.
 	Status KeylessCertificateStatus `json:"status" api:"required"`
-	// Configuration for using Keyless SSL through a Cloudflare Tunnel
+	// Configuration for using Keyless SSL through a Cloudflare Tunnel.
 	Tunnel Tunnel                 `json:"tunnel"`
 	JSON   keylessCertificateJSON `json:"-"`
 }
@@ -214,11 +214,11 @@ func (r KeylessCertificateStatus) IsKnown() bool {
 	return false
 }
 
-// Configuration for using Keyless SSL through a Cloudflare Tunnel
+// Configuration for using Keyless SSL through a Cloudflare Tunnel.
 type Tunnel struct {
-	// Private IP of the Key Server Host
+	// Private IP of the Key Server Host.
 	PrivateIP string `json:"private_ip" api:"required"`
-	// Cloudflare Tunnel Virtual Network ID
+	// Cloudflare Tunnel Virtual Network ID.
 	VnetID string     `json:"vnet_id" api:"required"`
 	JSON   tunnelJSON `json:"-"`
 }
@@ -239,11 +239,11 @@ func (r tunnelJSON) RawJSON() string {
 	return r.raw
 }
 
-// Configuration for using Keyless SSL through a Cloudflare Tunnel
+// Configuration for using Keyless SSL through a Cloudflare Tunnel.
 type TunnelParam struct {
-	// Private IP of the Key Server Host
+	// Private IP of the Key Server Host.
 	PrivateIP param.Field[string] `json:"private_ip" api:"required"`
-	// Cloudflare Tunnel Virtual Network ID
+	// Cloudflare Tunnel Virtual Network ID.
 	VnetID param.Field[string] `json:"vnet_id" api:"required"`
 }
 
@@ -290,7 +290,7 @@ type KeylessCertificateNewParams struct {
 	BundleMethod param.Field[custom_hostnames.BundleMethod] `json:"bundle_method"`
 	// The keyless SSL name.
 	Name param.Field[string] `json:"name"`
-	// Configuration for using Keyless SSL through a Cloudflare Tunnel
+	// Configuration for using Keyless SSL through a Cloudflare Tunnel.
 	Tunnel param.Field[TunnelParam] `json:"tunnel"`
 }
 
@@ -598,7 +598,7 @@ type KeylessCertificateEditParams struct {
 	// The keyless SSL port used to communicate between Cloudflare and the client's
 	// Keyless SSL server.
 	Port param.Field[float64] `json:"port"`
-	// Configuration for using Keyless SSL through a Cloudflare Tunnel
+	// Configuration for using Keyless SSL through a Cloudflare Tunnel.
 	Tunnel param.Field[TunnelParam] `json:"tunnel"`
 }
 

--- a/kv/aliases.go
+++ b/kv/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/leaked_credential_checks/aliases.go
+++ b/leaked_credential_checks/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/load_balancers/aliases.go
+++ b/load_balancers/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/logpush/aliases.go
+++ b/logpush/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/logs/aliases.go
+++ b/logs/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/magic_cloud_networking/aliases.go
+++ b/magic_cloud_networking/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/magic_network_monitoring/aliases.go
+++ b/magic_network_monitoring/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/magic_transit/aliases.go
+++ b/magic_transit/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/managed_transforms/aliases.go
+++ b/managed_transforms/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/memberships/aliases.go
+++ b/memberships/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/mtls_certificates/aliases.go
+++ b/mtls_certificates/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/network_interconnects/aliases.go
+++ b/network_interconnects/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/organizations/aliases.go
+++ b/organizations/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/origin_ca_certificates/aliases.go
+++ b/origin_ca_certificates/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/origin_ca_certificates/origincacertificate.go
+++ b/origin_ca_certificates/origincacertificate.go
@@ -359,7 +359,7 @@ type OriginCACertificateListParams struct {
 	ZoneID param.Field[string] `query:"zone_id" api:"required"`
 	// Limit to the number of records returned.
 	Limit param.Field[int64] `query:"limit"`
-	// Offset the results
+	// Offset the results.
 	Offset param.Field[int64] `query:"offset"`
 	// Page number of paginated results.
 	Page param.Field[float64] `query:"page"`

--- a/origin_ca_certificates/origincacertificate_test.go
+++ b/origin_ca_certificates/origincacertificate_test.go
@@ -27,9 +27,9 @@ func TestOriginCACertificateNewWithOptionalParams(t *testing.T) {
 	}
 	client := cloudflare.NewClient(
 		option.WithBaseURL(baseURL),
+		option.WithAPIToken("Sn3lZJTBX6kkg7OdcBUAxOO963GEIyGQqnFTOFYY"),
 		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
 		option.WithAPIEmail("user@example.com"),
-		option.WithUserServiceKey("v1.0-144c9defac04969c7bfad8ef-631a41d003a32d25fe878081ef365c49503f7fada600da935e2851a1c7326084b85cbf6429c4b859de8475731dc92a9c329631e6d59e6c73da7b198497172b4cefe071d90d0f5d2719"),
 	)
 	_, err := client.OriginCACertificates.New(context.TODO(), origin_ca_certificates.OriginCACertificateNewParams{
 		Csr:               cloudflare.F("-----BEGIN CERTIFICATE REQUEST-----\nMIICxzCCAa8CAQAwSDELMAkGA1UEBhMCVVMxFjAUBgNVBAgTDVNhbiBGcmFuY2lz\nY28xCzAJBgNVBAcTAkNBMRQwEgYDVQQDEwtleGFtcGxlLm5ldDCCASIwDQYJKoZI\nhvcNAQEBBQADggEPADCCAQoCggEBALxejtu4b+jPdFeFi6OUsye8TYJQBm3WfCvL\nHu5EvijMO/4Z2TImwASbwUF7Ir8OLgH+mGlQZeqyNvGoSOMEaZVXcYfpR1hlVak8\n4GGVr+04IGfOCqaBokaBFIwzclGZbzKmLGwIQioNxGfqFm6RGYGA3be2Je2iseBc\nN8GV1wYmvYE0RR+yWweJCTJ157exyRzu7sVxaEW9F87zBQLyOnwXc64rflXslRqi\ng7F7w5IaQYOl8yvmk/jEPCAha7fkiUfEpj4N12+oPRiMvleJF98chxjD4MH39c5I\nuOslULhrWunfh7GB1jwWNA9y44H0snrf+xvoy2TcHmxvma9Eln8CAwEAAaA6MDgG\nCSqGSIb3DQEJDjErMCkwJwYDVR0RBCAwHoILZXhhbXBsZS5uZXSCD3d3dy5leGFt\ncGxlLm5ldDANBgkqhkiG9w0BAQsFAAOCAQEAcBaX6dOnI8ncARrI9ZSF2AJX+8mx\npTHY2+Y2C0VvrVDGMtbBRH8R9yMbqWtlxeeNGf//LeMkSKSFa4kbpdx226lfui8/\nauRDBTJGx2R1ccUxmLZXx4my0W5iIMxunu+kez+BDlu7bTT2io0uXMRHue4i6quH\nyc5ibxvbJMjR7dqbcanVE10/34oprzXQsJ/VmSuZNXtjbtSKDlmcpw6To/eeAJ+J\nhXykcUihvHyG4A1m2R6qpANBjnA0pHexfwM/SgfzvpbvUg0T1ubmer8BgTwCKIWs\ndcWYTthM51JIqRBfNqy4QcBnX+GY05yltEEswQI55wdiS3CjTTA67sdbcQ==\n-----END CERTIFICATE REQUEST-----"),
@@ -57,9 +57,9 @@ func TestOriginCACertificateListWithOptionalParams(t *testing.T) {
 	}
 	client := cloudflare.NewClient(
 		option.WithBaseURL(baseURL),
+		option.WithAPIToken("Sn3lZJTBX6kkg7OdcBUAxOO963GEIyGQqnFTOFYY"),
 		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
 		option.WithAPIEmail("user@example.com"),
-		option.WithUserServiceKey("v1.0-144c9defac04969c7bfad8ef-631a41d003a32d25fe878081ef365c49503f7fada600da935e2851a1c7326084b85cbf6429c4b859de8475731dc92a9c329631e6d59e6c73da7b198497172b4cefe071d90d0f5d2719"),
 	)
 	_, err := client.OriginCACertificates.List(context.TODO(), origin_ca_certificates.OriginCACertificateListParams{
 		ZoneID:  cloudflare.F("023e105f4ecef8ad9ca31a8372d0c353"),
@@ -88,9 +88,9 @@ func TestOriginCACertificateDelete(t *testing.T) {
 	}
 	client := cloudflare.NewClient(
 		option.WithBaseURL(baseURL),
+		option.WithAPIToken("Sn3lZJTBX6kkg7OdcBUAxOO963GEIyGQqnFTOFYY"),
 		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
 		option.WithAPIEmail("user@example.com"),
-		option.WithUserServiceKey("v1.0-144c9defac04969c7bfad8ef-631a41d003a32d25fe878081ef365c49503f7fada600da935e2851a1c7326084b85cbf6429c4b859de8475731dc92a9c329631e6d59e6c73da7b198497172b4cefe071d90d0f5d2719"),
 	)
 	_, err := client.OriginCACertificates.Delete(context.TODO(), "023e105f4ecef8ad9ca31a8372d0c353")
 	if err != nil {
@@ -113,9 +113,9 @@ func TestOriginCACertificateGet(t *testing.T) {
 	}
 	client := cloudflare.NewClient(
 		option.WithBaseURL(baseURL),
+		option.WithAPIToken("Sn3lZJTBX6kkg7OdcBUAxOO963GEIyGQqnFTOFYY"),
 		option.WithAPIKey("144c9defac04969c7bfad8efaa8ea194"),
 		option.WithAPIEmail("user@example.com"),
-		option.WithUserServiceKey("v1.0-144c9defac04969c7bfad8ef-631a41d003a32d25fe878081ef365c49503f7fada600da935e2851a1c7326084b85cbf6429c4b859de8475731dc92a9c329631e6d59e6c73da7b198497172b4cefe071d90d0f5d2719"),
 	)
 	_, err := client.OriginCACertificates.Get(context.TODO(), "023e105f4ecef8ad9ca31a8372d0c353")
 	if err != nil {

--- a/origin_post_quantum_encryption/aliases.go
+++ b/origin_post_quantum_encryption/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/origin_tls_client_auth/aliases.go
+++ b/origin_tls_client_auth/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/page_rules/aliases.go
+++ b/page_rules/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/page_shield/aliases.go
+++ b/page_shield/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/pages/aliases.go
+++ b/pages/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/pipelines/aliases.go
+++ b/pipelines/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/queues/aliases.go
+++ b/queues/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/r2/aliases.go
+++ b/r2/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/r2_data_catalog/aliases.go
+++ b/r2_data_catalog/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/radar/aliases.go
+++ b/radar/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/rate_limits/aliases.go
+++ b/rate_limits/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/realtime_kit/aliases.go
+++ b/realtime_kit/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/registrar/aliases.go
+++ b/registrar/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/request_tracers/aliases.go
+++ b/request_tracers/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/resource_sharing/aliases.go
+++ b/resource_sharing/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/resource_tagging/aliases.go
+++ b/resource_tagging/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/rules/aliases.go
+++ b/rules/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/rulesets/aliases.go
+++ b/rulesets/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/rum/aliases.go
+++ b/rum/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/schema_validation/aliases.go
+++ b/schema_validation/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/secrets_store/aliases.go
+++ b/secrets_store/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/security_center/aliases.go
+++ b/security_center/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/security_txt/aliases.go
+++ b/security_txt/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/shared/shared.go
+++ b/shared/shared.go
@@ -178,7 +178,7 @@ func (r auditLogResourceJSON) RawJSON() string {
 	return r.raw
 }
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 type CertificateCA string
 
 const (

--- a/snippets/aliases.go
+++ b/snippets/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/spectrum/aliases.go
+++ b/spectrum/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/speed/aliases.go
+++ b/speed/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ssl/aliases.go
+++ b/ssl/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/ssl/certificatepack.go
+++ b/ssl/certificatepack.go
@@ -241,7 +241,7 @@ type CertificatePackNewResponse struct {
 	Type CertificatePackNewResponseType `json:"type" api:"required"`
 	// Certificate Authority selected for the order. For information on any certificate
 	// authority specific details or restrictions
-	// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+	// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 	CertificateAuthority CertificatePackNewResponseCertificateAuthority `json:"certificate_authority"`
 	// Whether or not to add Cloudflare Branding for the order. This will add a
 	// subdomain of sni.cloudflaressl.com as the Common Name if set to true.
@@ -408,7 +408,7 @@ func (r CertificatePackNewResponseType) IsKnown() bool {
 
 // Certificate Authority selected for the order. For information on any certificate
 // authority specific details or restrictions
-// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 type CertificatePackNewResponseCertificateAuthority string
 
 const (
@@ -593,7 +593,7 @@ type CertificatePackListResponse struct {
 	Type CertificatePackListResponseType `json:"type" api:"required"`
 	// Certificate Authority selected for the order. For information on any certificate
 	// authority specific details or restrictions
-	// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+	// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 	CertificateAuthority CertificatePackListResponseCertificateAuthority `json:"certificate_authority"`
 	// Whether or not to add Cloudflare Branding for the order. This will add a
 	// subdomain of sni.cloudflaressl.com as the Common Name if set to true.
@@ -760,7 +760,7 @@ func (r CertificatePackListResponseType) IsKnown() bool {
 
 // Certificate Authority selected for the order. For information on any certificate
 // authority specific details or restrictions
-// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 type CertificatePackListResponseCertificateAuthority string
 
 const (
@@ -967,7 +967,7 @@ type CertificatePackEditResponse struct {
 	Type CertificatePackEditResponseType `json:"type" api:"required"`
 	// Certificate Authority selected for the order. For information on any certificate
 	// authority specific details or restrictions
-	// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+	// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 	CertificateAuthority CertificatePackEditResponseCertificateAuthority `json:"certificate_authority"`
 	// Whether or not to add Cloudflare Branding for the order. This will add a
 	// subdomain of sni.cloudflaressl.com as the Common Name if set to true.
@@ -1134,7 +1134,7 @@ func (r CertificatePackEditResponseType) IsKnown() bool {
 
 // Certificate Authority selected for the order. For information on any certificate
 // authority specific details or restrictions
-// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 type CertificatePackEditResponseCertificateAuthority string
 
 const (
@@ -1319,7 +1319,7 @@ type CertificatePackGetResponse struct {
 	Type CertificatePackGetResponseType `json:"type" api:"required"`
 	// Certificate Authority selected for the order. For information on any certificate
 	// authority specific details or restrictions
-	// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+	// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 	CertificateAuthority CertificatePackGetResponseCertificateAuthority `json:"certificate_authority"`
 	// Whether or not to add Cloudflare Branding for the order. This will add a
 	// subdomain of sni.cloudflaressl.com as the Common Name if set to true.
@@ -1486,7 +1486,7 @@ func (r CertificatePackGetResponseType) IsKnown() bool {
 
 // Certificate Authority selected for the order. For information on any certificate
 // authority specific details or restrictions
-// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 type CertificatePackGetResponseCertificateAuthority string
 
 const (
@@ -1661,7 +1661,7 @@ type CertificatePackNewParams struct {
 	ZoneID param.Field[string] `path:"zone_id" api:"required"`
 	// Certificate Authority selected for the order. For information on any certificate
 	// authority specific details or restrictions
-	// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+	// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 	CertificateAuthority param.Field[CertificatePackNewParamsCertificateAuthority] `json:"certificate_authority" api:"required"`
 	// Comma separated list of valid host names for the certificate packs. Must contain
 	// the zone apex, may not contain more than 50 hosts, and may not be empty.
@@ -1683,7 +1683,7 @@ func (r CertificatePackNewParams) MarshalJSON() (data []byte, err error) {
 
 // Certificate Authority selected for the order. For information on any certificate
 // authority specific details or restrictions
-// [see this page for more details.](https://developers.cloudflare.com/ssl/reference/certificate-authorities)
+// [see this page for more details](https://developers.cloudflare.com/ssl/reference/certificate-authorities).
 type CertificatePackNewParamsCertificateAuthority string
 
 const (

--- a/stream/aliases.go
+++ b/stream/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/token_validation/aliases.go
+++ b/token_validation/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/turnstile/aliases.go
+++ b/turnstile/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/url_normalization/aliases.go
+++ b/url_normalization/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/url_scanner/aliases.go
+++ b/url_scanner/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/user/aliases.go
+++ b/user/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/vectorize/aliases.go
+++ b/vectorize/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/vulnerability_scanner/aliases.go
+++ b/vulnerability_scanner/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/waiting_rooms/aliases.go
+++ b/waiting_rooms/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/web3/aliases.go
+++ b/web3/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/workers/aliases.go
+++ b/workers/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/workers_for_platforms/aliases.go
+++ b/workers_for_platforms/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/workflows/aliases.go
+++ b/workflows/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/zaraz/aliases.go
+++ b/zaraz/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/zero_trust/aliases.go
+++ b/zero_trust/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA

--- a/zones/aliases.go
+++ b/zones/aliases.go
@@ -44,7 +44,7 @@ type AuditLogOwner = shared.AuditLogOwner
 // This is an alias to an internal type.
 type AuditLogResource = shared.AuditLogResource
 
-// The Certificate Authority that will issue the certificate
+// The Certificate Authority that will issue the certificate.
 //
 // This is an alias to an internal type.
 type CertificateCA = shared.CertificateCA


### PR DESCRIPTION
## Codegen Sync: staging-next -> next

Syncs the remaining delta from `staging-next` including a codegen-wide doc comment refresh and the last excluded breaking change.

### What changed

**Doc comment punctuation (110 packages)**
Mass codegen fix adding trailing periods to doc comments across all `aliases.go` files and certificate-related source files. Zero functional change.

**resource_sharing (BREAKING)**
Removes `Update`, `Delete`, `Get` methods and their param/response types from `ResourceService`. The upstream API no longer exposes these endpoints.

### Commits

| Commit | Description |
|--------|-------------|
| `chore: sync infrastructure packages` | shared/shared.go update |
| `chore: fix doc comment punctuation across all packages` | 109 aliases.go files |
| `chore: fix doc comment punctuation in certificate packages` | 11 cert-related files |
| `chore: update codegen metadata and root aliases` | .stats.yml, root aliases.go |
| `feat(resource_sharing)!: remove Update, Delete, Get methods` | breaking change |

### Excluded

None -- all previously excluded resources are now integrated.

### Validation

- [x] `go build ./...`
- [x] `go test` (110/110 resources pass against prism)
- [x] `./scripts/lint`
- [x] `detect-breaking-changes` flags only the intentional resource_sharing removal