### PR TITLE
docs: add v7.6.0 migration guide

### DIFF
--- a/docs/migration-guides/v7.6.0-migration-guide.md
+++ b/docs/migration-guides/v7.6.0-migration-guide.md
@@ -1,0 +1,132 @@
+# v7.6.0 Migration Guide
+
+## Breaking Changes
+
+### `realtime_kit`
+
+#### 1. GenerateSummaryOfTranscripts now returns a response
+
+**What changed:**
+`SessionService.GenerateSummaryOfTranscripts()` previously returned only `error`. It now returns `(*SessionGenerateSummaryOfTranscriptsResponse, error)`.
+
+**Impact:**
+Code that calls this method without capturing the first return value will no longer compile.
+
+**Before (v7.5.0):**
+```go
+err := client.RealtimeKit.Sessions.GenerateSummaryOfTranscripts(ctx, "app-id", "session-id", realtime_kit.SessionGenerateSummaryOfTranscriptsParams{
+    AccountID: cloudflare.F("account-id"),
+})
+```
+
+**After (v7.6.0):**
+```go
+resp, err := client.RealtimeKit.Sessions.GenerateSummaryOfTranscripts(ctx, "app-id", "session-id", realtime_kit.SessionGenerateSummaryOfTranscriptsParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// resp.Data contains the summary response
+```
+
+**Actions Needed:**
+1. Add a variable to capture the new `*SessionGenerateSummaryOfTranscriptsResponse` return value
+2. If you were discarding the result with `_ =`, update to capture both values
+
+---
+
+#### 2. StartTrackRecording now returns a response
+
+**What changed:**
+`RecordingService.StartTrackRecording()` previously returned only `error`. It now returns `(*RecordingStartTrackRecordingResponse, error)`.
+
+**Impact:**
+Code that calls this method without capturing the first return value will no longer compile.
+
+**Before (v7.5.0):**
+```go
+err := client.RealtimeKit.Recordings.StartTrackRecording(ctx, "app-id", realtime_kit.RecordingStartTrackRecordingParams{
+    AccountID: cloudflare.F("account-id"),
+})
+```
+
+**After (v7.6.0):**
+```go
+resp, err := client.RealtimeKit.Recordings.StartTrackRecording(ctx, "app-id", realtime_kit.RecordingStartTrackRecordingParams{
+    AccountID: cloudflare.F("account-id"),
+})
+// resp contains the track recording response
+```
+
+**Actions Needed:**
+1. Add a variable to capture the new `*RecordingStartTrackRecordingResponse` return value
+
+---
+
+#### 3. Session participant response sub-types renamed
+
+**What changed:**
+Sub-types under `SessionGetParticipantDataFromPeerIDResponseData` were restructured. A new `.Participant` nested struct was added, and sub-types were renamed:
+- `SessionGetParticipantDataFromPeerIDResponseDataPeerReport` -> `SessionGetParticipantDataFromPeerIDResponseDataParticipantPeerReport`
+
+**Impact:**
+Code that references the old type names directly will no longer compile.
+
+**Removed Types:**
+- `SessionGetParticipantDataFromPeerIDResponseDataPeerReport`
+
+**Replacement Types:**
+- `SessionGetParticipantDataFromPeerIDResponseDataParticipantPeerReport`
+
+**Before (v7.5.0):**
+```go
+data, _ := client.RealtimeKit.Sessions.GetParticipantDataFromPeerID(ctx, "app-id", "peer-id", params)
+report := data.Data.PeerReport
+```
+
+**After (v7.6.0):**
+```go
+data, _ := client.RealtimeKit.Sessions.GetParticipantDataFromPeerID(ctx, "app-id", "peer-id", params)
+report := data.Data.Participant.PeerReport
+```
+
+**Actions Needed:**
+1. Access peer report data through the new `.Participant` intermediate field
+2. Update any direct type references from `...DataPeerReport` to `...DataParticipantPeerReport`
+
+---
+
+### `email_security`
+
+#### 4. ActionLog parameter removed from InvestigateListParams
+
+**What changed:**
+The `ActionLog` field has been removed from `InvestigateListParams`.
+
+**Impact:**
+Code that sets the `ActionLog` query parameter when listing email security investigations will no longer compile.
+
+**Before (v7.5.0):**
+```go
+results, err := client.EmailSecurity.Investigate.List(ctx, email_security.InvestigateListParams{
+    AccountID: cloudflare.F("account-id"),
+    ActionLog: cloudflare.F(true),
+})
+```
+
+**After (v7.6.0):**
+```go
+results, err := client.EmailSecurity.Investigate.List(ctx, email_security.InvestigateListParams{
+    AccountID: cloudflare.F("account-id"),
+})
+```
+
+**Actions Needed:**
+1. Remove all references to the `ActionLog` field from `InvestigateListParams`
+
+---
+
+## Summary
+
+1. `realtime_kit.SessionService.GenerateSummaryOfTranscripts()` now returns `(*SessionGenerateSummaryOfTranscriptsResponse, error)` instead of `error`
+2. `realtime_kit.RecordingService.StartTrackRecording()` now returns `(*RecordingStartTrackRecordingResponse, error)` instead of `error`
+3. `realtime_kit` session participant sub-types renamed with `.Participant` nesting
+4. `email_security.InvestigateListParams.ActionLog` field removed


### PR DESCRIPTION
Adds the migration guide for the upcoming v7.6.0 release.

## Breaking changes covered

1. `realtime_kit.SessionService.GenerateSummaryOfTranscripts()` return type changed from `error` to `(*Response, error)`
2. `realtime_kit.RecordingService.StartTrackRecording()` return type changed from `error` to `(*Response, error)`
3. `realtime_kit` session participant sub-types renamed with `.Participant` nesting
4. `email_security.InvestigateListParams.ActionLog` field removed

Each section includes before/after code examples and specific actions needed.