### PR TITLE
fix(apijson): replace O(n^2) array encoding with O(n) bytes.Buffer

### DIFF
--- a/internal/apijson/array_bench_test.go
+++ b/internal/apijson/array_bench_test.go
@@ -1,0 +1,48 @@
+package apijson
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func makeIPSlice(n int) []string {
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = fmt.Sprintf("10.%d.%d.%d", (i>>16)&0xff, (i>>8)&0xff, i&0xff)
+	}
+	return out
+}
+
+func TestArrayMarshalCorrectness(t *testing.T) {
+	for _, n := range []int{0, 1, 2, 100} {
+		in := makeIPSlice(n)
+		got, err := Marshal(in)
+		if err != nil {
+			t.Fatalf("Marshal(n=%d) error: %v", n, err)
+		}
+		want, _ := json.Marshal(in)
+		if !strings.EqualFold(string(got), string(want)) {
+			t.Fatalf("n=%d: got=%s want=%s", n, got, want)
+		}
+	}
+}
+
+func benchmarkArrayMarshal(b *testing.B, n int) {
+	in := makeIPSlice(n)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := Marshal(in)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkArrayMarshal_100(b *testing.B)   { benchmarkArrayMarshal(b, 100) }
+func BenchmarkArrayMarshal_1000(b *testing.B)  { benchmarkArrayMarshal(b, 1000) }
+func BenchmarkArrayMarshal_5000(b *testing.B)  { benchmarkArrayMarshal(b, 5000) }
+func BenchmarkArrayMarshal_10000(b *testing.B) { benchmarkArrayMarshal(b, 10000) }
+func BenchmarkArrayMarshal_30000(b *testing.B) { benchmarkArrayMarshal(b, 30000) }

--- a/internal/apijson/encoder.go
+++ b/internal/apijson/encoder.go
@@ -183,25 +183,29 @@ func (e *encoder) newArrayTypeEncoder(t reflect.Type) encoderFunc {
 	itemEncoder := e.typeEncoder(t.Elem())
 
 	return func(value reflect.Value) ([]byte, error) {
-		json := []byte("[]")
-		for i := 0; i < value.Len(); i++ {
-			var value, err = itemEncoder(value.Index(i))
+		n := value.Len()
+		if n == 0 {
+			return []byte("[]"), nil
+		}
+		var buf bytes.Buffer
+		buf.WriteByte('[')
+		for i := 0; i < n; i++ {
+			item, err := itemEncoder(value.Index(i))
 			if err != nil {
 				return nil, err
 			}
-			if value == nil {
+			if item == nil {
 				// Assume that empty items should be inserted as `null` so that the output array
 				// will be the same length as the input array
-				value = []byte("null")
+				item = []byte("null")
 			}
-
-			json, err = sjson.SetRawBytes(json, "-1", value)
-			if err != nil {
-				return nil, err
+			if i > 0 {
+				buf.WriteByte(',')
 			}
+			buf.Write(item)
 		}
-
-		return json, nil
+		buf.WriteByte(']')
+		return buf.Bytes(), nil
 	}
 }
 


### PR DESCRIPTION
## Summary

`newArrayTypeEncoder` builds JSON arrays by calling `sjson.SetRawBytes(json, "-1", item)` in a loop. `sjson` re-parses and reallocates the entire accumulated buffer on each call, giving O(n^2) time and memory complexity. For a 30,000-element IP list update via `Rules.Lists.Items.Update`, this allocates ~6.2 GB and OOM-kills the process.

This replaces the `sjson` loop with a single-pass `bytes.Buffer` concatenation, restoring O(n). Output is byte-identical to the previous implementation.

## Context

- Customer escalation: a SAP BTP controller syncing ~30,000 IPs is OOM-killed every ~6 minutes
- GitHub issue: #4315
- Customer PR with equivalent fix: #4316

## Benchmarks (from #4316)

| N | before B/op | after B/op | mem reduction | before ns/op | after ns/op | speedup |
|---|---|---|---|---|---|---|
| 100 | 92 KB | 8 KB | 11x | 138 us | 24 us | 5.9x |
| 1,000 | 6.9 MB | 66 KB | 105x | 7.1 ms | 0.21 ms | 33x |
| 10,000 | 692 MB | 845 KB | 819x | 437 ms | 1.18 ms | 369x |
| 30,000 | 6.2 GB | 2.0 MB | 3,070x | 4,091 ms | 3.10 ms | 1,320x |

## Tests

All existing `internal/apijson` tests pass. Added `array_bench_test.go` with correctness verification against `encoding/json` and benchmarks at N=100..30,000 as a regression guard.

Fixes #4315