### PR TITLE
fix(ci): free disk space before test job on standard runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
     runs-on: ${{ github.repository == 'stainless-sdks/cloudflare-go' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
+      - name: Free disk space
+        if: github.repository != 'stainless-sdks/cloudflare-go'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
+          df -h /
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup go


### PR DESCRIPTION
## Problem

The `test` job intermittently fails with `no space left on device` on `ubuntu-latest` runners. `scripts/test` runs `go clean -cache -testcache -modcache` before `go test ./...`, forcing a full recompile of 280+ packages from scratch. On standard GitHub-hosted runners (~14 GB disk), this exhausts available space.

The `stainless-sdks/cloudflare-go` fork doesn't hit this because it uses larger `depot-ubuntu-24.04` runners.

## Fix

Add a disk cleanup step that removes pre-installed toolchains (`.NET`, `Android SDK`, `GHC`, `Boost`) before the test step, reclaiming ~15 GB. The step only runs on `cloudflare/cloudflare-go` -- skipped on `stainless-sdks` where Depot runners have sufficient disk.

## Evidence

Recent `push`-triggered CI failures on `next`:
- https://github.com/cloudflare/cloudflare-go/actions/runs/27710969424 (disk exhaustion crash)
- https://github.com/cloudflare/cloudflare-go/actions/runs/27647856330 (same pattern)

`pull_request`-triggered runs are unaffected because the `test` job's `if` condition skips non-fork PRs.