### PR TITLE
fix(apijson): protect union registry with sync.Map to prevent concurrency write panics

### DIFF
--- a/internal/apijson/decoder.go
+++ b/internal/apijson/decoder.go
@@ -143,13 +143,13 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 		return unmarshalerDecoder
 	}
 	if !d.root && reflect.PointerTo(t).Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()) {
-		if _, ok := unionVariants[t]; !ok {
+		if _, ok := unionVariants.Load(t); !ok {
 			return indirectUnmarshalerDecoder
 		}
 	}
 	d.root = false
 
-	if _, ok := unionRegistry[t]; ok {
+	if _, ok := unionRegistry.Load(t); ok {
 		return d.newUnionDecoder(t)
 	}
 
@@ -206,10 +206,11 @@ func (d *decoderBuilder) newTypeDecoder(t reflect.Type) decoderFunc {
 //
 // [smart algorithm]: https://docs.pydantic.dev/latest/concepts/unions/#smart-mode
 func (d *decoderBuilder) newUnionDecoder(t reflect.Type) decoderFunc {
-	unionEntry, ok := unionRegistry[t]
+	v, ok := unionRegistry.Load(t)
 	if !ok {
 		panic("apijson: couldn't find union of type " + t.String() + " in union registry")
 	}
+	unionEntry := v.(unionEntry)
 	decoders := []decoderFunc{}
 	for _, variant := range unionEntry.variants {
 		decoder := d.typeDecoder(variant.Type)

--- a/internal/apijson/registry.go
+++ b/internal/apijson/registry.go
@@ -2,6 +2,7 @@ package apijson
 
 import (
 	"reflect"
+	"sync"
 
 	"github.com/tidwall/gjson"
 )
@@ -12,8 +13,8 @@ type UnionVariant struct {
 	Type               reflect.Type
 }
 
-var unionRegistry = map[reflect.Type]unionEntry{}
-var unionVariants = map[reflect.Type]interface{}{}
+var unionRegistry sync.Map
+var unionVariants sync.Map
 
 type unionEntry struct {
 	discriminatorKey string
@@ -21,12 +22,12 @@ type unionEntry struct {
 }
 
 func RegisterUnion(typ reflect.Type, discriminator string, variants ...UnionVariant) {
-	unionRegistry[typ] = unionEntry{
+	unionRegistry.Store(typ, unionEntry{
 		discriminatorKey: discriminator,
 		variants:         variants,
-	}
+	})
 	for _, variant := range variants {
-		unionVariants[variant.Type] = typ
+		unionVariants.Store(variant.Type, typ)
 	}
 }
 


### PR DESCRIPTION
Fixes: #4326

## Summary
This change replaces the global unionRegistry and unionVariants maps with sync.Map and updates all read/write access sites to use the thread-safe Load and Store methods.

This prevents concurrent map write panics when RegisterUnion() is called from multiple goroutines.

### Testing
Ran the existing test suite locally and all tests passed.

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Change from to a thread safe map version or usage mutex was requested.