### PR TITLE
fix(apiquery): format float32 query values at float32 precision

### DIFF
--- a/internal/apiquery/encoder.go
+++ b/internal/apiquery/encoder.go
@@ -285,7 +285,11 @@ func (e *encoder) newPrimitiveTypeEncoder(t reflect.Type) encoderFunc {
 		return func(key string, v reflect.Value) []Pair {
 			return []Pair{{key, strconv.FormatUint(v.Uint(), 10)}}
 		}
-	case reflect.Float32, reflect.Float64:
+	case reflect.Float32:
+		return func(key string, v reflect.Value) []Pair {
+			return []Pair{{key, strconv.FormatFloat(v.Float(), 'f', -1, 32)}}
+		}
+	case reflect.Float64:
 		return func(key string, v reflect.Value) []Pair {
 			return []Pair{{key, strconv.FormatFloat(v.Float(), 'f', -1, 64)}}
 		}

--- a/internal/apiquery/query_test.go
+++ b/internal/apiquery/query_test.go
@@ -107,13 +107,13 @@ var tests = map[string]struct {
 	settings QuerySettings
 }{
 	"primitives": {
-		"a=false&b=237628372683&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4",
+		"a=false&b=237628372683&c=654&d=9999.43&e=43.76&f=1,2,3,4",
 		Primitives{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
 		QuerySettings{},
 	},
 
 	"slices_brackets": {
-		`mixed[]=1&mixed[]=2.3&mixed[]=hello&slices[][a]=false&slices[][a]=false&slices[][b]=237628372683&slices[][b]=237628372683&slices[][c]=654&slices[][c]=654&slices[][d]=9999.43&slices[][d]=9999.43&slices[][e]=43.7599983215332&slices[][e]=43.7599983215332&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4`,
+		`mixed[]=1&mixed[]=2.3&mixed[]=hello&slices[][a]=false&slices[][a]=false&slices[][b]=237628372683&slices[][b]=237628372683&slices[][c]=654&slices[][c]=654&slices[][d]=9999.43&slices[][d]=9999.43&slices[][e]=43.76&slices[][e]=43.76&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4&slices[][f][]=1&slices[][f][]=2&slices[][f][]=3&slices[][f][]=4`,
 		Slices{
 			Slice: []Primitives{
 				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
@@ -133,7 +133,7 @@ var tests = map[string]struct {
 	},
 
 	"slices_repeat": {
-		`mixed=1&mixed=2.3&mixed=hello&slices[a]=false&slices[a]=false&slices[b]=237628372683&slices[b]=237628372683&slices[c]=654&slices[c]=654&slices[d]=9999.43&slices[d]=9999.43&slices[e]=43.7599983215332&slices[e]=43.7599983215332&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4`,
+		`mixed=1&mixed=2.3&mixed=hello&slices[a]=false&slices[a]=false&slices[b]=237628372683&slices[b]=237628372683&slices[c]=654&slices[c]=654&slices[d]=9999.43&slices[d]=9999.43&slices[e]=43.76&slices[e]=43.76&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4&slices[f]=1&slices[f]=2&slices[f]=3&slices[f]=4`,
 		Slices{
 			Slice: []Primitives{
 				{A: false, B: 237628372683, C: uint(654), D: 9999.43, E: 43.76, F: []int{1, 2, 3, 4}},
@@ -145,7 +145,7 @@ var tests = map[string]struct {
 	},
 
 	"primitive_pointer_struct": {
-		"a=false&b=237628372683&c=654&d=9999.43&e=43.7599983215332&f=1,2,3,4,5",
+		"a=false&b=237628372683&c=654&d=9999.43&e=43.76&f=1,2,3,4,5",
 		PrimitivePointers{
 			A: P(false),
 			B: P(237628372683),


### PR DESCRIPTION
## What

The query encoder shared a single case between `reflect.Float32` and `reflect.Float64` and formatted both with bitSize 64.

## Why

`strconv.FormatFloat(v.Float(), 'f', -1, 64)` produces the shortest representation that round-trips as a **float64**. For a float32 like `43.76` that yields `43.7599983215332`, so every float32 query parameter went out with float64 noise digits. The sibling encoders in this repo already handle the two kinds separately — `internal/apijson/encoder.go` and `internal/apiform/encoder.go` both format Float32 at bitSize 32.

## Change

Split the case and format Float32 at bitSize 32, matching the other encoders. Six test expectations had the noisy output baked in (`e=43.7599983215332` for input `float32(43.76)`) and are updated to the shortest form; servers parsing the value as a float see an identical number either way, but the wire bytes now match what the same SDK emits through its JSON and form encoders.

## Verification

```
$ go test -count=1 ./internal/apiquery/          # with fix stashed (current behavior)
FAIL

$ go test -count=1 ./internal/apiquery/          # with this PR
ok
```

Same root cause as the fixes already shipped in anthropics/anthropic-sdk-go#423 and anthropics/anthropic-cli#87 (shared Stainless Go template).