### PR TITLE
docs(changelog): update CHANGELOG for v0.118.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.118.0 (Unreleased)
+## 0.118.0 (September 1st, 2026)
 
 ENHANCEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-## 0.117.0 (Unreleased)
+## 0.118.0 (Unreleased)
+
+ENHANCEMENTS:
+
+* rulesets: add `content_converter` to `RulesetRuleActionParameters` for `http_config_settings` `set_config` rules ([#4359](https://github.com/cloudflare/cloudflare-go/issues/4359))
+
+## 0.117.0 (May 20th, 2026)
+
+ENHANCEMENTS:
+
+* rulesets: add `asset_name` to `RulesetRuleActionParameters` for `http_custom_errors` `serve_error` rules ([#4312](https://github.com/cloudflare/cloudflare-go/issues/4312))
 
 ## 0.116.0 (September 5th, 2025)
 


### PR DESCRIPTION
The changelog bot did not run for the v0.117.0 release (May 20th, 2026) or the subsequent v0.118.0 placeholder. This PR manually applies both updates.

**Changes:**
- Fills in `0.117.0 (May 20th, 2026)` with the enhancement from #4312 (rulesets `asset_name`)
- Adds `0.118.0 (Unreleased)` placeholder with the enhancement from #4359 (rulesets `content_converter`)

The `update-changelog-v0` branch that existed previously was stale (pre-#4312) and only removed the unreleased header without adding content.